### PR TITLE
Fixed a crash trying to free the wrong pointer in Netapi32Util

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
@@ -652,7 +652,7 @@ public abstract class Netapi32Util {
             }
             return trusts.toArray(new DomainTrust[0]);
     	} finally {
-            rc = Netapi32.INSTANCE.NetApiBufferFree(domains.getPointer());   	    	
+            rc = Netapi32.INSTANCE.NetApiBufferFree(domains.getPointer().getPointer(0));   	    	
             if(W32Errors.NO_ERROR != rc) {
                 throw new Win32Exception(rc);
             }


### PR DESCRIPTION
This appears to fix a crash if this method is called, though I'm not confident if the fix is right.
