### PR TITLE
a kludge-around to get the windows native CI build to succeed (by avoidi...

### DIFF
--- a/native/libffi/include/ffi_common.h
+++ b/native/libffi/include/ffi_common.h
@@ -46,10 +46,12 @@ char *alloca ();
 /* Check for the existence of memcpy. */
 #if STDC_HEADERS
 # include <string.h>
-#else
-# ifndef HAVE_MEMCPY
-#  define memcpy(d, s, n) bcopy ((s), (d), (n))
-# endif
+/* This can cause Windows build to fail.
+else
+ ifndef HAVE_MEMCPY
+  define memcpy(d, s, n) bcopy ((s), (d), (n))
+ endif
+*/
 #endif
 
 #if defined(FFI_DEBUG)


### PR DESCRIPTION
...ng a native build error resulting from using bcopy() instead of memcpy() ).

If this change is valid, should it go here, or instead go back to the libffi project?
