### PR TITLE
JNA initialization fails with PermissionDenied

### DIFF
--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -908,7 +908,7 @@ public final class Native {
 
     static File getTempDir() {
         File tmp = new File(System.getProperty("java.io.tmpdir"));
-        File jnatmp = new File(tmp, "jna");
+        File jnatmp = new File(tmp, "jna-" + System.getProperty("user.name"));
         jnatmp.mkdirs();
         return jnatmp.exists() ? jnatmp : tmp;
     }


### PR DESCRIPTION
We are using jenkins on FreeBSD and see that JNA does not work for us.
Here is an example of stack trace (JNA part):

java.lang.Error: Failed to create temporary file for jnidispatch library: java.io.IOException: Permission denied
        at com.sun.jna.Native.loadNativeLibraryFromJar(Native.java:735)
        at com.sun.jna.Native.loadNativeLibrary(Native.java:674)
        at com.sun.jna.Native.<clinit>(Native.java:115)

It seems that JNA creates %TMPDIR%/jna directory and tries to create files in this directory. The problem is that when later JNA tries to initialize from another user, this simply does not work because another user does not have rights to write to this directory. I did check on Linux and it seems it should have same problem.
I can see two options: 1) Don't create this subdirectory at all. 2) Include user name into directory name. 

The pull request uses second way as I don't know reasons to create directory.
