### PR TITLE
re-fix broken download links (to maven central for now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Download
 
 Version 3.5.1
 
-* [jna.jar](https://maven.java.net/content/repositories/releases/net/java/dev/jna/jna/3.5.1/dist/jna-3.5.1.jar)
-* [platform.jar](https://maven.java.net/content/repositories/releases/net/java/dev/jna/platform/3.5.1/dist/platform-3.5.1.jar)
+* [jna.jar](https://maven.java.net/content/repositories/releases/net/java/dev/jna/jna/3.5.1/jna-3.5.1.jar)
+* [platform.jar](https://maven.java.net/content/repositories/releases/net/java/dev/jna/platform/3.5.1/platform-3.5.1.jar)
 
 Features
 ========


### PR DESCRIPTION
not sure why blob links work, then break...
