### PR TITLE
Support all Debian multi-arch directories in library lookups

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -228,6 +228,8 @@
     <echo>java.home=${java.home}</echo>
     <echo>java.library.path=${java.library.path}</echo>
     <echo>os.prefix=${os.prefix}</echo>
+    <echo>os.name=${os.name}</echo>
+    <echo>os.arch=${os.arch}</echo>
     <echo>build=${build}</echo>
     <echo>build.native=${build.native}</echo>
 

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -683,7 +683,8 @@ public class NativeLibrary {
             // on 64bit machines, so we have to explicitly search the 64bit
             // one when running a 64bit JVM.
             //
-            if (Platform.isLinux() || Platform.isSolaris() || Platform.isFreeBSD()) {
+            if (Platform.isLinux() || Platform.isSolaris() || Platform.isFreeBSD()
+                || Platform.iskFreeBSD()) {
                 // Linux & FreeBSD use /usr/lib32, solaris uses /usr/lib/32
                 archPath = (Platform.isSolaris() ? "/" : "") + Pointer.SIZE * 8;
             }
@@ -698,23 +699,27 @@ public class NativeLibrary {
             // paths is scanned against real directory
             // so for platforms which are not multi-arch
             // this should continue to work.
-            if (Platform.isLinux()) {
+            if (Platform.isLinux() || Platform.iskFreeBSD() || Platform.isGNU()) {
                 // Defaults - overridden below
-                String cpu = "";
+                String cpu = Platform.getBaseArch();
                 String kernel = "linux";
                 String libc = "gnu";
 
-                if (Platform.isIntel()) {
-                    cpu = (Platform.is64Bit() ? "x86_64" : "i386");
-                } else if (Platform.isPPC()) {
-                    cpu = (Platform.is64Bit() ? "powerpc64" : "powerpc");
-                } else if (Platform.isARM()) {
-                    cpu = "arm";
+                if (Platform.isARM()) {
                     libc = "gnueabi";
                 }
 
-                String multiArchPath =
-                    cpu + "-" + kernel + "-" + libc;
+                if (Platform.iskFreeBSD()) {
+                    kernel = "kfreebsd";
+                }
+
+                String multiArchPath;
+
+                if (Platform.isGNU()) {
+                    multiArchPath = cpu + "-" + libc;
+                } else {
+                    multiArchPath = cpu + "-" + kernel + "-" + libc;
+                }
 
                 // Assemble path with all possible options
                 paths = new String[] {

--- a/src/com/sun/jna/Platform.java
+++ b/src/com/sun/jna/Platform.java
@@ -21,6 +21,8 @@ public final class Platform {
     public static final int WINDOWSCE = 6;
     public static final int AIX = 7;
     public static final int ANDROID = 8;
+    public static final int GNU = 9;
+    public static final int KFREEBSD = 10;
 
     /** Whether read-only (final) fields within Structures are supported. */
     public static final boolean RO_FIELDS;
@@ -67,6 +69,12 @@ public final class Platform {
         }
         else if (osName.startsWith("OpenBSD")) {
             osType = OPENBSD;
+        }
+        else if (osName.equalsIgnoreCase("gnu")) {
+            osType = GNU;
+        }
+        else if (osName.equalsIgnoreCase("gnu/kfreebsd")) {
+            osType = KFREEBSD;
         }
         else {
             osType = UNSPECIFIED;
@@ -125,6 +133,11 @@ public final class Platform {
     public static final boolean isOpenBSD() {
         return osType == OPENBSD;
     }
+    public static final boolean isGNU() {
+        return osType == GNU;
+    }    public static final boolean iskFreeBSD() {
+        return osType == KFREEBSD;
+    }
     public static final boolean isX11() {
         // TODO: check filesystem for /usr/X11 or some other X11-specific test
         return !Platform.isWindows() && !Platform.isMac();
@@ -180,4 +193,19 @@ public final class Platform {
             System.getProperty("os.arch").toLowerCase().trim();
         return arch.startsWith("arm");
     }
+
+    public static final String getBaseArch() {
+        String arch =
+            System.getProperty("os.arch").toLowerCase().trim();
+        if("amd64".equals(arch))
+            arch = "x86_64";
+        if("i686-at386".equals(arch))
+            arch = "i386";
+        if("ppc".equals(arch))
+            arch = "powerpc";
+        if("ppc64".equals(arch))
+            arch = "powerpc64";
+        return arch;
+    }
+
 }


### PR DESCRIPTION
Debian and Ubuntu are moving to a multi-arch layout. You already accepted a patch from Ubuntu to handle this for the platforms they build for, however Debian builds for a much wider range of platforms. We would appreciate your consideration of this pull request to provide multiarch layout support on all supported Debian platforms.
