### PR TITLE
[475] Avoid touching native memory from Structure.hashCode/equals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,7 @@ Bug Fixes
 * [#404](https://github.com/twall/jna/pull/404): Fix `VARIANT` constructors for `int`, `short`, and `long` - [@lwahonen](https://github.com/lwahonen).
 * [#420](https://github.com/twall/jna/pull/420): Fix structure leaving always one element in ThreadLocal set - [@sjappig](https://github.com/sjappig).
 * [#467](https://github.com/twall/jna/issues/467): Fix TypeMapper usage with direct-mapped libraries converting primitives to Java objects (specifically enums) - [@twall](https://github.com/twall).
+* [#475](https://github.com/twall/jna/issues/475): Avoid modifying native memory in `Structure.equals()/hashCode()`- [@twall](https://github.com/twall).
 
 Release 4.1
 ===========

--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -1462,42 +1462,39 @@ public abstract class Structure {
         return getClass();
     }
 
-    /** This structure is equal to another based on the same data type
-     * and memory contents.
+    /** Return whether the given Structure's backing data is identical to
+     * this one.
      */
-    public boolean equals(Object o) {
-        if (o == this) {
+    public boolean dataEquals(Structure s) {
+        byte[] data = s.getPointer().getByteArray(0, s.size());
+        byte[] ref = getPointer().getByteArray(0, size());
+        if (data.length == ref.length) {
+            for (int i=0;i < data.length;i++) {
+                if (data[i] != ref[i]) {
+                    System.out.println("byte mismatch at offset " + i);
+                    return false;
+                }
+            }
             return true;
-        }
-        if (!(o instanceof Structure)) {
-            return false;
-        }
-        if (o.getClass() != getClass()
-            && ((Structure)o).baseClass() != baseClass()) {
-            return false;
-        }
-        Structure s = (Structure)o;
-        if (s.getPointer().equals(getPointer())) {
-            return true;
-        }
-        if (s.size() == size()) {
-            clear(); write();
-            byte[] buf = getPointer().getByteArray(0, size());
-            s.clear(); s.write();
-            byte[] sbuf = s.getPointer().getByteArray(0, s.size());
-            return Arrays.equals(buf, sbuf);
         }
         return false;
     }
 
-    /** Since {@link #equals} depends on the contents of memory, use that
-     * as the basis for the hash code.
+    /** Structures are equal if they share the same pointer. */
+    public boolean equals(Object o) {
+        return o instanceof Structure
+            && o.getClass() == getClass()
+            && ((Structure)o).getPointer().equals(getPointer());
+    }
+
+    /** Use the underlying memory pointer's hash code.
      */
     public int hashCode() {
-        clear(); write();
-        Adler32 code = new Adler32();
-        code.update(getPointer().getByteArray(0, size()));
-        return (int)code.getValue();
+        Pointer p = getPointer();
+        if (p != null) {
+            return getPointer().hashCode();
+        }
+        return getClass().hashCode();
     }
 
     /** Cache native type information for use in native code. */

--- a/test/com/sun/jna/ArgumentsMarshalTest.java
+++ b/test/com/sun/jna/ArgumentsMarshalTest.java
@@ -565,9 +565,9 @@ public class ArgumentsMarshalTest extends TestCase {
             null,
             new CheckFieldAlignment.ByReference(),
         };
-        assertEquals("Wrong value returned (0)", args[0], lib.returnPointerArrayElement(args, 0));
+        assertTrue("Wrong value returned (0)", args[0].dataEquals(lib.returnPointerArrayElement(args, 0)));
         assertNull("Wrong value returned (1)", lib.returnPointerArrayElement(args, 1));
-        assertEquals("Wrong value returned (2)", args[2], lib.returnPointerArrayElement(args, 2));
+        assertTrue("Wrong value returned (2)", args[2].dataEquals(lib.returnPointerArrayElement(args, 2)));
         assertNull("Native array should be null terminated", lib.returnPointerArrayElement(args, 3));
     }
 

--- a/test/com/sun/jna/CallbacksTest.java
+++ b/test/com/sun/jna/CallbacksTest.java
@@ -741,8 +741,8 @@ public class CallbacksTest extends TestCase implements Paths {
                    + arg[0].getPointer(), arg[0].getPointer() instanceof Memory);
         assertTrue("ByValue result should own its own memory, instead was "
                    + result.getPointer(), result.getPointer() instanceof Memory);
-        assertEquals("Wrong value for callback argument", s, arg[0]);
-        assertEquals("Wrong value for callback result", s, result);
+        assertTrue("Wrong value for callback argument", s.dataEquals(arg[0]));
+        assertTrue("Wrong value for callback result", s.dataEquals(result));
     }
     
     public void testUnionByValueCallbackArgument() throws Exception{ 


### PR DESCRIPTION
Fixes issue #475 

Provide a dedicated Structure method to compare native memory between two instances.  Otherwise `.equals()` just compares native pointer and type.
