### PR TITLE
Diagnostic for temp jnidispatch file creation

### DIFF
--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -770,7 +770,7 @@ public final class Native {
                 unpacked = true;
             }
             catch(IOException e) {
-                throw new Error("Failed to create temporary file for jnidispatch library: " + e);
+                throw new Error("Failed to create temporary file for jnidispatch library", e);
             }
             finally {
                 try { is.close(); } catch(IOException e) { }


### PR DESCRIPTION
Nesting underlying exception will provide more insight on what may caused an error.
