### PR TITLE
Replace StringBuffers with StringBuilders

### DIFF
--- a/contrib/alphamaskdemo/com/sun/jna/contrib/demo/AlphaMaskDemo.java
+++ b/contrib/alphamaskdemo/com/sun/jna/contrib/demo/AlphaMaskDemo.java
@@ -438,7 +438,7 @@ public class AlphaMaskDemo implements Runnable {
                     if (flavor != null) {
                         Reader reader = flavor.getReaderForText(t);
                         char[] buf = new char[512];
-                        StringBuffer b = new StringBuffer();
+                        StringBuilder b = new StringBuilder();
                         int count;
                         // excise excess NUL characters (bug in firefox, java
                         // or my code, not sure which).  someone got the 

--- a/contrib/alphamaskdemo/com/sun/jna/contrib/demo/AlphaMaskDemo2.java
+++ b/contrib/alphamaskdemo/com/sun/jna/contrib/demo/AlphaMaskDemo2.java
@@ -200,7 +200,7 @@ public class AlphaMaskDemo2 implements Runnable {
                     if (flavor != null) {
                         Reader reader = flavor.getReaderForText(t);
                         char[] buf = new char[512];
-                        StringBuffer b = new StringBuffer();
+                        StringBuilder b = new StringBuilder();
                         int count;
                         // excise excess NUL characters (bug in firefox,
                         // java

--- a/contrib/balloontips/com/sun/jna/contrib/demo/FilteredTextField.java
+++ b/contrib/balloontips/com/sun/jna/contrib/demo/FilteredTextField.java
@@ -256,8 +256,8 @@ public class FilteredTextField extends JTextField {
           balloon.hide();
         }
       }
-      StringBuffer buffer =
-        new StringBuffer(FilteredTextField.this.getText());
+      StringBuilder buffer =
+        new StringBuilder(FilteredTextField.this.getText());
       if (offset >= 0 && offset <= buffer.length()) {
         buffer.insert(offset, str);
         String strBuf = buffer.toString();

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
@@ -1747,7 +1747,7 @@ public abstract class Advapi32Util {
 	 * @return A environment block
 	 */
 	public static String getEnvironmentBlock(Map<String, String> environment) {
-		StringBuffer out = new StringBuffer();
+		StringBuilder out = new StringBuilder();
 		for (Entry<String, String> entry : environment.entrySet()) {
 			if (entry.getValue() != null) {
 				out.append(entry.getKey() + "=" + entry.getValue() + "\0");

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -1272,7 +1272,7 @@ public final class Native implements Version {
 
     // No String.replace available in 1.4
     static String replace(String s1, String s2, String str) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         while (true) {
             int idx = str.indexOf(s1);
             if (idx == -1) {

--- a/test/com/sun/jna/NativeTest.java
+++ b/test/com/sun/jna/NativeTest.java
@@ -28,7 +28,7 @@ public class NativeTest extends TestCase {
     private static final String UNICODE = "[\u0444]";
 
     public void testLongStringGeneration() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         final int MAX = Platform.isWindowsCE() ? 200000 : 2000000;
         for (int i=0;i < MAX;i++) {
             buf.append('a');


### PR DESCRIPTION
Here is a trivial patch replacing the private StringBuffers with non synchronized StringBuilders. This doesn't affect the StringBuffers exposed by the public API.
