### PR TITLE
java library search path

### DIFF
--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -112,6 +112,7 @@ public class NativeLibrary {
         }
         
         searchPath.addAll(initPaths("jna.library.path"));
+        searchPath.addAll(initPaths("java.library.path"));
         String libraryPath = findLibraryPath(libraryName, searchPath);
         long handle = 0;
         //


### PR DESCRIPTION
Default in eclipse you can set native library search path by clicking project properties. This property will set java.library.path environment property to directoty where the library located.

Unfortunatlely jna do not search this path and you have to call jna static function in additional to settings eclipse path enviroment variable. Like this:

```
    NativeLibrary.addSearchPath("vlc", System.getProperty("java.library.path"));
```

This commit will allow you to search this path automaticaly as last priority search path.
