### PR TITLE
Sxslib

### DIFF
--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -156,6 +156,7 @@ public final class Native {
         if (flib.delete()) {
             nativeLibraryPath = null;
             unpacked = false;
+
             // If finalization-on-exit is set, the marker file may have been
             // created by the shutdown hook (MarkTemporaryFile) just prior
             // to the finalization. Ensure the marker file is deleted.
@@ -660,8 +661,8 @@ public final class Native {
      * be changed for the hosting process or the JRE cannot be modified.
      * For Windows platforms the files would be named:
      * <ul>
-     * <li>jnidispatch-win32-x64.dll for 64-bit processes</li>
      * <li>jnidispatch-win32-x86.dll for 32-bit processes</li>
+     * <li>jnidispatch-win32-amd64.dll for 64-bit processes</li>
      * <ul>
      * Both versions of the library could be placed safely
      * in any directory in the PATH or and the correct DLL for the process


### PR DESCRIPTION
Please consider the following scenarios that warrant the inclusion of side-by-side deployment of jnidispatch libraries on Windows 64-bit OS with WoW support for 32-bit programs.

We have an API module that is written in Java and distributed in one of two ways on Windows platforms:
- a Java jar file
- a managed-code .NET DLL - a.NET version of the API which is generated from the Java jar file with IKVM resulting in the DLL
  We support multiple windows platforms and the code may be used in a JVM (JRE) or a .NET application (CLR).

In the case where the .NET API programmer is creating a module to be deployed to the Windows GAC (Global Assembly Cache), the programmer
- will not be targeting any specific architecture and will most likely not have the ability to dictate execution path requirements.
- is typically is not familiar with Java and various JRE requirements and only wants to use our module like it was a native .NET module.

Our API documentation states for the API user to copy DLLs to the assemly's bin folder:
- several architecture-neutral (managed code) IKVM DLLs
- two IKVM native (unmanaged code) DLLs (one for 32-bit and one for 64-bit)
- our architecture-neutral DLL

This allows the module to be loaded without problem by either 64-bit or 32-bit Windows processes from the single location in the Windows System GAC.

If the shut-down-on-exit bug were not an issue or the fix worked reliably and did not leave stray DLLs, we would have no further problems.  Also, it obviously preferable to deploy the jnidispatch DLLs since it is more efficient than creating and deleting temporary DLLs every time a process runs.

So, it seems that having a simple technique for finding the platform-specific jnidispatch library by naming convention would be unobtrusive and easy to deploy for our customers.  We would simply add the two DLLs (jnidispatch-win32-amd64.dll and jnidispath-win32-x86.dll) to the assembly's bin directory.
