### PR TITLE
Removed dependency on JNA_LIB and contrib paths.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" output="jna/build.eclipse/test-classes" path="contrib/platform/test"/>
-	<classpathentry kind="src" path="contrib/platform/src"/>
 	<classpathentry kind="src" output="build.eclipse/test-classes" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/3"/>
 	<classpathentry kind="lib" path="lib/test/reflections-0.9.8.jar"/>
-	<classpathentry kind="var" path="JNA_LIB"/>
 	<classpathentry kind="output" path="build.eclipse/classes"/>
 </classpath>


### PR DESCRIPTION
You can import `jnalib` into a fresh Eclipse project and it will fail in a couple of ways. The first one is that it wants a value for `JNA_LIB`, I am not sure why. The other is that `contrib/platform/src` will be built, which doesn't seem to  work, you should be importing the `contrib/platform` project separately. I think even if it did there're many more `contrib` projects and maybe we should move `platform` one level up, instead of trying to lump it into `jnalib`.
