### PR TITLE
Deploy libjnidispatch.so at installation time

### DIFF
--- a/ANDROID.md
+++ b/ANDROID.md
@@ -1,6 +1,8 @@
-* Add Android SDK/NDK tools into PATH (used by native/Makefile)
-* Set ANDROID_HOME (used by native/Makefile)
+* Add the path of an Android NDK toolchain into PATH (e.g. export PATH=$PATH:$ANDROID_NDK_HOME/toolchains/arm-linux-androideabi-4.4.3/prebuilt/linux-x86/bin)
+* Set ANDROID_HOME in native/Makefile to the full path of the NDK platform to use (e.g. /home/gili/android-ndk-r8/platforms/android-8/arch-arm). WARNING: The home directory alias ("~/") may not be used in ANDROID_HOME.
 * Tests must be run on the target platform, not the build platform
-* libjnidispatch.so must be preinstalled; you cannot rely on JNA to unpack it
-  from its jar file for you.  Follow the Android NDK directions.
-* http://developer.android.com/guide/practices/jni.html
+* Build using: ant -Dos.prefix=android-arm dist
+* Add dist/jna.jar and/or dist/platform.jar to your application, as needed.
+* If you're using android-maven-plugin, jna.jar can be used as-is (native libraries will be automatically copied into your project).
+* If you're using Google's Eclipse plugin then you must manually remove libjnidispatch.so from jna.jar/lib/armeabi and add it into your project's "libs/armeabi" directory.
+* See http://code.google.com/p/android/issues/detail?id=17861 and http://developer.android.com/guide/practices/jni.html for more information.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,6 @@ Release 3.4.x
 Features
 --------
 * Add android-arm target (thanks to ochafik for initial work)
-* Add `jna.tmpdir` to override temporary JNA storage location
 
 Bug Fixes
 ---------

--- a/build.xml
+++ b/build.xml
@@ -252,6 +252,7 @@
     <uptodate property="-jar" targetfile="${build}/${jar}">
       <srcfiles dir="${classes}">
         <patternset id="jar-compiled">
+          <include name="lib/armeabi/*"/>
           <include name="com/sun/jna/*"/>
           <include name="com/sun/jna/**/*"/>
         </patternset>
@@ -492,6 +493,16 @@
       </or>
     </condition>
 
+    <!-- Android-specific paths -->
+    <condition property="native.path"
+	       value="lib/armeabi">
+        <equals arg1="${os.prefix}" arg2="android-arm"/>
+    </condition>
+    <condition property="native.path"
+	       value="com/sun/jna/${os.prefix}">
+	<not><equals arg1="${os.prefix}" arg2="android-arm"/></not>
+    </condition>
+
     <!-- Default make program -->
     <property name="make" value="make"/>
 
@@ -510,8 +521,8 @@
       <arg value="JNA_JNI_VERSION=${jni.version}"/>
       <arg value="CHECKSUM=${jni.md5}"/>
     </exec>
-    <mkdir dir="${classes}/com/sun/jna/${os.prefix}"/>
-    <copy todir="${classes}/com/sun/jna/${os.prefix}">
+    <mkdir dir="${classes}/${native.path}"/>
+    <copy todir="${classes}/${native.path}">
       <fileset dir="${build.native}"
                includes="jnidispatch.dll,libjnidispatch.*"/>
     </copy>
@@ -591,7 +602,7 @@
   <!-- When running tests from an IDE, be sure to set jna.library.path -->
   <!-- to where the test library (testlib) is found.                   -->
   <target name="test" depends="jar,compile-tests"
-          description="Run all unit tests">
+          description="Run all unit tests" unless="os.prefix">
     <property name="test.fork" value="yes"/>
     <property name="reports.junit" location="${reports}/junit"/>
     <property name="results.junit" location="${build}/junit-results"/>
@@ -874,9 +885,6 @@ osname=macos,
       <zipfileset src="${dist}/w32ce-arm.jar"
                   includes="*jnidispatch*"
                   prefix="com/sun/jna/w32ce-arm"/>
-      <zipfileset src="${dist}/android-arm.jar"
-                  includes="*jnidispatch*"
-                  prefix="com/sun/jna/android-arm"/>
     </jar>
     <copy todir="${dist}">
       <fileset dir="${contrib}/platform/dist">

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -689,6 +689,10 @@ public final class Native {
                 }
             }
         }
+        if (Platform.isAndroid()) {
+            // Native libraries must be bundled with the APK
+            System.setProperty("jna.nounpack", "true");
+        }
         try {
             if (!Boolean.getBoolean("jna.nosys")) {
                 System.loadLibrary(libName);
@@ -917,18 +921,11 @@ public final class Native {
         Override with <code>jna.tmpdir</code>
     */
     static File getTempDir() {
-        File jnatmp;
-        String prop = System.getProperty("jna.tmpdir");
-        if (prop != null) {
-            jnatmp = new File(prop);
-        }
-        else {
-            File tmp = new File(System.getProperty("java.io.tmpdir"));
-            jnatmp = new File(tmp, "jna-" + System.getProperty("user.name"));
-            jnatmp.mkdirs();
-            if (!jnatmp.exists() || !jnatmp.canWrite()) {
-                jnatmp = tmp;
-            }
+        File tmp = new File(System.getProperty("java.io.tmpdir"));
+        File jnatmp = new File(tmp, "jna-" + System.getProperty("user.name"));
+        jnatmp.mkdirs();
+        if (!jnatmp.exists() || !jnatmp.canWrite()) {
+            jnatmp = tmp;
         }
         if (!jnatmp.exists()) {
             throw new Error("JNA temporary directory " + jnatmp + " does not exist");


### PR DESCRIPTION
This is the "correct" way to deploy native libraries according to the Android documentation.
