### PR TITLE
[496] Handle TypeMapper-returned String/WString in direct mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,7 @@ Bug Fixes
 * [#420](https://github.com/twall/jna/pull/420): Fix structure leaving always one element in ThreadLocal set - [@sjappig](https://github.com/sjappig).
 * [#467](https://github.com/twall/jna/issues/467): Fix TypeMapper usage with direct-mapped libraries converting primitives to Java objects (specifically enums) - [@twall](https://github.com/twall).
 * [#475](https://github.com/twall/jna/issues/475): Avoid modifying native memory in `Structure.equals()/hashCode()`- [@twall](https://github.com/twall).
+* [#496](https://github.com/twall/jna/issues/496): Properly handle direct mapping with type mappers which return String/WString - [@twall](https://github.com/twall).
 
 Release 4.1
 ===========

--- a/native/dispatch.h
+++ b/native/dispatch.h
@@ -93,10 +93,14 @@ enum {
   CVT_CALLBACK = com_sun_jna_Native_CVT_CALLBACK,
   CVT_FLOAT = com_sun_jna_Native_CVT_FLOAT,
   CVT_NATIVE_MAPPED = com_sun_jna_Native_CVT_NATIVE_MAPPED,
+  CVT_NATIVE_MAPPED_STRING = com_sun_jna_Native_CVT_NATIVE_MAPPED_STRING,
+  CVT_NATIVE_MAPPED_WSTRING = com_sun_jna_Native_CVT_NATIVE_MAPPED_WSTRING,
   CVT_WSTRING = com_sun_jna_Native_CVT_WSTRING,
   CVT_INTEGER_TYPE = com_sun_jna_Native_CVT_INTEGER_TYPE,
   CVT_POINTER_TYPE = com_sun_jna_Native_CVT_POINTER_TYPE,
   CVT_TYPE_MAPPER = com_sun_jna_Native_CVT_TYPE_MAPPER,
+  CVT_TYPE_MAPPER_STRING = com_sun_jna_Native_CVT_TYPE_MAPPER_STRING,
+  CVT_TYPE_MAPPER_WSTRING = com_sun_jna_Native_CVT_TYPE_MAPPER_WSTRING,
 };
 
 /* callback behavior flags */
@@ -191,8 +195,8 @@ extern callback* create_callback(JNIEnv*, jobject, jobject,
                                  jobjectArray, jclass,
                                  callconv_t, jint, jstring);
 extern void free_callback(JNIEnv*, callback*);
-extern void extract_value(JNIEnv*, jobject, void*, size_t, jboolean);
-extern jobject new_object(JNIEnv*, char, void*, jboolean);
+extern void extract_value(JNIEnv*, jobject, void*, size_t, jboolean, const char*);
+extern jobject new_object(JNIEnv*, char, void*, jboolean, const char*);
 extern jboolean is_protected();
 extern int get_conversion_flag(JNIEnv*, jclass);
 extern jboolean ffi_error(JNIEnv*,const char*,ffi_status);
@@ -211,8 +215,8 @@ extern jlong getIntegerTypeValue(JNIEnv*, jobject);
 extern void* getPointerTypeAddress(JNIEnv*, jobject);
 extern void writeStructure(JNIEnv*, jobject);
 extern jclass getNativeType(JNIEnv*, jclass);
-extern void toNative(JNIEnv*, jobject, void*, size_t, jboolean);
-extern jclass fromNative(JNIEnv*, jclass, ffi_type*, void*, jboolean);
+extern void toNative(JNIEnv*, jobject, void*, size_t, jboolean, const char*);
+extern jclass fromNative(JNIEnv*, jclass, ffi_type*, void*, jboolean, const char*);
 
 typedef struct _AttachOptions {
   int daemon;

--- a/native/testlib.c
+++ b/native/testlib.c
@@ -755,8 +755,8 @@ callCallbackWithByReferenceArgument(int (*func)(int arg, int* result), int arg, 
 }
 
 EXPORT char*
-callStringCallback(char* (*func)(char* arg), char* arg) {
-  return (*func)(arg);
+callStringCallback(char* (*func)(const char* arg, const char* arg2), const char* arg, const char* arg2) {
+  return (*func)(arg, arg2);
 }
 
 EXPORT char**
@@ -765,8 +765,8 @@ callStringArrayCallback(char** (*func)(char** arg), char** arg) {
 }
 
 EXPORT wchar_t*
-callWideStringCallback(wchar_t* (*func)(wchar_t* arg), wchar_t* arg) {
-  return (*func)(arg);
+callWideStringCallback(wchar_t* (*func)(const wchar_t* arg, const wchar_t* arg2), const wchar_t* arg, const wchar_t* arg2) {
+  return (*func)(arg, arg2);
 }
 
 struct cbstruct {

--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -165,13 +165,14 @@ class CallbackReference extends WeakReference {
                     direct = false;
                     break;
                 }
-                // No TypeMapper support in native callback code
+                // Direct mode callbacks do not support TypeMapper
                 if (mapper != null
                     && mapper.getFromNativeConverter(ptypes[i]) != null) {
                     direct = false;
                     break;
                 }
             }
+            // Direct mode callbacks do not support TypeMapper
             if (mapper != null
                 && mapper.getToNativeConverter(m.getReturnType()) != null) {
                 direct = false;

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -299,26 +299,25 @@ public class Function extends Pointer {
                                       mapper, allowObjects, paramType);
         }
         
-        Class nativeType = returnType;
+        Class nativeReturnType = returnType;
         FromNativeConverter resultConverter = null;
         if (NativeMapped.class.isAssignableFrom(returnType)) {
             NativeMappedConverter tc = NativeMappedConverter.getInstance(returnType);
             resultConverter = tc;
-            nativeType = tc.nativeType();
+            nativeReturnType = tc.nativeType();
         }
         else if (mapper != null) {
             resultConverter = mapper.getFromNativeConverter(returnType);
             if (resultConverter != null) {
-                nativeType = resultConverter.nativeType();
+                nativeReturnType = resultConverter.nativeType();
             }
         }
 
-        Object result = invoke(args, nativeType, allowObjects);
+        Object result = invoke(args, nativeReturnType, allowObjects);
 
         // Convert the result to a custom value/type if appropriate
         if (resultConverter != null) {
             FromNativeContext context;
-            
             if (invokingMethod != null) {
                 context = new MethodResultContext(returnType, this, inArgs, invokingMethod);
             } else {

--- a/src/com/sun/jna/NativeMapped.java
+++ b/src/com/sun/jna/NativeMapped.java
@@ -15,7 +15,8 @@ package com.sun.jna;
 /** Provide conversion for a Java type to and from a native type.  
  * {@link Function} and {@link Structure} will use this interface to determine
  * how to map a given Java object into a native type.<p>
- * Implementations of this interface must provide a no-args constructor. 
+ * Implementations of this interface must provide a no-args constructor.</p>
+ * <p>See {@link ToNativeConverter} for a list of allowable native types.</p>
  * @author wmeissner 
  */
 public interface NativeMapped {

--- a/src/com/sun/jna/NativeString.java
+++ b/src/com/sun/jna/NativeString.java
@@ -27,6 +27,13 @@ class NativeString implements CharSequence, Comparable {
     private Pointer pointer;
     private String encoding;
 
+    private class StringMemory extends Memory {
+        public StringMemory(long size) { super(size); }
+        public String toString() {
+            return NativeString.this.toString();
+        }
+    }
+
     /** Create a native string (NUL-terminated array of <code>char</code>).<p>
      * Uses the encoding returned by {@link Native#getDefaultStringEncoding()}.
      */
@@ -66,12 +73,12 @@ class NativeString implements CharSequence, Comparable {
         this.encoding = encoding;
         if (this.encoding == WIDE_STRING) {
             int len = (string.length() + 1 ) * Native.WCHAR_SIZE;
-            pointer = new Memory(len);
+            pointer = new StringMemory(len);
             pointer.setWideString(0, string);
         }
         else {
             byte[] data = Native.getBytes(string, encoding);
-            pointer = new Memory(data.length + 1);
+            pointer = new StringMemory(data.length + 1);
             pointer.write(0, data, 0, data.length);
             pointer.setByte(data.length, (byte)0);
         }

--- a/src/com/sun/jna/ToNativeConverter.java
+++ b/src/com/sun/jna/ToNativeConverter.java
@@ -32,8 +32,8 @@ public interface ToNativeConverter {
      * <li>{@link Structure}
      * <li>String
      * <li>{@link WString}
-     * <li>{@link java.nio.Buffer}
-     * <li>primitive array
+     * <li>{@link java.nio.Buffer} (unsupported in direct mode)
+     * <li>primitive array (unsupported in direct mode)
      * </ul>
      */
     Object toNative(Object value, ToNativeContext context);

--- a/test/com/sun/jna/DirectCallbacksTest.java
+++ b/test/com/sun/jna/DirectCallbacksTest.java
@@ -33,8 +33,8 @@ public class DirectCallbacksTest extends CallbacksTest {
         public native float callFloatCallback(FloatCallback c, float arg, float arg2);
         public native double callDoubleCallback(DoubleCallback c, double arg, double arg2);
         public native SmallTestStructure callStructureCallback(StructureCallback c, SmallTestStructure arg);
-        public native String callStringCallback(StringCallback c, String arg);
-        public native WString callWideStringCallback(WideStringCallback c, WString arg);
+        public native String callStringCallback(StringCallback c, String arg, String arg2);
+        public native WString callWideStringCallback(WideStringCallback c, WString arg, WString arg2);
         public Pointer callStringArrayCallback(StringArrayCallback c, String[] arg) { throw new UnsupportedOperationException(); }
         public native int callCallbackWithByReferenceArgument(CopyArgToByReference cb, int arg, IntByReference result);
         public native TestStructure.ByValue callCallbackWithStructByValue(TestStructure.TestCallback callback, TestStructure.ByValue cbstruct);
@@ -64,6 +64,7 @@ public class DirectCallbacksTest extends CallbacksTest {
     public static class DirectCallbackTestLibrary implements CallbackTestLibrary {
         public native double callInt32Callback(DoubleCallback c, double arg, double arg2);
         public native float callInt64Callback(FloatCallback c, float arg, float arg2);
+        public native String callWideStringCallback(WStringCallback c, String arg, String arg2);
         static {
             Native.register(NativeLibrary.getInstance("testlib", _OPTIONS));
         }

--- a/www/DirectMapping.md
+++ b/www/DirectMapping.md
@@ -20,7 +20,7 @@ JNA supports a direct mapping method which can improve performance substantially
         }
     }
 
-Direct mapping supports the same type mappings as interface mapping, except for arrays of `Pointer`/`Structure`/`String`/`WString`/`NativeMapped` as function arguments.  
+Direct mapping supports the same type mappings as interface mapping, except for arrays of `Pointer`/`Structure`/`String`/`WString`/`NativeMapped` as function arguments.  In addition, direct mapping does not support NIO Buffers or primitive arrays as types returned by type mappers or `NativeMapped`.
 
 **Varargs are not supported**.
 


### PR DESCRIPTION
When using a `TypeMapper` which indicates `String` or `WString` as the native type, final conversion from those types to a native `const char*` or `const wchar_t*` was not being performed, typically passing garbage to the native function.

