### PR TITLE
Use static Object[][] for argument arrays.

### DIFF
--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -286,9 +286,6 @@ public class Function extends Pointer {
     public Object invoke(Class returnType, Object[] inArgs, Map options) {
         // Clone the argument array to obtain a scratch space for modified
         // types/values
-        if (argTable.get() == null) {
-          createArgTable();
-        }
         Object[] args = argTable.get()[0];
         if (inArgs != null) {
             if (inArgs.length > MAX_NARGS) {

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -69,10 +69,10 @@ public class Function extends Pointer {
         @Override
         protected Object[][] initialValue() {        
             Object args[][] = new Object[MAX_NARGS+1][];  //+1 for zero args
-            argTable.set(args);
             for(int a=0;a<=MAX_NARGS;a++) {
                 args[a] = new Object[a];
             }
+            return args;
         }
     };
 

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -63,17 +63,18 @@ public class Function extends Pointer {
 
     static final Integer INTEGER_TRUE = new Integer(-1);
     static final Integer INTEGER_FALSE = new Integer(0);
-
-    private static ThreadLocal<Object[][]> argTable = new ThreadLocal<Object[][]>();
-
+    
     /** Creates Object[][] for arguments for this thread. */
-    private void createArgTable() {
-        Object args[][] = new Object[MAX_NARGS+1][];  //+1 for zero args
-        argTable.set(args);
-        for(int a=0;a<=MAX_NARGS;a++) {
-            args[a] = new Object[a];
+    private static ThreadLocal<Object[][]> argTable = new ThreadLocal<Object[][]>() {
+        @Override
+        protected Object[][] initialValue() {        
+            Object args[][] = new Object[MAX_NARGS+1][];  //+1 for zero args
+            argTable.set(args);
+            for(int a=0;a<=MAX_NARGS;a++) {
+                args[a] = new Object[a];
+            }
         }
-    }
+    };
 
     /** 
      * Obtain a <code>Function</code> representing a native 
@@ -369,7 +370,7 @@ public class Function extends Pointer {
                 else if (Structure[].class.isAssignableFrom(inArg.getClass())) {
                     Structure.autoRead((Structure[])inArg);
                 }
-                /* Clear args */
+                /* Clear args so they will get garbage collected. */
                 args[i] = null;
             }
         }


### PR DESCRIPTION
Use static Object[][] for argument arrays.  A table of arguments is created for any length of arguments per thread.  That's 258 Object[] objects per thread (including the base Object[][]).  But this avoids churn and burn on the GC which translates to better performance.  In my test OpenGL game I notice better and stable FPS.  A ThreadLocal table is used as suggested by Igoldstein so it should be thread safe now.  I also clear the arguments after the native call incase they need to be GCed themselves.