### PR TITLE
[531] Fix stdcall callback calling convention

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Bug Fixes
 ---------
 * [#549](https://github.com/java-native-access/jna/pull/549): Fixed bug in types derived from XID - [@twall](https://github.com/twall).
 * [#536](https://github.com/java-native-access/jna/pull/536): Fixed bug in determining the Library and options associated with types defined outside of a Library - [@twall](https://github.com/twall).
+* [#531](https://github.com/java-native-access/jna/pull/531): Ensure direct-mapped callbacks use the right calling convention - [@twall](https://github.com/twall).
 
 Release 4.2.1
 =============

--- a/test/com/sun/jna/CallbacksTest.java
+++ b/test/com/sun/jna/CallbacksTest.java
@@ -1439,6 +1439,54 @@ public class CallbacksTest extends TestCase implements Paths {
         }
     }
 
+    public interface TaggedCallingConventionTestLibrary extends Library, AltCallingConvention {
+        interface TestCallbackTagged extends Callback, AltCallingConvention {
+            void invoke();
+        }
+    }
+
+    public void testCallingConventionFromInterface() {
+        TaggedCallingConventionTestLibrary lib = (TaggedCallingConventionTestLibrary)
+            Native.loadLibrary("testlib", TaggedCallingConventionTestLibrary.class);
+        TaggedCallingConventionTestLibrary.TestCallbackTagged cb = new TaggedCallingConventionTestLibrary.TestCallbackTagged() {
+            public void invoke() { }
+        };
+        try {
+            Pointer p = CallbackReference.getFunctionPointer(cb);
+            CallbackReference ref = (CallbackReference)CallbackReference.callbackMap.get(cb);
+            assertNotNull("CallbackReference not found", ref);
+            assertEquals("Tag-based calling convention not applied", Function.ALT_CONVENTION, ref.callingConvention);
+        }
+        catch (IllegalArgumentException e) {
+            // Alt convention not supported
+        }
+    }
+
+    public interface OptionCallingConventionTestLibrary extends Library {
+        interface TestCallback extends Callback {
+            void invoke();
+        }
+    }
+
+    public void testCallingConventionFromOptions() {
+        Map options = new HashMap();
+        options.put(Library.OPTION_CALLING_CONVENTION, Function.ALT_CONVENTION);
+        OptionCallingConventionTestLibrary lib = (OptionCallingConventionTestLibrary)
+            Native.loadLibrary("testlib", OptionCallingConventionTestLibrary.class, options);
+        OptionCallingConventionTestLibrary.TestCallback cb = new OptionCallingConventionTestLibrary.TestCallback() {
+            public void invoke() { }
+        };
+        try {
+            Pointer p = CallbackReference.getFunctionPointer(cb);
+            CallbackReference ref = (CallbackReference)CallbackReference.callbackMap.get(cb);
+            assertNotNull("CallbackReference not found", ref);
+            assertEquals("Option-based calling convention not applied", Function.ALT_CONVENTION, ref.callingConvention);
+        }
+        catch(IllegalArgumentException e) {
+            // Alt convention not supported
+        }
+    }
+
     public static void main(java.lang.String[] argList) {
         junit.textui.TestRunner.run(CallbacksTest.class);
     }


### PR DESCRIPTION
Ensures that any calling convention set in library options gets propagated to callbacks.

Also includes non-direct callbacks in forced memory reclamation. 

Fixes issue #531 