### PR TITLE
Choose whether to use MSVC based on MSVC env.

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -162,12 +162,8 @@ endif
 
 ifeq ($(OS),win32)
 ARCH=$(shell uname -m | sed 's/i.86/i386/g')
-ifeq ($(ARCH),amd64)
-# To build entirely with mingw64, comment out this line (default is MSVC)
+ifdef $(MSVC)
 USE_MSVC=true
-else
-# To build 32-bit under MSVC, un-comment this line (default is gcc)
-#USE_MSVC=true
 endif
 
 CDEFINES=-DHAVE_PROTECTION -DPSAPI_VERSION=1 -DFFI_BUILDING -DUNICODE -D_UNICODE

--- a/www/WindowsDevelopmentEnvironment.md
+++ b/www/WindowsDevelopmentEnvironment.md
@@ -1,33 +1,50 @@
 ## Setting up a Windows Development Environment
 
-Type `ant` from the top.
+32-bit Windows
+--------------
 
-Windows builds require [cygwin](http://www.cygwin.com/). 
+#### Java
 
-When installing cygwin, include ssh, git, make, autotools, and either gcc3 or
-mingw64, depending on whether you're targeting win32 or win64, respectively (it's 
-possible to build both from the same host).
+Set `JAVA_HOME` to a 32-bit JDK, eg. `C:\Program Files (x86)\java\jdk1.6.0_24`. 
 
-To build on Win64, you'll need mingw64 (available with cygwin or separately),
-and optionally the free MS Visual Studio C++ Express compiler.  The MS
-compiler is preferred, since it provides structured event handling (SEH),
-which allows JNA to trap native faults when run in protected mode.
+#### Cygwin
 
-To build on Win64 and run tests in Eclipse you will need the 64-bit native build. 
+Install [cygwin](http://www.cygwin.com/) or [msys](http://mingw.org/wiki/msys).
+
+When installing cygwin, include ssh, git, make, autotools, and gcc3.
+
+When installing msys, include gcc packages. 
+
+64-bit Windows
+--------------
+
+#### Java
+
 Set `JAVA_HOME` to a 64-bit JDK, eg. `C:\Program Files\java\jdk1.6.0_24`. 
 
-To build with the mingw64, uncomment the line assigning `CC` to `$(MINGW)` in
-`native/Makefile` and make sure the cross-compiling mingw64 tools are in your
-path.
+#### Cygwin
 
-If you get errors such as `'\r': command not found`, run `dos2unix -f [filename]`
-for each file that it's complaining about.
+Install [cygwin](http://www.cygwin.com/) or [msys](http://mingw.org/wiki/msys).
+
+When installing cygwin, include ssh, git, make, autotools, and mingw64. 
+
+When installing msys, include gcc packages. 
+
+#### MingW64
+
+Install Mingw64 from [here](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Automated%20Builds/).
+Download a package starting with *mingw-w64-bin_i686-mingw*. Extract the files to `c:\MinGW`
+or the path where Cygwin is located.
+
+#### Visual Studio
+
+You can optionally use the free MS Visual Studio C++ Express compiler to compile
+native bits. The MS compiler provides structured event handling (SEH),
+which allows JNA to trap native faults when run in protected mode.
 
 To use the MS compiler, ensure that the 64-bit versions of
 cl.exe/ml64.exe/link.exe are in your PATH and that the INCLUDE and LIB
 environment variables are set properly (as in VCVARS.BAT). 
-
-Even if compiling with the MS compiler, you must also install mingw64.
 
 Sample configuration, setting up INCLUDE/LIB:
 
@@ -42,3 +59,14 @@ export LIB="$(cygpath -m "$MSVC")/lib/amd64;$(cygpath -m "$WSDK_64")/lib/x64"
 # for 32-bit target
 export LIB="$(cygpath -m "$MSVC")/lib;$(cygpath -m "$WSDK")/lib"
 ```
+
+### Issues
+
+#### Backslash R Command Not Found
+
+If you get errors such as `'\r': command not found`, run `dos2unix -f [filename]`
+for each file that it's complaining about.
+
+### Building
+
+Type `ant` from the top to build the project.


### PR DESCRIPTION
I had to setup a new box to build JNA and it was as painful as usual :) 

I've updated the instructions thoroughly, separating 32-bit Windows and 64-bit Windows.

The only real problem was that we tell people in the docs that Visual Studio is optional, but we don't behave that way. We also do different things on 32-bit vs. 64-bit, which is unnecessary. We do tell to define MSVC when you build with Visual Studio, so I changed the native bits Makefile to just set USE_MSVC based on that.

@twall, this is for your, LMK what you think.
