### PR TITLE
[494] avoid calling back to JVM on shared library unload

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -279,7 +279,7 @@
     <mkdir dir="${reports}"/>
     <mkdir dir="${doc}"/>
 
-    <echo>Java version ${java.version}, compatibility: ${compatibility}</echo>
+    <echo>Java version ${java.version}, compatibility: ${compatibility}, ant: ${ant.java.version}</echo>
     <echo>JNA version ${jna.version}, native ${jni.version}</echo>
     <echo>${java.vm.name} (${java.vm.vendor}, ${java.vm.version})</echo>
     <echo>java.home=${java.home}</echo>
@@ -1028,6 +1028,9 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
               value="&lt;center&gt;&lt;i&gt;${copyright}&lt;/i&gt;&lt;/center&gt;"/>
 
     <mkdir dir="${javadoc}"/>
+    <condition property="javadoc.opts" value="-Xdoclint:none" else="">
+      <matches pattern="^1.[89]$" string="${ant.java.version}"/>
+    </condition>
     <javadoc package="true"
              windowtitle="JNA API"
              sourcepathref="javadoc.src.path"
@@ -1035,7 +1038,7 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
              maxmemory="256m"
              packagenames="com.sun.jna,com.sun.jna.ptr,com.sun.jna.types,com.sun.jna.platform,com.sun.jna.platform.win32"
              overview="${src}/com/sun/jna/overview.html"
-             additionalparam="-Xdoclint:none"
+             additionalparam="${javadoc.opts}"
              destdir="${javadoc}">
       <!-- stylesheetfile="${stylesheet}" -->
       <doctitle>JNA API Documentation</doctitle>

--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -3203,7 +3203,8 @@ JNI_OnUnload(JavaVM *vm, void *UNUSED(reserved)) {
     }
   }
 
-  (*env)->CallStaticObjectMethod(env, classNative, MID_Native_dispose);
+  // Calls back to the Native class are unsafe at this point
+  //(*env)->CallStaticObjectMethod(env, classNative, MID_Native_dispose);
 
   if (fileEncoding) {
     (*env)->DeleteGlobalRef(env, fileEncoding);

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -76,6 +76,10 @@ import com.sun.jna.Structure.FFIType;
  * failure if the JNA native library is not properly installed on the system),
  * set the system property <code>jna.nounpack=true</code>.
  * </p>
