### PR TITLE
Changed the way that VarArgs are determined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Features
 * [#365](https://github.com/twall/jna/pull/365): Added `com.sun.jna.platform.win32.Kernel32.GetComputerNameEx` support - [@lgoldstein](https://github.com/lgoldstein).
 * [#368](https://github.com/twall/jna/pull/368): Added `com.sun.jna.platform.win32.Kernel32.VirtualQueryEx`, `com.sun.jna.platform.win32.WinNT.MEMORY_BASIC_INFORMATION` and `MEM_COMMIT`, `MEM_FREE`, `MEM_RESERVE`, `MEM_IMAGE`, `MEM_MAPPED`, `MEM_PRIVATE` constants - [@apsk](https://github.com/apsk).
 * Allow interoperation with JNI revision changes - [@twall](https://github.com/twall).
+* [#376](https://github.com/twall/jna/pull/373): Added `com.sun.jna.VarArgsChecker` for faster vararg checks. Used in `com.sun.jna.Function` - [@Boereck](https://github.com/Boereck).
 * [#391](https://github.com/twall/jna/pull/391): Added `com.sun.jna.platform.win32.Advapi3.EncryptFile`, `DecryptFile`, `FileEncryptionStatus`, `EncryptionDisable`, `OpenEncryptedFileRaw`, `ReadEncryptedFileRaw`, `WriteEncryptedFileRaw`, and `CloseEncryptedFileRaw` with related `Advapi32Util` helpers - [@khalidq](https://github.com/khalidq).
 * [#400](https://github.com/twall/jna/pull/400): Added `com.sun.jna.platform.WindowUtils.getAllWindows`, `getWindowIcon`, `getIconSize`, `getWindowTitle`, `getPRocessFilePath` and `getWindowLocationAndSize` - [@PAX523](https://github.com/PAX523).
 * [#400](https://github.com/twall/jna/pull/400): Added `com.sun.jna.platform.win32.Kernel32Util.getLastErrorMessage` - [@PAX523](https://github.com/PAX523).

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -10,7 +10,6 @@
  */
 package com.sun.jna;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
@@ -171,6 +170,9 @@ public class Function extends Pointer {
 
     /** For internal JNA use. */
     static final String OPTION_INVOKING_METHOD = "invoking-method";
+
+    /** For checking if methods declare varargs */
+    private static final VarArgsChecker IS_VARARGS = VarArgsChecker.create();
 
     /**
      * Create a new <code>Function</code> that is linked with a native 
@@ -509,7 +511,7 @@ public class Function extends Pointer {
                 Class ptype = struct.getClass();
             	if (invokingMethod != null) {
                     Class[] ptypes = invokingMethod.getParameterTypes();
-                    if (isVarArgs(invokingMethod)) {
+                    if (IS_VARARGS.isVarArgs(invokingMethod)) {
                         if (index < ptypes.length-1) {
                             ptype = ptypes[index];
                         }
@@ -776,37 +778,10 @@ public class Function extends Pointer {
         }
         return inArgs;
     }
-
-    /**
-     * Reference to Method.isVarArgs
-     */
-    private static Method isVarArgsMethod = getIsVarArgsMethod();
-    
-    /**
-     * If possible returns the Method.isVarArgs method via reflection
-     * @return Method.isVarArgs method
-     */
-    private static Method getIsVarArgsMethod() {
-        try {
-            return Method.class.getMethod("isVarArgs", new Class[0]);
-        } catch (SecurityException e) {
-            return null;
-        } catch (NoSuchMethodException e) {
-            return null;
-        }
-    }
     
     /** Varargs are only supported on 1.5+. */
     static boolean isVarArgs(Method m) {
-        if(isVarArgsMethod != null) {
-            try {
-                return Boolean.TRUE.equals(isVarArgsMethod.invoke(m, new Object[0]));
-            } catch (IllegalArgumentException e) {
-            } catch (IllegalAccessException e) {
-            } catch (InvocationTargetException e) {
-            }
-        }
-        return false;
+        return IS_VARARGS.isVarArgs(m);
     }
     
     private static class NativeMappedArray extends Memory implements PostCallRead {

--- a/src/com/sun/jna/VarArgsChecker.java
+++ b/src/com/sun/jna/VarArgsChecker.java
@@ -1,0 +1,71 @@
+package com.sun.jna;
+
+import java.lang.reflect.Method;
+
+/**
+ * Class for checking if a method has vararg parameters.
+ * Use method {@link VarArgsChecker#create() create()} to create an instance
+ * of this class. How the returned instance work depends on the capabilities
+ * of the underlying JVM implementation. On older versions of the VM not supporting
+ * varargs, the returned VarArgsChecker will always return <code>false</code> 
+ * on calls to {@link VarArgsChecker#isVarArgs(Method) isVarArgs(Method)}.
+ * @author Max Bureck
+ */
+abstract class VarArgsChecker {
+
+    private VarArgsChecker() {
+    }
+    
+    /**
+     * Implementation actually using Method.isVarArgs()
+     */
+    private static final class RealVarArgsChecker extends VarArgsChecker {
+        
+        boolean isVarArgs(Method m) {
+            return m.isVarArgs();
+        }
+        
+    }
+    
+    /**
+     * Implementation always returning false when {@link NoVarArgsChecker#isVarArgs(Method)}
+     * is called. This implementation will be chosen, if {@link Method#isVarArgs()} is not available
+     */
+    private static final class NoVarArgsChecker extends VarArgsChecker {
+        
+        boolean isVarArgs(Method m) {
+            return false;
+        }
+        
+    }
+    
+    /**
+     * Creates a new instance of a concrete subclass of VarArgsChecker, depending
+     * if {@link Method#isVarArgs()} exists.
+     * @return new instance of concrete VarArgsChecker subclass
+     */
+    static VarArgsChecker create() {
+        try {
+            // check if Method#isVarArgs() exists
+            final Method isVarArgsMethod = Method.class.getMethod("isVarArgs", new Class[0]);
+            if(isVarArgsMethod != null) {
+                // if it exitsts, return new instance of RealVarArgsChecker
+                return new RealVarArgsChecker();
+            } else {
+                return new NoVarArgsChecker();
+            }
+        } catch (NoSuchMethodException e) {
+            return new NoVarArgsChecker();
+        } catch (SecurityException e) {
+            return new NoVarArgsChecker();
+        }
+    }
+    
+    /**
+     * Checks if the given method was declared to take a variable number of arguments.
+     * @param m Method to be checked
+     * @return <code>true</code> if the given method takes a variable number of arguments, <code>false</code> otherwise.
+     */
+    abstract boolean isVarArgs(Method m);
+    
+}

--- a/test/com/sun/jna/VarArgsCheckerTest.java
+++ b/test/com/sun/jna/VarArgsCheckerTest.java
@@ -1,0 +1,34 @@
+package com.sun.jna;
+
+import java.lang.reflect.Method;
+
+import junit.framework.TestCase;
+
+public class VarArgsCheckerTest extends TestCase {
+
+    public void testCreation() throws Exception {
+        final VarArgsChecker sut = VarArgsChecker.create();
+        assertNotNull(sut);
+    }
+    
+    public void testNoVarArgs() throws Exception {
+        final VarArgsChecker sut = VarArgsChecker.create();
+        final Method toCheckForVarArgs = VarArgsCheckerTest.class.getMethod("testNoVarArgs", new Class[0]);
+        final boolean res = sut.isVarArgs(toCheckForVarArgs);
+        // no matter if JVM 1.4 or 1.5+, the result should always be false
+        assertFalse(res);
+    }
+    
+    public void testVarArgsExist() throws Exception {
+        final VarArgsChecker sut = VarArgsChecker.create();
+        final Method toCheckForVarArgs = VarArgsCheckerTest.class.getMethod("methodWithVarArgs", new Class[]{String[].class});
+        final boolean res = sut.isVarArgs(toCheckForVarArgs);
+        // this test has to run with Java 1.5+, because this has a method with
+        // varargs. So the result has to be true.
+        assertTrue(res);
+    }
+    
+    public void methodWithVarArgs(String... args) {
+        System.out.println();
+    }
+}


### PR DESCRIPTION
I noticed that using reflection for calling the isVarArgs method on java.lang.Method is pretty slow compared to a direct call. So Instead, I implemented a solution based on selection of a concrete subclass, depending whether the method is available or not. In my tests this lead to a 5% increase of method call speed.

This may be a bit controversial, because it needs Java 1.5+ to compile all sources. It does run under Java1.4 though, when compiling with -source and -target set to 1.4 (I checked). So, the maintainers should decide if this is a suitable solution or not.