### PR TITLE
Fix: use shell objects available on all versions of Windows.

### DIFF
--- a/contrib/platform/test/com/sun/jna/platform/win32/Ole32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Ole32Test.java
@@ -83,10 +83,9 @@ public class Ole32Test extends TestCase {
 		HRESULT hrCI = Ole32.INSTANCE.CoInitializeEx(null, 0);
 
 		GUID guid = Ole32Util
-				.getGUIDFromString("{13709620-C279-11CE-A49E-444553540000}"); // Shell
-																				// object
+				.getGUIDFromString("{00021401-0000-0000-C000-000000000046}"); // Shell object
 		GUID riid = Ole32Util
-				.getGUIDFromString("{D8F015C0-C278-11CE-A49E-444553540000}"); // IShellDispatch
+				.getGUIDFromString("{000214EE-0000-0000-C000-000000000046}"); // IShellLinkA
 
 		PointerByReference pDispatch = new PointerByReference();
 


### PR DESCRIPTION
To be honest I don't know why IShellDispatch is throwing a weird 0x80040154 error (cannot retrieve COM class factory). But changing the GUIDs to something more universal and built into Windows works.
