### PR TITLE
Add fix for issue #135 in Advapi32Util (reading empty values)

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
@@ -1262,8 +1262,28 @@ public abstract class Advapi32Util {
 	    
 	    String nameString = Native.toString(name);
 
-	    if(lpcbData.getValue() == 0 && lpType.getValue() == WinNT.REG_BINARY) {
-	        keyValues.put(nameString, new byte[0]);
+	    if(lpcbData.getValue() == 0) {
+	        switch (lpType.getValue()) {
+            case WinNT.REG_BINARY: {
+                keyValues.put(nameString, new byte[0]);
+                break;
+            }
+            case WinNT.REG_SZ:
+            case WinNT.REG_EXPAND_SZ: {
+                keyValues.put(nameString, new char[0]);
+                break;
+            }
+            case WinNT.REG_MULTI_SZ: {
+                keyValues.put(nameString, new String[0]);
+                break;
+            }
+            case WinNT.REG_NONE: {
+                keyValues.put(nameString, null);
+                break;
+            }
+	        default:
+	            throw new RuntimeException("Unsupported empty type: " + lpType.getValue());
+	        }
 	        continue;
 	    }
 


### PR DESCRIPTION
With this fix it is possible to read values from registry of the following
types even when the size of the value is 0:

REG_SZ
REG_EXPAND_SZ
REG_MULTI_SZ
REG_NONE
REG_BINARY (fixed by earlier committer)

Advapi32UtilTest updated with unit test triggering the bug.
