### PR TITLE
Fix: LPOLESTR constructor with a string doesn't allocate memory.

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
@@ -209,7 +209,7 @@ public interface WTypes {
         }
 
         public LPOLESTR(String value) {
-            this();
+            super(new Memory((value.length() + 1L) * Native.WCHAR_SIZE));
             this.setValue(value);
         }
 


### PR DESCRIPTION
A few of the COM tests fail because of this one. The constructor should work much like a `BSTR`.
