### PR TITLE
Fix W32FileMonitor (ULONG_PTRByReference)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,8 @@ Bug Fixes
 * Fix: avoid overwriting native `char *` or `wchar_t *` fields within structures when unmodified (similar to current operation with pointers) - [@twall](https://github.com/twall).
 * Fix: `platform.win32.DsGetDC.DS_DOMAIN_TRUSTS` and `DsEnumerateDomainTrusts` on Win32 64-bit - [@trejkaz](https://github.com/trejkaz).
 * Fix: Crash freeing the wrong pointer in `Netapi32Util.getDomainTrusts` - [@trejkaz](https://github.com/trejkaz).
- 
+* [#60](https://github.com/twall/jna/issues/60) Fix: `com.sun.jna.platform.win32.W32FileMonitor` broken - [@dblock](https://github.com/dblock).
+
 Release 3.4.1
 =============
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/BaseTSD.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/BaseTSD.java
@@ -68,24 +68,30 @@ public interface BaseTSD extends StdCallLibrary {
      */
     public static class ULONG_PTRByReference extends ByReference {
         public ULONG_PTRByReference() {
-            this(new ULONG_PTR(0));
+            this(null);
         }
         public ULONG_PTRByReference(ULONG_PTR value) {
             super(Pointer.SIZE);
             setValue(value);
         }
         public void setValue(ULONG_PTR value) {
-            if (Pointer.SIZE == 4) {
-                getPointer().setInt(0, value.intValue());
-            }
-            else {
-                getPointer().setLong(0, value.longValue());
-            }
+        	if (value != null) {
+        		if (Pointer.SIZE == 4) {
+        			getPointer().setInt(0, value.intValue());
+        		} else {
+        			getPointer().setLong(0, value.longValue());
+        		}
+        	}
         }
         public ULONG_PTR getValue() {
-            return new ULONG_PTR(Pointer.SIZE == 4
-                                 ? getPointer().getInt(0)
-                                 : getPointer().getLong(0));
+        	Pointer p = getPointer().getPointer(0);
+        	if (p == null) {
+        		return null;
+        	}
+            return new ULONG_PTR(
+            		Pointer.SIZE == 4
+            			? getPointer().getInt(0)
+                        : getPointer().getLong(0));
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -561,7 +561,7 @@ public interface Kernel32 extends WinNT {
      */
     boolean GetQueuedCompletionStatus(HANDLE CompletionPort, 
                                       IntByReference lpNumberOfBytes,
-                                      ULONG_PTRByReference lpCompletionKey, 
+                                      HANDLEByReference lpCompletionKey, 
                                       PointerByReference lpOverlapped,
                                       int dwMilliseconds);
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/W32FileMonitor.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/W32FileMonitor.java
@@ -19,10 +19,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.sun.jna.platform.FileMonitor;
-import com.sun.jna.platform.win32.BaseTSD.ULONG_PTRByReference;
 import com.sun.jna.platform.win32.WinBase.OVERLAPPED;
 import com.sun.jna.platform.win32.WinNT.FILE_NOTIFY_INFORMATION;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
@@ -111,7 +111,7 @@ public class W32FileMonitor extends FileMonitor {
     private FileInfo waitForChange() {
         Kernel32 klib = Kernel32.INSTANCE;
         IntByReference rcount = new IntByReference();
-        ULONG_PTRByReference rkey = new ULONG_PTRByReference();
+        HANDLEByReference rkey = new HANDLEByReference();
         PointerByReference roverlap = new PointerByReference();
         klib.GetQueuedCompletionStatus(port, rcount, rkey, roverlap, WinBase.INFINITE);
         


### PR DESCRIPTION
Fixed `W32FileMonitor`. It calls `GetQueuedCompletionStatus` which uses ULONG_PTRByReference. Since that's a pointer, it needs to be initialized at NULL, not 0.

@twall - I am not sure this is the right fix, please comment / merge.
