### PR TITLE
Fixing a crash in Netapi32Utils.getDomainTrusts()

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
@@ -652,7 +652,7 @@ public abstract class Netapi32Util {
             }
             return trusts.toArray(new DomainTrust[0]);
     	} finally {
-            rc = Netapi32.INSTANCE.NetApiBufferFree(domains.getPointer());   	    	
+            rc = Netapi32.INSTANCE.NetApiBufferFree(domains.getPointer().getPointer(0));   	    	
             if(W32Errors.NO_ERROR != rc) {
                 throw new Win32Exception(rc);
             }


### PR DESCRIPTION
The cleanup in Netapi32Utils.getDomainTrusts() seems always to crash the JVM. I tried adding an additional getPointer(0) onto the end of it and now it appears to work correctly.
