### PR TITLE
Improved function call performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Features
 * [#350](https://github.com/twall/jna/pull/350): Added `jnacontrib.x11.api.X.Window.getSubwindows` - [@rm5248](https://github.com/rm5248).
 * Improved `contrib/msoffice` sample - [@wolftobias](https://github.com/wolftobias).
 * [#352](https://github.com/twall/jna/pull/352): Performance improvements due to reduced locking in `com.sun.jna.Library$Handler` and fewer vararg checks in `com.sun.jna.Function` - [@Boereck](https://github.com/Boereck).
+* [#353](https://github.com/twall/jna/pull/353): Performance improvements by improved collaboration between `com.sun.jna.Library$Handler` and `com.sun.jna.Function` - [@Boereck](https://github.com/Boereck).
 * [#357](https://github.com/twall/jna/pull/357): Added `com.sun.jna.platform.win32.Kernel32.SetSystemTime` - [@lgoldstein](https://github.com/lgoldstein), [@thomasjoulin](https://github.com/thomasjoulin).
 * [#365](https://github.com/twall/jna/pull/365): Added `com.sun.jna.platform.win32.Kernel32.GetComputerNameEx` support - [@lgoldstein](https://github.com/lgoldstein).
 * [#368](https://github.com/twall/jna/pull/368): Added `com.sun.jna.platform.win32.Kernel32.VirtualQueryEx`, `com.sun.jna.platform.win32.WinNT.MEMORY_BASIC_INFORMATION` and `MEM_COMMIT`, `MEM_FREE`, `MEM_RESERVE`, `MEM_IMAGE`, `MEM_MAPPED`, `MEM_PRIVATE` constants - [@apsk](https://github.com/apsk).

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -272,6 +272,17 @@ public class Function extends Pointer {
      * native result as an Object.
      */
     public Object invoke(Class returnType, Object[] inArgs, Map options) {
+        Method invokingMethod = (Method)options.get(OPTION_INVOKING_METHOD);
+        Class[] paramTypes = invokingMethod != null ? invokingMethod.getParameterTypes() : null;
+        return invoke(invokingMethod, paramTypes, returnType, inArgs, options);
+    }
+
+    /** Invoke the native function with the given arguments, returning the
+     * native result as an Object. This method can be called if invoking method and parameter
+     * types are already at hand. When calling {@link Function#invoke(Class, Object[], Map)},
+     * the method has to be in the options under key {@link Function#OPTION_INVOKING_METHOD}.
+     */
+    Object invoke(Method invokingMethod, Class[] paramTypes, Class returnType, Object[] inArgs, Map options) {
         // Clone the argument array to obtain a scratch space for modified
         // types/values
         Object[] args = { };
@@ -285,8 +296,6 @@ public class Function extends Pointer {
 
         TypeMapper mapper = 
             (TypeMapper)options.get(Library.OPTION_TYPE_MAPPER);
-        Method invokingMethod = (Method)options.get(OPTION_INVOKING_METHOD);
-        Class[] paramTypes = invokingMethod != null ? invokingMethod.getParameterTypes() : null;
         boolean allowObjects = Boolean.TRUE.equals(options.get(Library.OPTION_ALLOW_OBJECTS));
         boolean isVarArgs = args.length > 0 && invokingMethod != null ? isVarArgs(invokingMethod) : false;
         for (int i=0; i < args.length; i++) {


### PR DESCRIPTION
Hi, another change for method call performance. Some unnecessary time was spent in Function#invoke(Class returnType, Object[] inArgs, Map options). The method looked up the method object and the parameter types, although this information is already available, when invoking the method from Library$Handler#invoke(Object proxy, Method method, Object[] inArgs). So I refactored both classes a bit so that no unnecessary work is done. In my tests function calls are now measurably faster and produce fewer objects (->less garbage).