+ * <p>While this class and its corresponding native library are loaded, the 
+ * system property <code>jna.loaded</code> will be set.  The property will be
+ * cleared when native support has been unloaded (i.e. the Native class and
+ * its underlying native support has been GC'd).</p>
  * <p>NOTE: all native functions are provided within this class to ensure that
  * all other JNA-provided classes and objects are GC'd and/or
  * finalized/disposed before this class is disposed and/or removed from
@@ -165,6 +169,7 @@ public final class Native implements Version {
             || Platform.isAndroid()
             ? 8 : LONG_SIZE;
         MAX_PADDING = (Platform.isMac() && Platform.isPPC()) ? 8 : MAX_ALIGNMENT;
+        System.setProperty("jna.loaded", "true");
     }
 
     /** Force a dispose when the Native class is GC'd. */
@@ -185,6 +190,7 @@ public final class Native implements Version {
         NativeLibrary.disposeAll();
         unregisterAll();
         jnidispatchPath = null;
+        System.setProperty("jna.loaded", "false");
     }
 
     /** Remove any automatically unpacked native library.

--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -1556,7 +1556,7 @@ public abstract class Structure {
 
     /** Return whether the given Structure's backing data is identical to
      * this one.
-     * @param o object to compare
+     * @param s Structure to compare
      * @return equality result
      */
     public boolean dataEquals(Structure s) {

--- a/test/com/sun/jna/JNALoadTest.java
+++ b/test/com/sun/jna/JNALoadTest.java
@@ -104,6 +104,7 @@ public class JNALoadTest extends TestCase implements Paths {
         ClassLoader loader = new TestLoader(true);
         Class cls = Class.forName("com.sun.jna.Native", true, loader);
         assertEquals("Wrong class loader", loader, cls.getClassLoader());
+        assertTrue("System property jna.loaded not set", Boolean.getBoolean("jna.loaded"));
 
         Field field = cls.getDeclaredField("jnidispatchPath");
         field.setAccessible(true);
@@ -124,6 +125,7 @@ public class JNALoadTest extends TestCase implements Paths {
         }
         assertNull("Class not GC'd: " + ref.get(), ref.get());
         assertNull("ClassLoader not GC'd: " + clref.get(), clref.get());
+        assertFalse("System property jna.loaded not cleared", Boolean.getBoolean("jna.loaded"));
 
         // Check for temporary file deletion
         File f = new File(path);
@@ -158,6 +160,7 @@ public class JNALoadTest extends TestCase implements Paths {
         ClassLoader loader = new TestLoader(false);
         Class cls = Class.forName("com.sun.jna.Native", true, loader);
         assertEquals("Wrong class loader", loader, cls.getClassLoader());
+        assertTrue("System property jna.loaded not set", Boolean.getBoolean("jna.loaded"));
 
         Field field = cls.getDeclaredField("jnidispatchPath");
         field.setAccessible(true);
@@ -176,6 +179,7 @@ public class JNALoadTest extends TestCase implements Paths {
         }
         assertNull("Class not GC'd: " + ref.get(), ref.get());
         assertNull("ClassLoader not GC'd: " + clref.get(), clref.get());
+        assertFalse("System property jna.loaded not cleared", Boolean.getBoolean("jna.loaded"));
 
         Throwable throwable = null;
         // NOTE: IBM J9 needs some extra time to unload the native library,
@@ -205,8 +209,8 @@ public class JNALoadTest extends TestCase implements Paths {
         }
     }
 
-    // Fails on Sun JVM windows (32 and 64-bit) 
-    // Works with IBM J9 (jdk6)
+    // Fails on Sun JVM windows (32 and 64-bit) (JVM bug)
+    // Works with IBM J9 (jdk6) windows
     public void testLoadFromUnicodePath() throws Exception {
         final String UNICODE = getName() + "-\u0444\u043b\u0441\u0432\u0443";
         File tmpdir = new File(System.getProperty("java.io.tmpdir"));
@@ -219,6 +223,8 @@ public class JNALoadTest extends TestCase implements Paths {
             ClassLoader loader = new TestLoader(true);
             Class cls = Class.forName("com.sun.jna.Native", true, loader);
             assertEquals("Wrong class loader", loader, cls.getClassLoader());
+            assertTrue("System property jna.loaded not set", Boolean.getBoolean("jna.loaded"));
+
             String path = System.getProperty("jnidispatch.path");
             if (path != null) {
                 File lib = new File(path);

--- a/test/com/sun/jna/JNALoadTest.java
+++ b/test/com/sun/jna/JNALoadTest.java
@@ -125,11 +125,10 @@ public class JNALoadTest extends TestCase implements Paths {
         }
         assertNull("Class not GC'd: " + ref.get(), ref.get());
         assertNull("ClassLoader not GC'd: " + clref.get(), clref.get());
-        assertFalse("System property jna.loaded not cleared", Boolean.getBoolean("jna.loaded"));
 
         // Check for temporary file deletion
         File f = new File(path);
-        for (int i=0;i < 100 && f.exists();i++) {
+        for (int i=0;i < 100 && (f.exists() || Boolean.getBoolean("jna.loaded"));i++) {
             Thread.sleep(10);
             System.gc();
         }
@@ -138,6 +137,7 @@ public class JNALoadTest extends TestCase implements Paths {
             assertTrue("Temporary jnidispatch not marked for later deletion: "
                        + f, new File(f.getAbsolutePath()+".x").exists());
         }
+        assertFalse("System property jna.loaded not cleared", Boolean.getBoolean("jna.loaded"));
 
         // Should be able to load again without complaints about library
         // already loaded in another class loader
@@ -173,7 +173,7 @@ public class JNALoadTest extends TestCase implements Paths {
         cls = null;
         field = null;
         System.gc();
-        for (int i=0;i < 100 && (ref.get() != null || clref.get() != null);i++) {
+        for (int i=0;i < 100 && (ref.get() != null || clref.get() != null || Boolean.getBoolean("jna.loaded"));i++) {
             Thread.sleep(10);
             System.gc();
         }


### PR DESCRIPTION
Expects to have class finalizer called in order to perform pre-unload cleanup.

Not safe to call back to JVM in `JNI_OnUnload()` (even though it currently works in most cases).