### PR TITLE
Fix: Eclipse project build.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,6 +6,6 @@
 	<classpathentry kind="src" output="build.eclipse/test-classes" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/3"/>
-	<classpathentry kind="lib" path="C:/GitHub/jna-3.5.1.jar"/>
+	<classpathentry kind="lib" path="lib/test/reflections-0.9.8.jar"/>
 	<classpathentry kind="output" path="build.eclipse/classes"/>
 </classpath>


### PR DESCRIPTION
The hard-coded path is obviously not right. Added the missing JAR.

Now the project builds, but tests don't run. This is something related to 32/64 bit I think on Windows and I can't remember how we fixed it. Appreciate any suggestions.

```
java.lang.UnsatisfiedLinkError: Native library (com/sun/jna/win32-x86-64/jnidispatch.dll) not found in resource path ([file:/C:/Users/dblock/Source/GitHub/jna/dblock/jna/build.eclipse/test-classes/, file:/C:/Users/dblock/Source/GitHub/jna/dblock/build.eclipse/test-classes/, file:/C:/Users/dblock/Source/GitHub/jna/dblock/build.eclipse/classes/, file:/C:/Program%20Files/Eclipse/plugins/org.junit_3.8.2.v3_8_2_v20100427-1100/junit.jar, file:/C:/Users/dblock/Source/GitHub/jna/dblock/lib/test/reflections-0.9.8.jar, file:/C:/Program%20Files/Eclipse/configuration/org.eclipse.osgi/bundles/207/2/.cp/])
    at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:721)
    at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:689)
    at com.sun.jna.Native.<clinit>(Native.java:128)
    at com.sun.jna.NativeLong.<clinit>(NativeLong.java:23)
    at com.sun.jna.platform.win32.WinError.<clinit>(WinError.java:24247)
    at com.sun.jna.platform.win32.Shell32Test.testSHGetFolderPath(Shell32Test.java:32)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at junit.framework.TestCase.runTest(TestCase.java:164)
    at junit.framework.TestCase.runBare(TestCase.java:130)
    at junit.framework.TestResult$1.protect(TestResult.java:106)
    at junit.framework.TestResult.runProtected(TestResult.java:124)
    at junit.framework.TestResult.run(TestResult.java:109)
    at junit.framework.TestCase.run(TestCase.java:120)
    at junit.framework.TestSuite.runTest(TestSuite.java:230)
    at junit.framework.TestSuite.run(TestSuite.java:225)
    at org.eclipse.jdt.internal.junit.runner.junit3.JUnit3TestReference.run(JUnit3TestReference.java:130)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)
```
