### PR TITLE
Pulled varargs test out of the loop to avoid checking on each parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Features
 * [#338](https://github.com/twall/jna/pull/338): Added `com.sun.jna.platform.mac.XAttr` and `com.sun.jna.platform.mac.XAttrUtil` JNA wrapper for `<sys/xattr.h>` for Mac OS X - [@rednoah](https://github.com/rednoah).
 * [#339](https://github.com/twall/jna/pull/339): Added `GetWindowPlacement`, `SetWindowPlacement`, `AdjustWindowRect`, `AdjustWindowRectEx`, `ExitWindowsEx`, and `LockWorkstation` to `com.sun.jna.platform.win32.User32` - [@Timeroot](https://github.com/Timeroot).
 * [#286](https://github.com/twall/jna/pull/286): Added in com.sun.jna.platform.win32.Kernel32: CreateRemoteThread, WritePocessMemory and ReadProcessMemory - [@sstokic-tgm](https://github.com/sstokic-tgm).
+* [#352](https://github.com/twall/jna/pull/352): Performance improvements due to reduced locking in `com.sun.jna.Library$Handler` and fewer vararg checks in `com.sun.jna.Function` - [@Boereck](https://github.com/Boereck).
 
 Bug Fixes
 ---------

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -288,9 +288,10 @@ public class Function extends Pointer {
         Method invokingMethod = (Method)options.get(OPTION_INVOKING_METHOD);
         Class[] paramTypes = invokingMethod != null ? invokingMethod.getParameterTypes() : null;
         boolean allowObjects = Boolean.TRUE.equals(options.get(Library.OPTION_ALLOW_OBJECTS));
+        boolean isVarArgs = args.length > 0 && invokingMethod != null ? isVarArgs(invokingMethod) : false;
         for (int i=0; i < args.length; i++) {
             Class paramType = invokingMethod != null
-                ? (isVarArgs(invokingMethod) && i >= paramTypes.length-1
+                ? (isVarArgs && i >= paramTypes.length-1
                    ? paramTypes[paramTypes.length-1].getComponentType()
                    : paramTypes[i])
                 : null;
@@ -776,21 +777,34 @@ public class Function extends Pointer {
         return inArgs;
     }
 
+    /**
+     * Reference to Method.isVarArgs
+     */
+    private static Method isVarArgsMethod = getIsVarArgsMethod();
+    
+    /**
+     * If possible returns the Method.isVarArgs method via reflection
+     * @return Method.isVarArgs method
+     */
+    private static Method getIsVarArgsMethod() {
+        try {
+            return Method.class.getMethod("isVarArgs", new Class[0]);
+        } catch (SecurityException e) {
+            return null;
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+    
     /** Varargs are only supported on 1.5+. */
     static boolean isVarArgs(Method m) {
-        try {
-            Method v = m.getClass().getMethod("isVarArgs", new Class[0]);
-            return Boolean.TRUE.equals(v.invoke(m, new Object[0]));
-        }
-        catch (SecurityException e) {
-        }
-        catch (NoSuchMethodException e) {
-        }
-        catch (IllegalArgumentException e) {
-        }
-        catch (IllegalAccessException e) {
-        }
-        catch (InvocationTargetException e) {
+        if(isVarArgsMethod != null) {
+            try {
+                return Boolean.TRUE.equals(isVarArgsMethod.invoke(m, new Object[0]));
+            } catch (IllegalArgumentException e) {
+            } catch (IllegalAccessException e) {
+            } catch (InvocationTargetException e) {
+            }
         }
         return false;
     }


### PR DESCRIPTION
I realized that a lot of time is spent in the isVarArgs method, because it is called for every parameter, but the result will always be the same in each loop iteration.
So I pulled the check out of the loop. For functions with no parameter it introduces one more check and variable assignment, but the gain for methods with >1 parameter is dramatic.
This change makes one of the applications I am working on 13 to 15 percent faster on my machine.
