### PR TITLE
Pointer.getWideStringArray respects the length parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Bug Fixes
 * [#319](https://github.com/twall/jna/pull/319): Fix direct-mapping type-mapped pointer result types - [@marco2357](https://github.com/marco2357).
 * [#350](https://github.com/twall/jna/pull/350): Fix `jnacontrib.x11.api.X.Window.getXXXProperty`, returns `null` if the window property is not found - [@rm5248](https://github.com/rm5248).
 * Fixed `com.sun.jna.platform.win32.Variant` and `TlbImp` - [@wolftobias](https://github.com/wolftobias).
+* Fixed `com.sun.jna.Pointer.getWideStringArray` not respecting the length parameter - [@csoren](https://github.com/csoren).
 
 Release 4.1
 ===========

--- a/src/com/sun/jna/Pointer.java
+++ b/src/com/sun/jna/Pointer.java
@@ -849,7 +849,7 @@ v     * @param wide whether to convert from a wide or standard C string
     }
 
     public String[] getWideStringArray(long offset, int length) {
-        return getStringArray(offset, -1, NativeString.WIDE_STRING);
+        return getStringArray(offset, length, NativeString.WIDE_STRING);
     }
 
     /** Returns an array of <code>String</code> based on a native array

--- a/test/com/sun/jna/PointerTest.java
+++ b/test/com/sun/jna/PointerTest.java
@@ -122,6 +122,27 @@ public class PointerTest extends TestCase {
                      Arrays.asList(p.getStringArray(0, 2, ENCODING)));
     }
 
+    public void testGetWideStringArray() {
+        Pointer p = new Memory(Pointer.SIZE*3);
+        final String VALUE1 = getName() + UNICODE;
+        final String VALUE2 = getName() + "2" + UNICODE;
+
+        p.setPointer(0, new NativeString(VALUE1, true).getPointer());
+        p.setPointer(Pointer.SIZE, new NativeString(VALUE2, true).getPointer());
+        p.setPointer(Pointer.SIZE*2, null);
+
+        assertEquals("Wrong null-terminated String array",
+                     Arrays.asList(new String[] { VALUE1, VALUE2 }),
+                     Arrays.asList(p.getWideStringArray(0)));
+
+        assertEquals("Wrong length-specified String array (1)",
+                     Arrays.asList(new String[] { VALUE1 }),
+                     Arrays.asList(p.getWideStringArray(0, 1)));
+        assertEquals("Wrong length-specified String array (2)",
+                     Arrays.asList(new String[] { VALUE1, VALUE2 }),
+                     Arrays.asList(p.getWideStringArray(0, 2)));
+    }
+
     public void testReadPointerArray() {
         Pointer mem = new Memory(Pointer.SIZE * 2);
         Pointer[] p = new Pointer[2];


### PR DESCRIPTION
Fixes Pointer.getWideStringArray not respecting the length parameter. Added a test as requested, and updated CHANGES.md.
