### PR TITLE
OSGi fix for Mac OS X

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -356,7 +356,7 @@ com/sun/jna/freebsd-amd64/libjnidispatch.so;
 processor=x86-64;osname=freebsd,
 
 com/sun/jna/darwin/libjnidispatch.jnilib;
-osname=macos
+osname=macosx;processor=x86;processor=x86_64;processor=ppc
 "/>
       </manifest>
       <fileset dir="${classes}" excludes="${jar.omitted}">


### PR DESCRIPTION
In order to get JNA working as an OSGi bundle with Felix 4.0.3 on Mac OS X (10.6), I had to change the MANIFEST header a bit. I'm not sure if it is a JNA or a Felix problem, but this patched fixed it.
