### PR TITLE
Pointer.getWideStringArray respects the length parameter

### DIFF
--- a/src/com/sun/jna/Pointer.java
+++ b/src/com/sun/jna/Pointer.java
@@ -849,7 +849,7 @@ v     * @param wide whether to convert from a wide or standard C string
     }
 
     public String[] getWideStringArray(long offset, int length) {
-        return getStringArray(offset, -1, NativeString.WIDE_STRING);
+        return getStringArray(offset, length, NativeString.WIDE_STRING);
     }
 
     /** Returns an array of <code>String</code> based on a native array


### PR DESCRIPTION
Pointer.getWideStringArray had what looks like a cut'n paste error and didn't pass the length parameter on.
