### PR TITLE
Use getCanonicalPath instead of getAbsolutePath for native library tests

### DIFF
--- a/test/com/sun/jna/NativeLibraryTest.java
+++ b/test/com/sun/jna/NativeLibraryTest.java
@@ -188,9 +188,9 @@ public class NativeLibraryTest extends TestCase {
     	File lib1_1 = new File(dir, "lib" + name + ".so.1.1");
         lib1_1.createNewFile();
     	lib1_1.deleteOnExit();
-    	List path = Arrays.asList(new String[] { dir.getAbsolutePath() });
+        List path = Arrays.asList(new String[] { dir.getCanonicalPath() });
     	assertEquals("Latest versioned library not found when unversioned requested",
-                     lib1_1.getAbsolutePath(),	
+                     lib1_1.getCanonicalPath(),
                      NativeLibrary.matchLibrary(name, path));
     }
     
@@ -203,9 +203,9 @@ public class NativeLibraryTest extends TestCase {
         File lib1 = new File(dir, "lib" + name + "-client.so.2");
         lib1.createNewFile();
         lib1.deleteOnExit();
-    	List path = Arrays.asList(new String[] { dir.getAbsolutePath() });
+        List path = Arrays.asList(new String[] { dir.getCanonicalPath() });
     	assertEquals("Library with similar prefix should be ignored",
-                     lib0.getAbsolutePath(),	
+                     lib0.getCanonicalPath(),
                      NativeLibrary.matchLibrary(name, path));
     }
 


### PR DESCRIPTION
Was running into some issues with these tests and switching it to getCacnonicalPath fixed it. Absolute path was returning "..." for some reason, not sure why. Test result looked like:

```
[junit] Testcase: testMatchUnversionedToVersioned(com.sun.jna.NativeLibraryTest):   FAILED
[junit] Latest versioned library not found when unversioned requested expected:<.../...> but was:<......>
[junit] junit.framework.ComparisonFailure: Latest versioned library not found when unversioned requested expected:<.../...> but was:<......>
[junit]     at com.sun.jna.NativeLibraryTest.testMatchUnversionedToVersioned(NativeLibraryTest.java:192)
[junit] 
[junit] 
[junit] Testcase: testAvoidFalseMatch(com.sun.jna.NativeLibraryTest):   FAILED
[junit] Library with similar prefix should be ignored expected:<.../...> but was:<......>
[junit] junit.framework.ComparisonFailure: Library with similar prefix should be ignored expected:<.../...> but was:<......>
[junit]     at com.sun.jna.NativeLibraryTest.testAvoidFalseMatch(NativeLibraryTest.java:207)
```

See:

http://meatwad.mouf.net/rubick/poudriere/logs/bulk/10amd64-default/2014-02-26_18h52m31s/logs/errors/jna-4.0_1.log

for more details.
