### PR TITLE
Fix for issue#226 "Convert platform to OSGi"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -356,7 +356,7 @@
         <attribute name="Bundle-Name" value="jna"/>
         <attribute name="Bundle-Description" value="JNA Library"/>
         <attribute name="Bundle-SymbolicName" value="com.sun.jna"/>
-        <attribute name="Bundle-Version" value="${spec.version}"/>
+        <attribute name="Bundle-Version" value="${jna.major}.${jna.minor}.${jna.revision}"/>
         <attribute name="Bundle-RequiredExecutionEnvironment" value="J2SE-1.4"/>
         <attribute name="Bundle-Vendor" value="${vendor}"/>
         <attribute name="Bundle-ActivationPolicy" value="lazy"/>
@@ -489,6 +489,14 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
       <property name="libs.junit.classpath" location="lib/junit.jar"/>
       <property name="javac.source" value="${platform.compatibility}"/>
       <property name="javac.target" value="${platform.compatibility}"/>
+      <!-- OSGi manifest properties -->
+      <property name="vendor" value="${vendor}"/>
+      <property name="impl.title" value="${impl.title}.platform"/>
+      <property name="impl.version" value="${impl.version}"/>
+      <property name="spec.title" value="${spec.title}"/>
+      <property name="spec.vendor" value="${spec.vendor}"/>
+      <property name="spec.version" value="${spec.version}"/>
+      <property name="osgi.version" value="${jna.major}.${jna.minor}.${jna.revision}"/>
       <fileset dir="${contrib}" includes="platform/build.xml" />
     </subant>
     <!-- Sources package as required by maven -->

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -57,12 +57,54 @@
             </exec>
         </target>
 
-    Notice that the overridden target depends on the jar target and not only on 
-    the compile target as the regular run target does. Again, for a list of available 
+    Notice that the overridden target depends on the jar target and not only on
+    the compile target as the regular run target does. Again, for a list of available
     properties which you can use, check the target you are overriding in the
-    nbproject/build-impl.xml file. 
+    nbproject/build-impl.xml file.
 
     -->
+
+    <target name="-do-jar-without-manifest">
+       <jar jarfile="${dist.jar}" compress="${jar.compress}">
+         <manifest>
+           <attribute name="Main-Class" value="com.sun.jna.Native"/>
+           <attribute name="Manifest-Version" value="1.0"/>
+           <attribute name="Implementation-Title" value="${impl.title}"/>
+           <attribute name="Implementation-Vendor" value="${vendor}"/>
+           <attribute name="Implementation-Version" value="${impl.version}"/>
+           <attribute name="Specification-Title" value="${spec.title}"/>
+           <attribute name="Specification-Vendor" value="${spec.vendor}"/>
+           <attribute name="Specification-Version" value="${spec.version}"/>
+           <!--
+              OSGi Bundle attributes
+              See http://www.osgi.org/Specifications/Reference
+            -->
+           <attribute name="Bundle-Category" value="jni"/>
+           <attribute name="Bundle-ManifestVersion" value="2"/>
+           <attribute name="Bundle-Name" value="jna-platform"/>
+           <attribute name="Bundle-Description" value="JNA Platform Library"/>
+           <attribute name="Bundle-SymbolicName" value="com.sun.jna.platform"/>
+           <attribute name="Bundle-Version" value="${osgi.version}"/>
+           <attribute name="Bundle-RequiredExecutionEnvironment" value="J2SE-1.4"/>
+           <attribute name="Bundle-Vendor" value="${vendor}"/>
+           <attribute name="Require-Bundle" value="com.sun.jna;bundle-version=&quot;${osgi.version}&quot;"/>
+           <attribute name="Export-Package"
+                   value="
+com.sun.jna.platform,
+com.sun.jna.platform.dnd,
+com.sun.jna.platform.mac,
+com.sun.jna.platform.unix,
+com.sun.jna.platform.win32,
+com.sun.jna.platform.win32.COM,
+com.sun.jna.platform.win32.COM.tlb,
+com.sun.jna.platform.win32.COM.tlb.imp,
+com.sun.jna.platform.wince
+"/>
+         </manifest>
+         <fileset dir="${build.classes.dir}"/>
+       </jar>
+    </target>
+
     <target name="test" depends="init,compile,compile-test,-pre-test-run" description="Run platform unit tests.">
       <echo>Running platform tests: ${test.src.dir}</echo>
       <property name="test.fork" value="yes"/>


### PR DESCRIPTION
Sorry for the messy commits.  Commit e4a1158 was made, but on reviewing the diff I noticed that there was a large number of lines that showed whitespace differences (obscuring what was actually changed).  Commit 57197d3 reverted the e4a1158 commit, returning the repository to pristine condition.  Commit 9de2005 contains the same changes as the original e4a1158 commit with most of the whitespace differences removed.

As the commit message says:

Build jna-platform jar with OSGi headers. Also, fix OSGi "Bundle-Version" header of core jna.jar to contain full version number, rather than just ${jna.major} number.
