### PR TITLE
Remove unused imports

### DIFF
--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -19,7 +19,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -14,7 +14,6 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.WeakHashMap;
 
 /**
  * A <code>Pointer</code> to memory obtained from the native heap via a 

--- a/src/com/sun/jna/Pointer.java
+++ b/src/com/sun/jna/Pointer.java
@@ -10,7 +10,6 @@
  */
 package com.sun.jna;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;

--- a/src/com/sun/jna/ptr/ByReference.java
+++ b/src/com/sun/jna/ptr/ByReference.java
@@ -13,8 +13,6 @@
 package com.sun.jna.ptr;
 
 import com.sun.jna.Memory;
-import com.sun.jna.NativeMapped;
-import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 
 /** Provides generic "pointer to type" functionality, often used in C

--- a/src/com/sun/jna/win32/StdCallFunctionMapper.java
+++ b/src/com/sun/jna/win32/StdCallFunctionMapper.java
@@ -13,20 +13,13 @@
 package com.sun.jna.win32;
 
 import java.lang.reflect.Method;
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
 
-import com.sun.jna.Callback;
 import com.sun.jna.FunctionMapper;
 import com.sun.jna.Native;
 import com.sun.jna.NativeLibrary;
-import com.sun.jna.NativeLong;
 import com.sun.jna.NativeMapped;
 import com.sun.jna.NativeMappedConverter;
 import com.sun.jna.Pointer;
-import com.sun.jna.PointerType;
-import com.sun.jna.Structure;
-import com.sun.jna.WString;
 
 /** Provides mapping from simple method names to w32 stdcall-decorated names
  * where the name suffix is "@" followed by the number of bytes popped by

--- a/src/com/sun/jna/win32/W32APIOptions.java
+++ b/src/com/sun/jna/win32/W32APIOptions.java
@@ -2,7 +2,6 @@ package com.sun.jna.win32;
 
 import java.util.HashMap;
 import java.util.Map;
-import com.sun.jna.Library;
 
 public interface W32APIOptions extends StdCallLibrary {
     /** Standard options to use the unicode version of a w32 API. */

--- a/src/com/sun/jna/win32/W32APITypeMapper.java
+++ b/src/com/sun/jna/win32/W32APITypeMapper.java
@@ -12,13 +12,8 @@
  */
 package com.sun.jna.win32;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.sun.jna.DefaultTypeMapper;
 import com.sun.jna.FromNativeContext;
-import com.sun.jna.Pointer;
-import com.sun.jna.Library;
 import com.sun.jna.StringArray;
 import com.sun.jna.ToNativeContext;
 import com.sun.jna.TypeConverter;


### PR DESCRIPTION
I noticed some unused import statements in the code, here is a patch removing them.
