### PR TITLE
6 Win32 function stubs, 8 constants, 1 structure, and 1 helper function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@ Features
 * [#532](https://github.com/java-native-access/jna/pull/529): Added `com.sun.jna.platform.win32.Mpr`, `com.sun.jna.platform.win32.LmShare`, and `com.sun.jna.platform.win32.Winnetwk` - [@amarcionek](https://github.com/amarcionek).
 * [#532](https://github.com/java-native-access/jna/pull/529): Added `ACCESS_*` definitions to `com.sun.jna.platform.win32.LmAccess` - [@amarcionek](https://github.com/amarcionek).
 * [#532](https://github.com/java-native-access/jna/pull/529): Added `NetShareAdd` and `NetShareDel` to `com.sun.jna.platform.win32.Netapi32` - [@amarcionek](https://github.com/amarcionek).
+* [#535](https://github.com/java-native-access/jna/pull/535): Added `CreateProcessWithLogonW` to `com.sun.jna.platform.win32.Advapi32` - [@mlfreeman2](https://github.com/mlfreeman2}
+* [#535](https://github.com/java-native-access/jna/pull/535): Added `CertAddEncodedCertificateToSystemStore` to `com.sun.jna.platform.win32.Crypt32` - [@mlfreeman2](https://github.com/mlfreeman2}
+* [#535](https://github.com/java-native-access/jna/pull/535): Added `BitBlt` to `com.sun.jna.platform.win32.GDI32`, Added `com.sun.jna.platform.win32.GDI32Util` and added `getScreenshot()` to it - [@mlfreeman2](https://github.com/mlfreeman2}
+* [#535](https://github.com/java-native-access/jna/pull/535): Added `SHEmptyRecycleBin`, `ShellExecuteEx` to `com.sun.jna.platform.win32.Shell32` - [@mlfreeman2](https://github.com/mlfreeman2}
+* [#535](https://github.com/java-native-access/jna/pull/535): Added `GetDesktopWindow` to `com.sun.jna.platform.win32.User32` - [@mlfreeman2](https://github.com/mlfreeman2}
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -17,8 +17,10 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
+import com.sun.jna.platform.win32.WinBase.STARTUPINFO;
 import com.sun.jna.platform.win32.WinBase.FE_EXPORT_FUNC;
 import com.sun.jna.platform.win32.WinBase.FE_IMPORT_FUNC;
+import com.sun.jna.platform.win32.WinBase.PROCESS_INFORMATION;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.platform.win32.WinNT.PSID;
@@ -63,6 +65,36 @@ public interface Advapi32 extends StdCallLibrary {
 	public static final int RRF_RT_REG_NONE = 0x00000001;
 	public static final int RRF_RT_REG_QWORD = 0x00000040;
 	public static final int RRF_RT_REG_SZ = 0x00000002;
+
+	/**
+	 * LOGON_WITH_PROFILE: 0x00000001<br>
+	 * Log on, then load the user profile in the HKEY_USERS registry key.<br>
+	 * The function returns after the profile is loaded. <br>
+	 * Loading the profile can be time-consuming, so it is best to use this
+	 * value only if you must access the information in the HKEY_CURRENT_USER
+	 * registry key.<br>
+	 * Windows Server 2003: The profile is unloaded after the new process is
+	 * terminated, whether or not it has created child processes.<br>
+	 * Windows XP: The profile is unloaded after the new process and all child
+	 * processes it has created are terminated.<br>
+	 */
+	int LOGON_WITH_PROFILE = 0x00000001;
+
+	/**
+	 * LOGON_NETCREDENTIALS_ONLY: 0x00000002<br>
+	 * Log on, but use the specified credentials on the network only.<br>
+	 * The new process uses the same token as the caller, but the system creates
+	 * a new logon session within LSA, and the process uses the specified
+	 * credentials as the default credentials. <br>
+	 * This value can be used to create a process that uses a different set of
+	 * credentials locally than it does remotely.<br>
+	 * This is useful in inter-domain scenarios where there is no trust
+	 * relationship.<br>
+	 * The system does not validate the specified credentials.<br>
+	 * Therefore, the process can start, but it may not have access to network
+	 * resources.
+	 */
+	int LOGON_NETCREDENTIALS_ONLY = 0x00000002;
 
 	/**
 	 * Retrieves the name of the user associated with the current thread.
@@ -1902,4 +1934,311 @@ public interface Advapi32 extends StdCallLibrary {
 	 *         OpenEncryptedFileRaw function returns the context block.
 	 */
 	public void CloseEncryptedFileRaw(Pointer pvContext);
+	
+	/**
+	 * <code>
+	        BOOL WINAPI CreateProcessWithLogonW(
+	          _In_         LPCWSTR lpUsername,
+	          _In_opt_     LPCWSTR lpDomain,
+	          _In_         LPCWSTR lpPassword,
+	          _In_         DWORD dwLogonFlags,
+	          _In_opt_     LPCWSTR lpApplicationName,
+	          _Inout_opt_  LPWSTR lpCommandLine,
+	          _In_         DWORD dwCreationFlags,
+	          _In_opt_     LPVOID lpEnvironment,
+	          _In_opt_     LPCWSTR lpCurrentDirectory,
+	          _In_         LPSTARTUPINFOW lpStartupInfo,
+	          _Out_        LPPROCESS_INFORMATION lpProcessInfo
+	        );
+	 * </code>
+	 * 
+	 * @param lpUsername
+	 *            [in]<br>
+	 *            The name of the user. This is the name of the user account to
+	 *            log on to. <br>
+	 *            If you use the UPN format, user@DNS_domain_name, the lpDomain
+	 *            parameter must be NULL.<br>
+	 *            The user account must have the Log On Locally permission on
+	 *            the local computer. <br>
+	 *            This permission is granted to all users on workstations and
+	 *            servers, but only to administrators on domain controllers.
+	 * @param lpDomain
+	 *            [in, optional]<br>
+	 *            The name of the domain or server whose account database
+	 *            contains the lpUsername account. <br>
+	 *            If this parameter is NULL, the user name must be specified in
+	 *            UPN format.
+	 * @param lpPassword
+	 *            [in]<br>
+	 *            The clear-text password for the lpUsername account.
+	 * @param dwLogonFlags
+	 *            [in]<br>
+	 *            The logon option. This parameter can be 0 (zero) or one of the
+	 *            following values. <br>
+	 *            LOGON_WITH_PROFILE: 0x00000001<br>
+	 *            Log on, then load the user profile in the HKEY_USERS registry
+	 *            key.<br>
+	 *            The function returns after the profile is loaded. <br>
+	 *            Loading the profile can be time-consuming, so it is best to
+	 *            use this value only if you must access the information in the
+	 *            HKEY_CURRENT_USER registry key.<br>
+	 *            Windows Server 2003: The profile is unloaded after the new
+	 *            process is terminated, whether or not it has created child
+	 *            processes.<br>
+	 *            Windows XP: The profile is unloaded after the new process and
+	 *            all child processes it has created are terminated.<br>
+	 *            <br>
+	 *            LOGON_NETCREDENTIALS_ONLY: 0x00000002<br>
+	 *            Log on, but use the specified credentials on the network only.
+	 *            <br>
+	 *            The new process uses the same token as the caller, but the
+	 *            system creates a new logon session within LSA, and the process
+	 *            uses the specified credentials as the default credentials.
+	 *            <br>
+	 *            This value can be used to create a process that uses a
+	 *            different set of credentials locally than it does remotely.
+	 *            <br>
+	 *            This is useful in inter-domain scenarios where there is no
+	 *            trust relationship.<br>
+	 *            The system does not validate the specified credentials.<br>
+	 *            Therefore, the process can start, but it may not have access
+	 *            to network resources.
+	 * @param lpApplicationName
+	 *            [in, optional]<br>
+	 *            The name of the module to be executed. This module can be a
+	 *            Windows-based application.<br>
+	 *            It can be some other type of module (for example, MS-DOS or
+	 *            OS/2) if the appropriate subsystem is available on the local
+	 *            computer. The string can specify the full path and file name
+	 *            of the module to execute or it can specify a partial name.
+	 *            <br>
+	 *            If it is a partial name, the function uses the current drive
+	 *            and current directory to complete the specification. <br>
+	 *            The function does not use the search path. This parameter must
+	 *            include the file name extension; no default extension is
+	 *            assumed. The lpApplicationName parameter can be NULL, and the
+	 *            module name must be the first white space-delimited token in
+	 *            the lpCommandLine string.<br>
+	 *            If you are using a long file name that contains a space, use
+	 *            quoted strings to indicate where the file name ends and the
+	 *            arguments begin; otherwise, the file name is ambiguous. For
+	 *            example, the following string can be interpreted in different
+	 *            ways:<br>
+	 *            "c:\program files\sub dir\program name"<br>
+	 *            The system tries to interpret the possibilities in the
+	 *            following order:<br>
+	 *            <br>
+	 *            c:\program.exe files\sub dir\program name<br>
+	 *            c:\program files\sub.exe dir\program name<br>
+	 *            c:\program files\sub dir\program.exe name<br>
+	 *            c:\program files\sub dir\program name.exe<br>
+	 *            <br>
+	 *            If the executable module is a 16-bit application,
+	 *            lpApplicationName should be NULL, and the string pointed to by
+	 *            lpCommandLine should specify the executable module and its
+	 *            arguments.
+	 * @param lpCommandLine
+	 *            [in, out, optional]<br>
+	 *            The command line to be executed. The maximum length of this
+	 *            string is 1024 characters. <br>
+	 *            If lpApplicationName is NULL, the module name portion of
+	 *            lpCommandLine is limited to MAX_PATH characters.<br>
+	 *            The function can modify the contents of this string. <br>
+	 *            Therefore, this parameter cannot be a pointer to read-only
+	 *            memory (such as a const variable or a literal string).<br>
+	 *            If this parameter is a constant string, the function may cause
+	 *            an access violation.<br>
+	 *            The lpCommandLine parameter can be NULL, and the function uses
+	 *            the string pointed to by lpApplicationNameas the command line.
+	 *            <br>
+	 *            <br>
+	 *            If both lpApplicationName and lpCommandLine are non-NULL,
+	 *            *lpApplicationName specifies the module to execute, and
+	 *            *lpCommandLine specifies the command line.<br>
+	 *            The new process can use GetCommandLine to retrieve the entire
+	 *            command line.<br>
+	 *            Console processes written in C can use the argc and argv
+	 *            arguments to parse the command line. <br>
+	 *            Because argv[0] is the module name, C programmers typically
+	 *            repeat the module name as the first token in the command line.
+	 *            <br>
+	 *            If lpApplicationName is NULL, the first white space-delimited
+	 *            token of the command line specifies the module name.<br>
+	 *            If you are using a long file name that contains a space, use
+	 *            quoted strings to indicate where the file name ends and the
+	 *            arguments begin (see the explanation for the lpApplicationName
+	 *            parameter). If the file name does not contain an extension,
+	 *            .exe is appended. Therefore, if the file name extension is
+	 *            .com, this parameter must include the .com extension. If the
+	 *            file name ends in a period with no extension, or if the file
+	 *            name contains a path, .exe is not appended. If the file name
+	 *            does not contain a directory path, the system searches for the
+	 *            executable file in the following sequence:<br>
+	 *            <br>
+	 *            1. The directory from which the application loaded.<br>
+	 *            2. The current directory for the parent process.<br>
+	 *            3. The 32-bit Windows system directory. Use the
+	 *            GetSystemDirectory function to get the path of this directory.
+	 *            <br>
+	 *            4. The 16-bit Windows system directory. There is no function
+	 *            that obtains the path of this directory, but it is searched.
+	 *            <br>
+	 *            5. The Windows directory. Use the GetWindowsDirectory function
+	 *            to get the path of this directory.<br>
+	 *            6. The directories that are listed in the PATH environment
+	 *            variable. Note that this function does not search the
+	 *            per-application path specified by the App Paths registry key.
+	 *            To include this per-application path in the search sequence,
+	 *            use the ShellExecute function.<br>
+	 *            <br>
+	 *            The system adds a null character to the command line string to
+	 *            separate the file name from the arguments. This divides the
+	 *            original string into two strings for internal processing.<br>
+	 * @param dwCreationFlags
+	 *            The flags that control how the process is created. <br>
+	 *            The CREATE_DEFAULT_ERROR_MODE, CREATE_NEW_CONSOLE, and
+	 *            CREATE_NEW_PROCESS_GROUP flags are enabled by default. <br>
+	 *            Even if you do not set the flag, the system functions as if it
+	 *            were set. You can specify additional flags as noted.<br>
+	 *            <br>
+	 *            CREATE_DEFAULT_ERROR_MODE: 0x04000000<br>
+	 *            The new process does not inherit the error mode of the calling
+	 *            process. <br>
+	 *            Instead, CreateProcessWithLogonW gives the new process the
+	 *            current default error mode. <br>
+	 *            An application sets the current default error mode by calling
+	 *            SetErrorMode. This flag is enabled by default.<br>
+	 *            <br>
+	 *            CREATE_NEW_CONSOLE: 0x00000010<br>
+	 *            The new process has a new console, instead of inheriting the
+	 *            parent's console. This flag cannot be used with the
+	 *            DETACHED_PROCESS flag.<br>
+	 *            This flag is enabled by default.<br>
+	 *            <br>
+	 *            CREATE_NEW_PROCESS_GROUP: 0x00000200<br>
+	 *            The new process is the root process of a new process group.
+	 *            <br>
+	 *            The process group includes all processes that are descendants
+	 *            of this root process.<br>
+	 *            The process identifier of the new process group is the same as
+	 *            the process identifier, which is returned in the lpProcessInfo
+	 *            parameter.<br>
+	 *            Process groups are used by the GenerateConsoleCtrlEvent
+	 *            function to enable sending a CTRL+C or CTRL+BREAK signal to a
+	 *            group of console processes.<br>
+	 *            This flag is enabled by default.<br>
+	 *            <br>
+	 *            CREATE_SEPARATE_WOW_VDM: 0x00000800<br>
+	 *            This flag is only valid starting a 16-bit Windows-based
+	 *            application.<br>
+	 *            If set, the new process runs in a private Virtual DOS Machine
+	 *            (VDM).<br>
+	 *            By default, all 16-bit Windows-based applications run in a
+	 *            single, shared VDM.<br>
+	 *            The advantage of running separately is that a crash only
+	 *            terminates the single VDM; any other programs running in
+	 *            distinct VDMs continue to function normally.<br>
+	 *            Also, 16-bit Windows-based applications that run in separate
+	 *            VDMs have separate input queues, which means that if one
+	 *            application stops responding momentarily, applications in
+	 *            separate VDMs continue to receive input. <br>
+	 *            CREATE_SUSPENDED: 0x00000004<br>
+	 *            The primary thread of the new process is created in a
+	 *            suspended state, and does not run until the ResumeThread
+	 *            function is called.<br>
+	 *            <br>
+	 *            CREATE_UNICODE_ENVIRONMENT: 0x00000400<br>
+	 *            Indicates the format of the lpEnvironment parameter.<br>
+	 *            If this flag is set, the environment block pointed to by
+	 *            lpEnvironment uses Unicode characters. <br>
+	 *            Otherwise, the environment block uses ANSI characters. <br>
+	 *            EXTENDED_STARTUPINFO_PRESENT: 0x00080000<br>
+	 *            The process is created with extended startup information; the
+	 *            lpStartupInfo parameter specifies a STARTUPINFOEX structure.
+	 *            <br>
+	 *            Windows Server 2003 and Windows XP: This value is not
+	 *            supported.<br>
+	 * @param lpEnvironment
+	 *            [in, optional]<br>
+	 *            A pointer to an environment block for the new process.<br>
+	 *            If this parameter is NULL, the new process uses an environment
+	 *            created from the profile of the user specified by lpUsername.
+	 *            An environment block consists of a null-terminated block of
+	 *            null-terminated strings.<br>
+	 *            Each string is in the following form:<br>
+	 *            name=value<br>
+	 *            Because the equal sign (=) is used as a separator, it must not
+	 *            be used in the name of an environment variable.<br>
+	 *            An environment block can contain Unicode or ANSI characters.
+	 *            <br>
+	 *            If the environment block pointed to by lpEnvironment contains
+	 *            Unicode characters, ensure that dwCreationFlags includes
+	 *            CREATE_UNICODE_ENVIRONMENT.<br>
+	 *            If this parameter is NULL and the environment block of the
+	 *            parent process contains Unicode characters, you must also
+	 *            ensure that dwCreationFlags includes
+	 *            CREATE_UNICODE_ENVIRONMENT.<br>
+	 *            An ANSI environment block is terminated by two 0 (zero) bytes:
+	 *            one for the last string and one more to terminate the block.
+	 *            <br>
+	 *            A Unicode environment block is terminated by four zero bytes:
+	 *            two for the last string and two more to terminate the block.
+	 *            <br>
+	 *            To retrieve a copy of the environment block for a specific
+	 *            user, use the CreateEnvironmentBlock function.<br>
+	 * @param lpCurrentDirectory
+	 *            [in, optional]<br>
+	 *            The full path to the current directory for the process.<br>
+	 *            The string can also specify a UNC path.<br>
+	 *            If this parameter is NULL, the new process has the same
+	 *            current drive and directory as the calling process.<br>
+	 *            This feature is provided primarily for shells that need to
+	 *            start an application, and specify its initial drive and
+	 *            working directory.<br>
+	 * @param lpStartupInfo
+	 *            [in]<br>
+	 *            A pointer to a STARTUPINFO or STARTUPINFOEX structure. <br>
+	 *            The application must add permission for the specified user
+	 *            account to the specified window station and desktop, even for
+	 *            WinSta0\Default.<br>
+	 *            If the lpDesktop member is NULL or an empty string, the new
+	 *            process inherits the desktop and window station of its parent
+	 *            process.<br>
+	 *            The application must add permission for the specified user
+	 *            account to the inherited window station and desktop.<br>
+	 *            Windows XP: CreateProcessWithLogonW adds permission for the
+	 *            specified user account to the inherited window station and
+	 *            desktop.<br>
+	 *            Handles in STARTUPINFO or STARTUPINFOEX must be closed with
+	 *            CloseHandle when they are no longer needed.<br>
+	 *            Important If the dwFlags member of the STARTUPINFO structure
+	 *            specifies STARTF_USESTDHANDLES, the standard handle fields are
+	 *            copied unchanged to the child process without validation.<br>
+	 *            The caller is responsible for ensuring that these fields
+	 *            contain valid handle values. Incorrect values can cause the
+	 *            child process to misbehave or crash.<br>
+	 *            Use the Application Verifier runtime verification tool to
+	 *            detect invalid handles.
+	 * @param lpProcessInfo
+	 *            [out]<br>
+	 *            A pointer to a PROCESS_INFORMATION structure that receives
+	 *            identification information for the new process, including a
+	 *            handle to the process.<br>
+	 *            Handles in PROCESS_INFORMATION must be closed with the
+	 *            CloseHandle function when they are not needed.<br>
+	 * @return If the function succeeds, the return value is nonzero.<br>
+	 *         If the function fails, the return value is 0 (zero).<br>
+	 *         To get extended error information, call GetLastError.<br>
+	 *         Note that the function returns before the process has finished
+	 *         initialization.<br>
+	 *         If a required DLL cannot be located or fails to initialize, the
+	 *         process is terminated.<br>
+	 *         To get the termination status of a process, call
+	 *         GetExitCodeProcess.
+	 * @see MSDN {@link http://msdn.microsoft.com/en-us/library/windows/desktop/ms682431%28v=vs.85%29.aspx }
+	 */
+	boolean CreateProcessWithLogonW(String lpUsername, String lpDomain, String lpPassword, int dwLogonFlags,
+			String lpApplicationName, String lpCommandLine, int dwCreationFlags, Pointer lpEnvironment,
+			String lpCurrentDirectory, STARTUPINFO lpStartupInfo, PROCESS_INFORMATION lpProcessInfo);
+
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
@@ -132,5 +132,5 @@ public interface Crypt32 extends StdCallLibrary {
 	 *         For extended error information, call GetLastError.
 	 * @see MSDN {@link http://msdn.microsoft.com/en-us/library/bb736347(v=vs.85).aspx }
 	 */
-	boolean CertAddEncodedCertificateToSystemStore(String szCertStoreName, Pointer pbCertEncoded, DWORD cbCertEncoded);
+	boolean CertAddEncodedCertificateToSystemStore(String szCertStoreName, Pointer pbCertEncoded, int cbCertEncoded);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
@@ -16,6 +16,7 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinCrypt.CRYPTPROTECT_PROMPTSTRUCT;
 import com.sun.jna.platform.win32.WinCrypt.DATA_BLOB;
+import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
@@ -109,4 +110,27 @@ public interface Crypt32 extends StdCallLibrary {
 			CRYPTPROTECT_PROMPTSTRUCT pPromptStruct,
 			int dwFlags,
 			DATA_BLOB pDataOut);
+
+	/**
+	 * The CertAddEncodedCertificateToSystemStore function opens the specified
+	 * system store and adds the encoded certificate to it.
+	 * 
+	 * @param szCertStoreName
+	 *            A null-terminated string that contains the name of the system
+	 *            store for the encoded certificate.
+	 * @param pbCertEncoded
+	 *            A pointer to a buffer that contains the encoded certificate to
+	 *            add.
+	 * @param cbCertEncoded
+	 *            The size, in bytes, of the pbCertEncoded buffer.
+	 * @return If the function succeeds, the return value is TRUE.<br>
+	 *         If the function fails, the return value is FALSE.<br>
+	 *         CertAddEncodedCertificateToSystemStore depends on the functions
+	 *         listed in the following remarks for error handling. <br>
+	 *         Refer to those function topics for their respective error
+	 *         handling behaviors.<br>
+	 *         For extended error information, call GetLastError.
+	 * @see MSDN {@link http://msdn.microsoft.com/en-us/library/bb736347(v=vs.85).aspx }
+	 */
+	boolean CertAddEncodedCertificateToSystemStore(String szCertStoreName, Pointer pbCertEncoded, DWORD cbCertEncoded);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/GDI32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/GDI32.java
@@ -42,6 +42,12 @@ public interface GDI32 extends StdCallLibrary {
     GDI32 INSTANCE = (GDI32) Native.loadLibrary("gdi32", GDI32.class,
                                                 W32APIOptions.DEFAULT_OPTIONS);
 
+	/**
+	 * Used with BitBlt. Copies the source rectangle directly to the destination
+	 * rectangle.
+	 */
+	int SRCCOPY = 0xCC0020;
+    
     /**
      * The ExtCreateRegion function creates a region from the specified region and transformation data.
      * @param lpXform
@@ -430,4 +436,148 @@ public interface GDI32 extends StdCallLibrary {
 	 */
 	public int GetObject(final HANDLE hgdiobj, final int cbBuffer,
 			final Pointer lpvObject);
+	
+	/**
+	 * The BitBlt function performs a bit-block transfer of the color data
+	 * corresponding to a rectangle of pixels from the specified source device
+	 * context into a destination device context.
+	 * 
+	 * @param hdcDest
+	 *            A handle to the destination device context.
+	 * @param nXDest
+	 *            The x-coordinate, in logical units, of the upper-left corner
+	 *            of the destination rectangle.
+	 * @param nYDest
+	 *            The y-coordinate, in logical units, of the upper-left corner
+	 *            of the destination rectangle.
+	 * @param nWidth
+	 *            The width, in logical units, of the source and destination
+	 *            rectangles.
+	 * @param nHeight
+	 *            The height, in logical units, of the source and the
+	 *            destination rectangles.
+	 * @param hdcSrc
+	 *            A handle to the source device context.
+	 * @param nXSrc
+	 *            The x-coordinate, in logical units, of the upper-left corner
+	 *            of the source rectangle.
+	 * @param nYSrc
+	 *            The y-coordinate, in logical units, of the upper-left corner
+	 *            of the source rectangle.
+	 * @param dwRop
+	 *            A raster-operation code.<br>
+	 *            These codes define how the color data for the source rectangle
+	 *            is to be combined with the color data for the destination
+	 *            rectangle to achieve the final color.<br>
+	 *            The following list shows some common raster operation codes.
+	 *            <br>
+	 *            <table>
+	 *            <tbody>
+	 *            <tr>
+	 *            <th>Value</th>
+	 *            <th>Meaning</th>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>BLACKNESS</strong></td>
+	 *            <td>Fills the destination rectangle using the color associated
+	 *            with index 0 in the physical palette. (This color is black for
+	 *            the default physical palette.)</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>CAPTUREBLT</strong></td>
+	 *            <td>Includes any windows that are layered on top of your
+	 *            window in the resulting image. By default, the image only
+	 *            contains your window. Note that this generally cannot be used
+	 *            for printing device contexts.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>DSTINVERT</strong></td>
+	 *            <td>Inverts the destination rectangle.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>MERGECOPY</strong></td>
+	 *            <td>Merges the colors of the source rectangle with the brush
+	 *            currently selected in <em>hdcDest</em>, by using the Boolean
+	 *            AND operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>MERGEPAINT</strong></td>
+	 *            <td>Merges the colors of the inverted source rectangle with
+	 *            the colors of the destination rectangle by using the Boolean
+	 *            OR operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>NOMIRRORBITMAP</strong</td>
+	 *            <td>Prevents the bitmap from being mirrored.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>NOTSRCCOPY</strong></td>
+	 *            <td>Copies the inverted source rectangle to the destination.
+	 *            </td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>NOTSRCERASE</strong></td>
+	 *            <td>Combines the colors of the source and destination
+	 *            rectangles by using the Boolean OR operator and then inverts
+	 *            the resultant color.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>PATCOPY</strong></td>
+	 *            <td>Copies the brush currently selected in <em>hdcDest</em>,
+	 *            into the destination bitmap.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>PATINVERT</strong></td>
+	 *            <td>Combines the colors of the brush currently selected in
+	 *            <em>hdcDest</em>, with the colors of the destination rectangle
+	 *            by using the Boolean XOR operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>PATPAINT</strong></td>
+	 *            <td>Combines the colors of the brush currently selected in
+	 *            <em>hdcDest</em>, with the colors of the inverted source
+	 *            rectangle by using the Boolean OR operator. The result of this
+	 *            operation is combined with the colors of the destination
+	 *            rectangle by using the Boolean OR operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>SRCAND</strong></td>
+	 *            <td>Combines the colors of the source and destination
+	 *            rectangles by using the Boolean AND operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>SRCCOPY</strong></td>
+	 *            <td>Copies the source rectangle directly to the destination
+	 *            rectangle.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>SRCERASE</strong></td>
+	 *            <td>Combines the inverted colors of the destination rectangle
+	 *            with the colors of the source rectangle by using the Boolean
+	 *            AND operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>SRCINVERT</strong></td>
+	 *            <td>Combines the colors of the source and destination
+	 *            rectangles by using the Boolean XOR operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>SRCPAINT</strong></td>
+	 *            <td>Combines the colors of the source and destination
+	 *            rectangles by using the Boolean OR operator.</td>
+	 *            </tr>
+	 *            <tr>
+	 *            <td><strong>WHITENESS</strong></td>
+	 *            <td>Fills the destination rectangle using the color associated
+	 *            with index 1 in the physical palette. (This color is white for
+	 *            the default physical palette.)</td>
+	 *            </tr>
+	 *            </tbody>
+	 *            </table>
+	 * @return True if the function succeeded, False if not. To get extended
+	 *         error information, call GetLastError.
+	 */
+	boolean BitBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight, HDC hdcSrc, int nXSrc, int nYSrc,
+			int dwRop);
+
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/GDI32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/GDI32Util.java
@@ -35,7 +35,7 @@ public class GDI32Util {
 	 * 
 	 * @param target
 	 *            The window to target
-	 * @return the window captured as a screenshot
+	 * @return the window captured as a screenshot, or null if the BufferedImage doesn't construct properly
 	 * @throws IllegalStateException
 	 *             if the rectangle from GetWindowRect has a width and/or height
 	 *             of 0. <br>
@@ -62,9 +62,6 @@ public class GDI32Util {
 
 		Win32Exception we = null;
 
-		// final java image structure we're returning.
-		final BufferedImage image = new BufferedImage(windowWidth, windowHeight, BufferedImage.TYPE_INT_RGB);
-
 		// device context used for drawing
 		HDC hdcTargetMem = null;
 
@@ -74,7 +71,12 @@ public class GDI32Util {
 		// original display surface associated with the device context
 		HANDLE hOriginal = null;
 
+		// final java image structure we're returning.
+		BufferedImage image = null;
+		
 		try {
+			image = new BufferedImage(windowWidth, windowHeight, BufferedImage.TYPE_INT_RGB);
+			
 			hdcTargetMem = GDI32.INSTANCE.CreateCompatibleDC(hdcTarget);
 			if (hdcTargetMem == null) {
 				throw new Win32Exception(Native.getLastError());
@@ -119,7 +121,7 @@ public class GDI32Util {
 				// per MSDN, set the display surface back when done drawing
 				HANDLE result = GDI32.INSTANCE.SelectObject(hdcTargetMem, hOriginal);
 				// failure modes are null or equal to HGDI_ERROR
-				if (result == null || result == WinGDI.HGDI_ERROR) {
+				if (result == null || WinGDI.HGDI_ERROR.equals(result)) {
 					Win32Exception ex = new Win32Exception(Native.getLastError());
 					if (we != null) {
 						ex.addSuppressed(we);

--- a/contrib/platform/src/com/sun/jna/platform/win32/GDI32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/GDI32Util.java
@@ -1,0 +1,164 @@
+/* Copyright (c) 2015 Michael Freeman, All Rights Reserved
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.  
+ */
+package com.sun.jna.platform.win32;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.platform.win32.WinDef.HBITMAP;
+import com.sun.jna.platform.win32.WinDef.HDC;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinDef.RECT;
+import com.sun.jna.platform.win32.WinGDI.BITMAPINFO;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+
+/**
+ * GDI32 utility API.
+ * 
+ * @author mlfreeman[at]gmail.com
+ */
+public class GDI32Util {
+	/**
+	 * Takes a screenshot of the given window
+	 * 
+	 * @param target
+	 *            The window to target
+	 * @return the window captured as a screenshot
+	 * @throws IllegalStateException
+	 *             if the rectangle from GetWindowRect has a width and/or height
+	 *             of 0. <br>
+	 *             if the device context acquired from the original HWND doesn't
+	 *             release properly
+	 */
+	public static BufferedImage getScreenshot(HWND target) {
+		RECT rect = new RECT();
+		if (!User32.INSTANCE.GetWindowRect(target, rect)) {
+			throw new Win32Exception(Native.getLastError());
+		}
+		Rectangle jRectangle = rect.toRectangle();
+		int windowWidth = jRectangle.width;
+		int windowHeight = jRectangle.height;
+		
+		if (windowWidth == 0 || windowHeight == 0) {
+			throw new IllegalStateException("Window width and/or height were 0 even though GetWindowRect did not appear to fail.");
+		}
+		
+		HDC hdcTarget = User32.INSTANCE.GetDC(target);
+		if (hdcTarget == null) {
+			throw new Win32Exception(Native.getLastError());
+		}
+
+		Win32Exception we = null;
+
+		// final java image structure we're returning.
+		final BufferedImage image = new BufferedImage(windowWidth, windowHeight, BufferedImage.TYPE_INT_RGB);
+
+		// device context used for drawing
+		HDC hdcTargetMem = null;
+
+		// handle to the bitmap to be drawn to
+		HBITMAP hBitmap = null;
+
+		// original display surface associated with the device context
+		HANDLE hOriginal = null;
+
+		try {
+			hdcTargetMem = GDI32.INSTANCE.CreateCompatibleDC(hdcTarget);
+			if (hdcTargetMem == null) {
+				throw new Win32Exception(Native.getLastError());
+			}
+
+			hBitmap = GDI32.INSTANCE.CreateCompatibleBitmap(hdcTarget, windowWidth, windowHeight);
+			if (hBitmap == null) {
+				throw new Win32Exception(Native.getLastError());
+			}
+
+			hOriginal = GDI32.INSTANCE.SelectObject(hdcTargetMem, hBitmap);
+			if (hOriginal == null) {
+				throw new Win32Exception(Native.getLastError());
+			}
+
+			// draw to the bitmap
+			if (!GDI32.INSTANCE.BitBlt(hdcTargetMem, 0, 0, windowWidth, windowHeight, hdcTarget, 0, 0, GDI32.SRCCOPY)) {
+				throw new Win32Exception(Native.getLastError());
+			}
+
+			BITMAPINFO bmi = new BITMAPINFO();
+			bmi.bmiHeader.biWidth = windowWidth;
+			bmi.bmiHeader.biHeight = -windowHeight;
+			bmi.bmiHeader.biPlanes = 1;
+			bmi.bmiHeader.biBitCount = 32;
+			bmi.bmiHeader.biCompression = WinGDI.BI_RGB;
+
+			Memory buffer = new Memory(windowWidth * windowHeight * 4);
+			int resultOfDrawing = GDI32.INSTANCE.GetDIBits(hdcTarget, hBitmap, 0, windowHeight, buffer, bmi,
+					WinGDI.DIB_RGB_COLORS);
+			if (resultOfDrawing == 0 || resultOfDrawing == WinError.ERROR_INVALID_PARAMETER) {
+				throw new Win32Exception(Native.getLastError());
+			}
+
+			image.setRGB(0, 0, windowWidth, windowHeight, buffer.getIntArray(0, windowWidth * windowHeight), 0,
+					windowWidth);
+
+		} catch (Win32Exception e) {
+			we = e;
+		} finally {
+			if (hOriginal != null) {
+				// per MSDN, set the display surface back when done drawing
+				HANDLE result = GDI32.INSTANCE.SelectObject(hdcTargetMem, hOriginal);
+				// failure modes are null or equal to HGDI_ERROR
+				if (result == null || result == WinGDI.HGDI_ERROR) {
+					Win32Exception ex = new Win32Exception(Native.getLastError());
+					if (we != null) {
+						ex.addSuppressed(we);
+					}
+					we = ex;
+				}
+			}
+
+			if (hBitmap != null) {
+				if (!GDI32.INSTANCE.DeleteObject(hBitmap)) {
+					Win32Exception ex = new Win32Exception(Native.getLastError());
+					if (we != null) {
+						ex.addSuppressed(we);
+					}
+					we = ex;
+				}
+			}
+
+			if (hdcTargetMem != null) {
+				// get rid of the device context when done
+				if (!GDI32.INSTANCE.DeleteDC(hdcTargetMem)) {
+					Win32Exception ex = new Win32Exception(Native.getLastError());
+					if (we != null) {
+						ex.addSuppressed(we);
+					}
+					we = ex;
+				}
+			}
+
+			if (hdcTarget != null) {
+				if (0 == User32.INSTANCE.ReleaseDC(target, hdcTarget)) {
+					throw new IllegalStateException("Device context did not release properly.");
+				}
+			}
+		}
+
+		if (we != null) {
+			throw we;
+		}
+		return image;
+	}
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
@@ -31,7 +31,37 @@ public interface Shell32 extends ShellAPI, StdCallLibrary {
 	
     Shell32 INSTANCE = (Shell32) Native.loadLibrary("shell32", Shell32.class, 
     		W32APIOptions.UNICODE_OPTIONS);
-    
+
+	/**
+	 * No dialog box confirming the deletion of the objects will be displayed.
+	 */
+	int SHERB_NOCONFIRMATION = 0x00000001;
+
+	/**
+	 * No dialog box indicating the progress will be displayed.
+	 */
+	int SHERB_NOPROGRESSUI = 0x00000002;
+
+	/**
+	 * No sound will be played when the operation is complete.
+	 */
+	int SHERB_NOSOUND = 0x00000004;
+
+	/**
+	 * <p>
+	 * <strong>SEE_MASK_NOCLOSEPROCESS</strong> (0x00000040)
+	 * </p>
+	 * <p>
+	 * Use to indicate that the <strong>hProcess</strong> member receives the
+	 * process handle. This handle is typically used to allow an application to
+	 * find out when a process created with terminates. In some cases, such as
+	 * when execution is satisfied through a DDE conversation, no handle will be
+	 * returned. The calling application is responsible for closing the handle
+	 * when it is no longer needed.
+	 * </p>
+	 */
+	int SEE_MASK_NOCLOSEPROCESS = 0x00000040;
+	
     /**
      * This function can be used to copy, move, rename, or delete a file system object.
      * @param fileop
@@ -238,4 +268,52 @@ public interface Shell32 extends ShellAPI, StdCallLibrary {
      * 
      */
     UINT_PTR SHAppBarMessage( DWORD dwMessage, APPBARDATA pData );
+
+	/**
+	 * Empties the Recycle Bin on the specified drive.
+	 * 
+	 * @param hwnd
+	 *            A handle to the parent window of any dialog boxes that might
+	 *            be displayed during the operation.<br>
+	 *            This parameter can be NULL.
+	 * @param pszRootPath
+	 *            a null-terminated string of maximum length MAX_PATH that
+	 *            contains the path of the root<br>
+	 *            drive on which the Recycle Bin is located. This parameter can
+	 *            contain a string formatted with the drive,<br>
+	 *            folder, and subfolder names, for example c:\windows\system\,
+	 *            etc. It can also contain an empty string or<br>
+	 *            NULL. If this value is an empty string or NULL, all Recycle
+	 *            Bins on all drives will be emptied.
+	 * @param dwFlags
+	 *            a bitwise combination of SHERB_NOCONFIRMATION,
+	 *            SHERB_NOPROGRESSUI and SHERB_NOSOUND.<br>
+	 * @return Returns S_OK (0) if successful, or a COM-defined error value
+	 *         otherwise.<br>
+	 */
+	int SHEmptyRecycleBin(HANDLE hwnd, String pszRootPath, int dwFlags);
+
+	/**
+	 * @param lpExecInfo
+	 *            <p>
+	 *            Type: <strong>SHELLEXECUTEINFO*</strong>
+	 *            </p>
+	 *            <p>
+	 *            A pointer to a <a href=
+	 *            "https://msdn.microsoft.com/en-us/library/windows/desktop/bb759784(v=vs.85).aspx">
+	 *            <strong xmlns="http://www.w3.org/1999/xhtml">SHELLEXECUTEINFO
+	 *            </strong></a> structure that contains and receives information
+	 *            about the application being executed.
+	 *            </p>
+	 * @return
+	 * 		<p>
+	 *         Returns <strong>TRUE</strong> if successful; otherwise,
+	 *         <strong>FALSE</strong>. Call <a href=
+	 *         "https://msdn.microsoft.com/en-us/library/windows/desktop/ms679360(v=vs.85).aspx">
+	 *         <strong xmlns="http://www.w3.org/1999/xhtml">GetLastError
+	 *         </strong></a> for extended error information.
+	 *         </p>
+	 */
+	boolean ShellExecuteEx(ShellAPI.SHELLEXECUTEINFO lpExecInfo);
+
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
@@ -62,6 +62,11 @@ public interface Shell32 extends ShellAPI, StdCallLibrary {
 	 */
 	int SEE_MASK_NOCLOSEPROCESS = 0x00000040;
 	
+	/**
+	 * Do not display an error message box if an error occurs.
+	 */
+	int SEE_MASK_FLAG_NO_UI = 0x00000400;
+	
     /**
      * This function can be used to copy, move, rename, or delete a file system object.
      * @param fileop

--- a/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
@@ -707,7 +707,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * </dd>
 		 * </dl>
 		 */
-		public String lpVerb;
+		public WString lpVerb;
 	
 		/**
 		 * <p>
@@ -735,7 +735,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * <div class="note"><strong>Note</strong>&nbsp;&nbsp;If the path is not
 		 * included with the name, the current directory is assumed.</div>
 		 */
-		public String lpFile;
+		public WString lpFile;
 	
 		/**
 		 * <p>
@@ -748,7 +748,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * <strong>lpParameters</strong> should be <strong>NULL</strong>.
 		 * </p>
 		 */
-		public String lpParameters;
+		public WString lpParameters;
 	
 		/**
 		 * <p>
@@ -761,7 +761,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * directory.
 		 * </p>
 		 */
-		public String lpDirectory;
+		public WString lpDirectory;
 	
 		/**
 		 * <p>

--- a/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
@@ -20,12 +20,14 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinDef.DWORD;
+import com.sun.jna.platform.win32.WinDef.HINSTANCE;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinDef.LPARAM;
 import com.sun.jna.platform.win32.WinDef.RECT;
 import com.sun.jna.platform.win32.WinDef.UINT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.PSID;
+import com.sun.jna.platform.win32.WinReg.HKEY;
 import com.sun.jna.win32.StdCallLibrary;
 
 /**
@@ -208,5 +210,853 @@ public interface ShellAPI extends StdCallLibrary {
         	return Arrays.asList("cbSize", "hWnd", "uCallbackMessage", "uEdge",	"rc", "lParam");
         }
     }
+
+	/**
+	 * <p>
+	 * Contains information used by <a href=
+	 * "https://msdn.microsoft.com/en-us/library/windows/desktop/bb762154(v=vs.85).aspx">
+	 * <strong xmlns="http://www.w3.org/1999/xhtml">ShellExecuteEx</strong></a>.
+	 * </p>
+	 * 
+	 * <pre>
+	 * <span style="color:Blue;">typedef</span> <span style="color:Blue;">struct</span> _SHELLEXECUTEINFO {
+	 *   DWORD &nbsp;&nbsp;&nbsp;&nbsp;cbSize;
+	 *   ULONG &nbsp;&nbsp;&nbsp;&nbsp;fMask;
+	 *   HWND &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hwnd;
+	 *   LPCTSTR &nbsp;&nbsp;lpVerb;
+	 *   LPCTSTR &nbsp;&nbsp;lpFile;
+	 *   LPCTSTR &nbsp;&nbsp;lpParameters;
+	 *   LPCTSTR &nbsp;&nbsp;lpDirectory;
+	 *   <span style="color:Blue;">int</span> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nShow;
+	 *   HINSTANCE hInstApp;
+	 *   LPVOID &nbsp;&nbsp;&nbsp;lpIDList;
+	 *   LPCTSTR &nbsp;&nbsp;lpClass;
+	 *   HKEY &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hkeyClass;
+	 *   DWORD &nbsp;&nbsp;&nbsp;&nbsp;dwHotKey;
+	 *   <span style="color:Blue;">union</span> {
+	 *     HANDLE hIcon;
+	 *     HANDLE hMonitor;
+	 *   }&nbsp;DUMMYUNIONNAME;
+	 *   HANDLE &nbsp;&nbsp;&nbsp;hProcess;
+	 * } SHELLEXECUTEINFO, *LPSHELLEXECUTEINFO;
+	 * </pre>
+	 * 
+	 * <h2>Remarks</h2>
+	 * <p>
+	 * The <strong>SEE_MASK_NOASYNC</strong> flag must be specified if the
+	 * thread calling <a href=
+	 * "https://msdn.microsoft.com/en-us/library/windows/desktop/bb762154(v=vs.85).aspx">
+	 * <strong xmlns="http://www.w3.org/1999/xhtml">ShellExecuteEx</strong></a>
+	 * does not have a message loop or if the thread or process will terminate
+	 * soon after <strong>ShellExecuteEx</strong> returns. Under such
+	 * conditions, the calling thread will not be available to complete the DDE
+	 * conversation, so it is important that <strong>ShellExecuteEx</strong>
+	 * complete the conversation before returning control to the calling
+	 * application. Failure to complete the conversation can result in an
+	 * unsuccessful launch of the document.
+	 * </p>
+	 * <p>
+	 * If the calling thread has a message loop and will exist for some time
+	 * after the call to <a href=
+	 * "https://msdn.microsoft.com/en-us/library/windows/desktop/bb762154(v=vs.85).aspx">
+	 * <strong xmlns="http://www.w3.org/1999/xhtml">ShellExecuteEx</strong></a>
+	 * returns, the <strong>SEE_MASK_NOASYNC</strong> flag is optional. If the
+	 * flag is omitted, the calling thread's message pump will be used to
+	 * complete the DDE conversation. The calling application regains control
+	 * sooner, since the DDE conversation can be completed in the background.
+	 * </p>
+	 * <p>
+	 * When populating the most frequently used program list using the
+	 * <strong>SEE_MASK_FLAG_LOG_USAGE</strong> flag in <strong>fMask</strong>,
+	 * counts are made differently for the classic and Windows&nbsp;XP-style
+	 * Start menus. The classic style menu only counts hits to the shortcuts in
+	 * the Program menu. The Windows&nbsp;XP-style menu counts both hits to the
+	 * shortcuts in the Program menu and hits to those shortcuts' targets
+	 * outside of the Program menu. Therefore, setting <strong>lpFile</strong>
+	 * to myfile.exe would affect the count for the Windows&nbsp;XP-style menu
+	 * regardless of whether that file was launched directly or through a
+	 * shortcut. The classic style-which would require <strong>lpFile</strong>
+	 * to contain a .lnk file name-would not be affected.
+	 * </p>
+	 * <p>
+	 * To include double quotation marks in <strong>lpParameters</strong>,
+	 * enclose each mark in a pair of quotation marks, as in the following
+	 * example.
+	 * </p>
+	 * <div id="code-snippet-2" class="codeSnippetContainer" xmlns=""> <div
+	 * class="codeSnippetContainerTabs"> </div>
+	 * <div class="codeSnippetContainerCodeContainer"> <div class=
+	 * "codeSnippetToolBar"> <div class="codeSnippetToolBarText"> <a name=
+	 * "CodeSnippetCopyLink" style="display: none;" title=
+	 * "Copy to clipboard." href=
+	 * "javascript:if (window.epx.codeSnippet)window.epx.codeSnippet.copyCode('CodeSnippetContainerCode_3de148bb-edf3-4344-8ecf-c211304bfa9e');"
+	 * >Copy</a> </div> </div>
+	 * <div id="CodeSnippetContainerCode_3de148bb-edf3-4344-8ecf-c211304bfa9e"
+	 * class="codeSnippetContainerCode" dir="ltr"> <div style="color:Black;">
+	 * 
+	 * <pre>
+	 * sei.lpParameters = &quot;An example: \&quot;\&quot;\&quot;quoted text\&quot;\&quot;\&quot;&quot;;
+	 * </pre>
+	 * 
+	 * </div> </div> </div> </div>
+	 * <p>
+	 * In this case, the application receives three parameters: <em>An</em>,
+	 * <em>example:</em>, and <em>"quoted text"</em>.
+	 * </p>
+	 */
+	public class SHELLEXECUTEINFO extends Structure {
+	
+		/**
+		 * <p>
+		 * Type: <strong>DWORD</strong>
+		 * </p>
+		 * <p>
+		 * Required. The size of this structure, in bytes.
+		 * </p>
+		 */
+		public int cbSize = size();
+	
+		/**
+		 * <p>
+		 * Type: <strong>ULONG</strong>
+		 * </p>
+		 * <p>
+		 * Flags that indicate the content and validity of the other structure
+		 * members; a combination of the following values:
+		 * </p>
+		 * <dl class="indent">
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_DEFAULT</strong> (0x00000000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use default values.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_CLASSNAME</strong> (0x00000001)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use the class name given by the <strong>lpClass</strong> member. If
+		 * both SEE_MASK_CLASSKEY and SEE_MASK_CLASSNAME are set, the class key
+		 * is used.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_CLASSKEY</strong> (0x00000003)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use the class key given by the <strong>hkeyClass</strong> member. If
+		 * both SEE_MASK_CLASSKEY and SEE_MASK_CLASSNAME are set, the class key
+		 * is used.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_IDLIST</strong> (0x00000004)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use the item identifier list given by the <strong>lpIDList</strong>
+		 * member. The <strong>lpIDList</strong> member must point to an
+		 * structure.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_INVOKEIDLIST</strong> (0x0000000C)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use the interface of the selected item's . Use either
+		 * <strong>lpFile</strong> to identify the item by its file system path
+		 * or <strong>lpIDList</strong> to identify the item by its PIDL. This
+		 * flag allows applications to use to invoke verbs from shortcut menu
+		 * extensions instead of the static verbs listed in the registry.
+		 * </p>
+		 * <div class="note"><strong>Note</strong>
+		 * &nbsp;&nbsp;SEE_MASK_INVOKEIDLIST overrides and implies
+		 * SEE_MASK_IDLIST.</div></dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_ICON</strong> (0x00000010)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use the icon given by the <strong>hIcon</strong> member. This flag
+		 * cannot be combined with SEE_MASK_HMONITOR.
+		 * </p>
+		 * <div class="note"><strong>Note</strong>&nbsp;&nbsp;This flag is used
+		 * only in Windows&nbsp;XP and earlier. It is ignored as of
+		 * Windows&nbsp;Vista.</div></dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_HOTKEY</strong> (0x00000020)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use the keyboard shortcut given by the <strong>dwHotKey</strong>
+		 * member.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_NOCLOSEPROCESS</strong> (0x00000040)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use to indicate that the <strong>hProcess</strong> member receives
+		 * the process handle. This handle is typically used to allow an
+		 * application to find out when a process created with terminates. In
+		 * some cases, such as when execution is satisfied through a DDE
+		 * conversation, no handle will be returned. The calling application is
+		 * responsible for closing the handle when it is no longer needed.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_CONNECTNETDRV</strong> (0x00000080)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Validate the share and connect to a drive letter. This enables
+		 * reconnection of disconnected network drives. The
+		 * <strong>lpFile</strong> member is a UNC path of a file on a network.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_NOASYNC</strong> (0x00000100)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Wait for the execute operation to complete before returning. This
+		 * flag should be used by callers that are using ShellExecute forms that
+		 * might result in an async activation, for example DDE, and create a
+		 * process that might be run on a background thread. (Note: runs on a
+		 * background thread by default if the caller's threading model is not
+		 * Apartment.) Calls to <strong>ShellExecuteEx</strong> from processes
+		 * already running on background threads should always pass this flag.
+		 * Also, applications that exit immediately after calling
+		 * <strong>ShellExecuteEx</strong> should specify this flag.
+		 * </p>
+		 * <p>
+		 * If the execute operation is performed on a background thread and the
+		 * caller did not specify the SEE_MASK_ASYNCOK flag, then the calling
+		 * thread waits until the new process has started before returning. This
+		 * typically means that either has been called, the DDE communication
+		 * has completed, or that the custom execution delegate has notified
+		 * that it is done. If the SEE_MASK_WAITFORINPUTIDLE flag is specified,
+		 * then <strong>ShellExecuteEx</strong> calls and waits for the new
+		 * process to idle before returning, with a maximum timeout of 1 minute.
+		 * </p>
+		 * <p>
+		 * For further discussion on when this flag is necessary, see the
+		 * Remarks section.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_FLAG_DDEWAIT</strong> (0x00000100)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Do not use; use SEE_MASK_NOASYNC instead.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_DOENVSUBST</strong> (0x00000200)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Expand any environment variables specified in the string given by the
+		 * <strong>lpDirectory</strong> or <strong>lpFile</strong> member.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_FLAG_NO_UI</strong> (0x00000400)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Do not display an error message box if an error occurs.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_UNICODE</strong> (0x00004000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use this flag to indicate a Unicode application.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_NO_CONSOLE</strong> (0x00008000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use to inherit the parent's console for the new process instead of
+		 * having it create a new console. It is the opposite of using a
+		 * CREATE_NEW_CONSOLE flag with .
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_ASYNCOK</strong> (0x00100000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * The execution can be performed on a background thread and the call
+		 * should return immediately without waiting for the background thread
+		 * to finish. Note that in certain cases ignores this flag and waits for
+		 * the process to finish before returning.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_NOQUERYCLASSSTORE</strong> (0x01000000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Not used.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_HMONITOR</strong> (0x00200000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Use this flag when specifying a monitor on multi-monitor systems. The
+		 * monitor is specified in the <strong>hMonitor</strong> member. This
+		 * flag cannot be combined with SEE_MASK_ICON.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_NOZONECHECKS</strong> (0x00800000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * <strong>Introduced in Windows&nbsp;XP</strong>. Do not perform a zone
+		 * check. This flag allows to bypass zone checking put into place by .
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_WAITFORINPUTIDLE</strong> (0x02000000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * After the new process is created, wait for the process to become idle
+		 * before returning, with a one minute timeout. See for more details.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_FLAG_LOG_USAGE</strong> (0x04000000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * <strong>Introduced in Windows&nbsp;XP</strong>. Keep track of the
+		 * number of times this application has been launched. Applications with
+		 * sufficiently high counts appear in the Start Menu's list of most
+		 * frequently used programs.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SEE_MASK_FLAG_HINST_IS_SITE</strong> (0x08000000)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * <strong>Introduced in Windows&nbsp;8</strong>. The
+		 * <strong>hInstApp</strong> member is used to specify the of an object
+		 * that implements . This object will be used as a site pointer. The
+		 * site pointer is used to provide services to the function, the handler
+		 * binding process, and invoked verb handlers.
+		 * </p>
+		 * </dd>
+		 * </dl>
+		 */
+		public int fMask;
+	
+		/**
+		 * <p>
+		 * Type: <strong>HWND</strong>
+		 * </p>
+		 * <p>
+		 * Optional. A handle to the parent window, used to display any message
+		 * boxes that the system might produce while executing this function.
+		 * This value can be <strong>NULL</strong>.
+		 * </p>
+		 */
+		public HWND hwnd;
+	
+		/**
+		 * <p>
+		 * Type: <strong>LPCTSTR</strong>
+		 * </p>
+		 * </dd>
+		 * <dd>
+		 * <p>
+		 * A string, referred to as a <em>verb</em>, that specifies the action
+		 * to be performed. The set of available verbs depends on the particular
+		 * file or folder. Generally, the actions available from an object's
+		 * shortcut menu are available verbs. This parameter can be
+		 * <strong>NULL</strong>, in which case the default verb is used if
+		 * available. If not, the "open" verb is used. If neither verb is
+		 * available, the system uses the first verb listed in the registry. The
+		 * following verbs are commonly used:
+		 * </p>
+		 * <dl class="indent">
+		 * <dt>
+		 * <p>
+		 * <strong>edit</strong>
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Launches an editor and opens the document for editing. If
+		 * <strong>lpFile</strong> is not a document file, the function will
+		 * fail.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>explore</strong>
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Explores the folder specified by <strong>lpFile</strong>.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>find</strong>
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Initiates a search starting from the specified directory.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>open</strong>
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Opens the file specified by the <strong>lpFile</strong> parameter.
+		 * The file can be an executable file, a document file, or a folder.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>print</strong>
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Prints the document file specified by <strong>lpFile</strong>. If
+		 * <strong>lpFile</strong> is not a document file, the function will
+		 * fail.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>properties</strong>
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Displays the file or folder's properties.
+		 * </p>
+		 * </dd>
+		 * </dl>
+		 */
+		public String lpVerb;
+	
+		/**
+		 * <p>
+		 * Type: <strong>LPCTSTR</strong>
+		 * </p>
+		 * <p>
+		 * The address of a null-terminated string that specifies the name of
+		 * the file or object on which will perform the action specified by the
+		 * <strong>lpVerb</strong> parameter. The system registry verbs that are
+		 * supported by the <strong>ShellExecuteEx</strong> function include
+		 * "open" for executable files and document files and "print" for
+		 * document files for which a print handler has been registered. Other
+		 * applications might have added Shell verbs through the system
+		 * registry, such as "play" for .avi and .wav files. To specify a Shell
+		 * namespace object, pass the fully qualified parse name and set the
+		 * <strong>SEE_MASK_INVOKEIDLIST</strong> flag in the
+		 * <strong>fMask</strong> parameter.
+		 * </p>
+		 * <div class="note"><strong>Note</strong>&nbsp;&nbsp;If the
+		 * <strong>SEE_MASK_INVOKEIDLIST</strong> flag is set, you can use
+		 * either <strong>lpFile</strong> or <strong>lpIDList</strong> to
+		 * identify the item by its file system path or its PIDL respectively.
+		 * One of the two values-<strong>lpFile</strong> or
+		 * <strong>lpIDList</strong>-must be set.</div>
+		 * <div class="note"><strong>Note</strong>&nbsp;&nbsp;If the path is not
+		 * included with the name, the current directory is assumed.</div>
+		 */
+		public String lpFile;
+	
+		/**
+		 * <p>
+		 * Type: <strong>LPCTSTR</strong>
+		 * </p>
+		 * <p>
+		 * Optional. The address of a null-terminated string that contains the
+		 * application parameters. The parameters must be separated by spaces.
+		 * If the <strong>lpFile</strong> member specifies a document file,
+		 * <strong>lpParameters</strong> should be <strong>NULL</strong>.
+		 * </p>
+		 */
+		public String lpParameters;
+	
+		/**
+		 * <p>
+		 * Type: <strong>LPCTSTR</strong>
+		 * </p>
+		 * <p>
+		 * Optional. The address of a null-terminated string that specifies the
+		 * name of the working directory. If this member is
+		 * <strong>NULL</strong>, the current directory is used as the working
+		 * directory.
+		 * </p>
+		 */
+		public String lpDirectory;
+	
+		/**
+		 * <p>
+		 * Type: <strong>int</strong>
+		 * </p>
+		 * <p>
+		 * Required. Flags that specify how an application is to be shown when
+		 * it is opened; one of the SW_ values listed for the <a href=
+		 * "https://msdn.microsoft.com/en-us/library/windows/desktop/bb762153(v=vs.85).aspx">
+		 * <strong xmlns="http://www.w3.org/1999/xhtml">ShellExecute</strong>
+		 * </a> function. If <strong>lpFile</strong> specifies a document file,
+		 * the flag is simply passed to the associated application. It is up to
+		 * the application to decide how to handle it.
+		 * </p>
+		 */
+		public int nShow;
+	
+		/**
+		 * <p>
+		 * Type: <strong>HINSTANCE</strong>
+		 * </p>
+		 * <p>
+		 * [out] If SEE_MASK_NOCLOSEPROCESS is set and the call succeeds, it
+		 * sets this member to a value greater than 32. If the function fails,
+		 * it is set to an SE_ERR_XXX error value that indicates the cause of
+		 * the failure. Although <strong>hInstApp</strong> is declared as an
+		 * HINSTANCE for compatibility with 16-bit Windows applications, it is
+		 * not a true HINSTANCE. It can be cast only to an <strong>int</strong>
+		 * and compared to either 32 or the following SE_ERR_XXX error codes.
+		 * </p>
+		 * <dl class="indent">
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_FNF</strong> (2)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * File not found.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_PNF</strong> (3)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Path not found.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_ACCESSDENIED</strong> (5)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Access denied.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_OOM</strong> (8)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Out of memory.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_DLLNOTFOUND</strong> (32)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Dynamic-link library not found.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_SHARE</strong> (26)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * Cannot share an open file.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_ASSOCINCOMPLETE</strong> (27)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * File association information not complete.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_DDETIMEOUT</strong> (28)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * DDE operation timed out.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_DDEFAIL</strong> (29)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * DDE operation failed.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_DDEBUSY</strong> (30)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * DDE operation is busy.
+		 * </p>
+		 * </dd>
+		 * <dt>
+		 * <p>
+		 * <strong>SE_ERR_NOASSOC</strong> (31)
+		 * </p>
+		 * </dt>
+		 * <dd>
+		 * <p>
+		 * File association not available.
+		 * </p>
+		 * </dd>
+		 * </dl>
+		 */
+		public HINSTANCE hInstApp;
+	
+		/**
+		 * <p>
+		 * Type: <strong>LPVOID</strong>
+		 * </p>
+		 * <p>
+		 * The address of an absolute <a href=
+		 * "https://msdn.microsoft.com/en-us/library/windows/desktop/bb773321(v=vs.85).aspx">
+		 * <strong xmlns="http://www.w3.org/1999/xhtml">ITEMIDLIST</strong></a>
+		 * structure (PCIDLIST_ABSOLUTE) to contain an item identifier list that
+		 * uniquely identifies the file to execute. This member is ignored if
+		 * the <strong>fMask</strong> member does not include
+		 * <strong>SEE_MASK_IDLIST</strong> or
+		 * <strong>SEE_MASK_INVOKEIDLIST</strong>.
+		 * </p>
+		 */
+		public Pointer lpIDList;
+	
+		/**
+		 * <p>
+		 * Type: <strong>LPCTSTR</strong>
+		 * </p>
+		 * 
+		 * <p>
+		 * The address of a null-terminated string that specifies one of the
+		 * following:
+		 * </p>
+		 * <ul>
+		 * <li>A ProgId. For example, "Paint.Picture".</li>
+		 * <li>A URI protocol scheme. For example, "http".</li>
+		 * <li>A file extension. For example, ".txt".</li>
+		 * <li>A registry path under HKEY_CLASSES_ROOT that names a subkey that
+		 * contains one or more Shell verbs. This key will have a subkey that
+		 * conforms to the Shell verb registry schema, such as
+		 * <p>
+		 * <strong>shell</strong>\<em>verb name</em>
+		 * </p>
+		 * .</li>
+		 * </ul>
+		 * <p>
+		 * This member is ignored if <strong>fMask</strong> does not include
+		 * <strong>SEE_MASK_CLASSNAME</strong>.
+		 * </p>
+		 */
+		public WString lpClass;
+	
+		/**
+		 * <p>
+		 * Type: <strong>HKEY</strong>
+		 * </p>
+		 * <p>
+		 * A handle to the registry key for the file type. The access rights for
+		 * this registry key should be set to KEY_READ. This member is ignored
+		 * if <strong>fMask</strong> does not include
+		 * <strong>SEE_MASK_CLASSKEY</strong>.
+		 * </p>
+		 */
+		public HKEY hKeyClass;
+	
+		/**
+		 * <p>
+		 * Type: <strong>DWORD</strong>
+		 * </p>
+		 * <p>
+		 * A keyboard shortcut to associate with the application. The low-order
+		 * word is the virtual key code, and the high-order word is a modifier
+		 * flag (HOTKEYF_). For a list of modifier flags, see the description of
+		 * the <a href=
+		 * "https://msdn.microsoft.com/en-us/library/windows/desktop/ms646284(v=vs.85).aspx">
+		 * <strong xmlns="http://www.w3.org/1999/xhtml">WM_SETHOTKEY</strong>
+		 * </a> message. This member is ignored if <strong>fMask</strong> does
+		 * not include <strong>SEE_MASK_HOTKEY</strong>.
+		 * </p>
+		 */
+		public int dwHotKey;
+	
+		/**
+		 * This is actually a union:
+		 * 
+		 * <pre>
+		 * <code>union { HANDLE hIcon; HANDLE hMonitor; } DUMMYUNIONNAME;</code>
+		 * </pre>
+		 * 
+		 * <strong>DUMMYUNIONNAME</strong>
+		 * <dl>
+		 * <dt><strong>hIcon</strong></dt>
+		 * <dd>
+		 * <p>
+		 * <strong>Type: <strong>HANDLE</strong></strong>
+		 * </p>
+		 * </dd>
+		 * <dd>
+		 * <p>
+		 * A handle to the icon for the file type. This member is ignored if
+		 * <strong>fMask</strong> does not include
+		 * <strong>SEE_MASK_ICON</strong>. This value is used only in
+		 * Windows&nbsp;XP and earlier. It is ignored as of Windows&nbsp;Vista.
+		 * </p>
+		 * </dd>
+		 * <dt><strong>hMonitor</strong></dt>
+		 * <dd>
+		 * <p>
+		 * <strong>Type: <strong>HANDLE</strong></strong>
+		 * </p>
+		 * </dd>
+		 * <dd>
+		 * <p>
+		 * A handle to the monitor upon which the document is to be displayed.
+		 * This member is ignored if <strong>fMask</strong> does not include
+		 * <strong>SEE_MASK_HMONITOR</strong>.
+		 * </p>
+		 * </dd>
+		 * </dl>
+		 */
+		public HANDLE hMonitor;
+	
+		/**
+		 * <p>
+		 * Type: <strong>HANDLE</strong>
+		 * </p>
+		 * <p>
+		 * A handle to the newly started application. This member is set on
+		 * return and is always <strong>NULL</strong> unless
+		 * <strong>fMask</strong> is set to
+		 * <strong>SEE_MASK_NOCLOSEPROCESS</strong>. Even if
+		 * <strong>fMask</strong> is set to
+		 * <strong>SEE_MASK_NOCLOSEPROCESS</strong>, <strong>hProcess</strong>
+		 * will be <strong>NULL</strong> if no process was launched. For
+		 * example, if a document to be launched is a URL and an instance of
+		 * Internet Explorer is already running, it will display the document.
+		 * No new process is launched, and <strong>hProcess</strong> will be
+		 * <strong>NULL</strong>.
+		 * </p>
+		 * <div class="note"><strong>Note</strong>&nbsp;&nbsp;<a href=
+		 * "https://msdn.microsoft.com/en-us/library/windows/desktop/bb762154(v=vs.85).aspx">
+		 * <strong xmlns="http://www.w3.org/1999/xhtml">ShellExecuteEx</strong>
+		 * </a> does not always return an <strong>hProcess</strong>, even if a
+		 * process is launched as the result of the call. For example, an
+		 * <strong>hProcess</strong> does not return when you use
+		 * <strong>SEE_MASK_INVOKEIDLIST</strong> to invoke <a href=
+		 * "https://msdn.microsoft.com/en-us/library/windows/desktop/bb776095(v=vs.85).aspx">
+		 * <strong xmlns="http://www.w3.org/1999/xhtml">IContextMenu</strong>
+		 * </a>.</div>
+		 */
+		public HANDLE hProcess;
+	
+		protected List getFieldOrder() {
+			return Arrays.asList(new String[] { "cbSize", "fMask", "hwnd", "lpVerb", "lpFile", "lpParameters",
+					"lpDirectory", "nShow", "hInstApp", "lpIDList", "lpClass", "hKeyClass", "dwHotKey", "hMonitor",
+					"hProcess", });
+		}
+	}
 
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
@@ -18,6 +18,7 @@ import java.util.List;
 import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.TypeMapper;
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.HINSTANCE;
@@ -26,9 +27,9 @@ import com.sun.jna.platform.win32.WinDef.LPARAM;
 import com.sun.jna.platform.win32.WinDef.RECT;
 import com.sun.jna.platform.win32.WinDef.UINT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
-import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.platform.win32.WinReg.HKEY;
 import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APITypeMapper;
 
 /**
  * Ported from ShellAPI.h.
@@ -38,6 +39,7 @@ import com.sun.jna.win32.StdCallLibrary;
 public interface ShellAPI extends StdCallLibrary {
 
     int STRUCTURE_ALIGNMENT = Platform.is64Bit() ? Structure.ALIGN_DEFAULT : Structure.ALIGN_NONE;
+	TypeMapper TYPE_MAPPER = Boolean.getBoolean("w32.ascii") ? W32APITypeMapper.ASCII : W32APITypeMapper.UNICODE;
 	
     int FO_MOVE = 0x0001;
     int FO_COPY = 0x0002;
@@ -707,7 +709,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * </dd>
 		 * </dl>
 		 */
-		public WString lpVerb;
+		public String lpVerb;
 	
 		/**
 		 * <p>
@@ -735,7 +737,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * <div class="note"><strong>Note</strong>&nbsp;&nbsp;If the path is not
 		 * included with the name, the current directory is assumed.</div>
 		 */
-		public WString lpFile;
+		public String lpFile;
 	
 		/**
 		 * <p>
@@ -748,7 +750,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * <strong>lpParameters</strong> should be <strong>NULL</strong>.
 		 * </p>
 		 */
-		public WString lpParameters;
+		public String lpParameters;
 	
 		/**
 		 * <p>
@@ -761,7 +763,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * directory.
 		 * </p>
 		 */
-		public WString lpDirectory;
+		public String lpDirectory;
 	
 		/**
 		 * <p>
@@ -950,7 +952,7 @@ public interface ShellAPI extends StdCallLibrary {
 		 * <strong>SEE_MASK_CLASSNAME</strong>.
 		 * </p>
 		 */
-		public WString lpClass;
+		public String lpClass;
 	
 		/**
 		 * <p>

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32.java
@@ -58,6 +58,19 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
     /** The device notify all interface classes. */
     int DEVICE_NOTIFY_ALL_INTERFACE_CLASSES = 0x00000004;
 
+	/**
+	 * <p>
+	 * Sets the show state based on the SW_ value specified in the <a href=
+	 * "https://msdn.microsoft.com/en-us/library/windows/desktop/ms686331(v=vs.85).aspx">
+	 * <strong xmlns="http://www.w3.org/1999/xhtml">STARTUPINFO</strong></a>
+	 * structure passed to the <a href=
+	 * "https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx">
+	 * <strong xmlns="http://www.w3.org/1999/xhtml">CreateProcess</strong></a>
+	 * function by the program that started the application.
+	 * </p>
+	 */
+	int SW_SHOWDEFAULT = 10;
+    
     /**
      * This function retrieves a handle to a display device context (DC) for the
      * client area of the specified window. The display device context can be
@@ -2011,4 +2024,14 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
 	 * @see <A HREF="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645598(v=vs.85).aspx">GetRawInputDeviceList</A>
 	 */
 	int GetRawInputDeviceList(RAWINPUTDEVICELIST[] pRawInputDeviceList, IntByReference puiNumDevices, int cbSize);
+	
+	
+	/**
+	 * Retrieves a handle to the desktop window. The desktop window covers the
+	 * entire screen. The desktop window is the area on top of which other
+	 * windows are painted.
+	 * 
+	 * @return Type: HWND The return value is a handle to the desktop window.
+	 */
+	HWND GetDesktopWindow();
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
@@ -172,4 +172,119 @@ public interface WinCrypt extends StdCallLibrary {
      * Regenerate the local machine protection.
      */
     int CRYPTPROTECT_CRED_REGENERATE = 0x80;
+
+	/**
+	 * ASN.1 Certificate encode/decode return value base
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_ERROR = 0x80093100;
+
+	/**
+	 * ASN.1 internal encode or decode error
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_INTERNAL = 0x80093101;
+
+	/**
+	 * ASN.1 unexpected end of data
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_EOD = 0x80093102;
+
+	/**
+	 * ASN.1 corrupted data
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_CORRUPT = 0x80093103;
+
+	/**
+	 * ASN.1 value too large
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_LARGE = 0x80093104;
+
+	/**
+	 * ASN.1 constraint violated
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_CONSTRAINT = 0x80093105;
+
+	/**
+	 * ASN.1 out of memory
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_MEMORY = 0x80093106;
+
+	/**
+	 * ASN.1 buffer overflow
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_OVERFLOW = 0x80093107;
+
+	/**
+	 * ASN.1 function not supported for this PDU
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_BADPDU = 0x80093108;
+
+	/**
+	 * ASN.1 bad arguments to function call
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_BADARGS = 0x80093109;
+
+	/**
+	 * ASN.1 bad real value
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_BADREAL = 0x8009310A;
+
+	/**
+	 * ASN.1 bad tag value met
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_BADTAG = 0x8009310B;
+
+	/**
+	 * ASN.1 bad choice value
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_CHOICE = 0x8009310C;
+
+	/**
+	 * ASN.1 bad encoding rule
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_RULE = 0x8009310D;
+
+	/**
+	 * ASN.1 bad Unicode (UTF8)
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_UTF8 = 0x8009310E;
+
+	/**
+	 * ASN.1 bad PDU type
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_PDU_TYPE = 0x80093133;
+
+	/**
+	 * ASN.1 not yet implemented
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_NYI = 0x80093134;
+
+	/**
+	 * ASN.1 skipped unknown extensions
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_EXTENDED = 0x80093201;
+
+	/**
+	 * ASN.1 end of data expected
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa375564(v=vs.85).aspx
+	 */
+	int CRYPT_E_ASN1_NOEOD = 0x80093202;
+    
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinGDI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinGDI.java
@@ -30,9 +30,9 @@ import com.sun.jna.win32.StdCallLibrary;
  * @author Andreas "PAX" L&uuml;ck, onkelpax-git[at]yahoo.de
  */
 public interface WinGDI extends StdCallLibrary {
-    public int RDH_RECTANGLES = 1;
+    int RDH_RECTANGLES = 1;
 
-    public class RGNDATAHEADER extends Structure {
+    class RGNDATAHEADER extends Structure {
         public int dwSize = size();
         public int iType = RDH_RECTANGLES; // required
         public int nCount;
@@ -44,7 +44,7 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
     
-    public class RGNDATA extends Structure {
+    class RGNDATA extends Structure {
         public RGNDATAHEADER rdh;
         public byte[] Buffer;
 
@@ -61,50 +61,52 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
 
-    public int RGN_AND = 1;
-    public int RGN_OR = 2;
-    public int RGN_XOR = 3;
-    public int RGN_DIFF = 4;
-    public int RGN_COPY = 5;
+    HANDLE HGDI_ERROR = new HANDLE(Pointer.createConstant(0xFFFFFFFF));
     
-    public int ERROR = 0;
-    public int NULLREGION = 1;
-    public int SIMPLEREGION = 2;
-    public int COMPLEXREGION = 3;
-
-    public int ALTERNATE = 1;
-    public int WINDING = 2;
+    int RGN_AND = 1;
+    int RGN_OR = 2;
+    int RGN_XOR = 3;
+    int RGN_DIFF = 4;
+    int RGN_COPY = 5;
     
-    public int BI_RGB = 0;
-    public int BI_RLE8 = 1;
-    public int BI_RLE4 = 2;
-    public int BI_BITFIELDS = 3;
-    public int BI_JPEG = 4;
-    public int BI_PNG = 5;
+    int ERROR = 0;
+    int NULLREGION = 1;
+    int SIMPLEREGION = 2;
+    int COMPLEXREGION = 3;
+
+    int ALTERNATE = 1;
+    int WINDING = 2;
     
-    public final int PFD_TYPE_RGBA = 0;
-    public final int PFD_TYPE_COLORINDEX = 1;
+    int BI_RGB = 0;
+    int BI_RLE8 = 1;
+    int BI_RLE4 = 2;
+    int BI_BITFIELDS = 3;
+    int BI_JPEG = 4;
+    int BI_PNG = 5;
+    
+    int PFD_TYPE_RGBA = 0;
+    int PFD_TYPE_COLORINDEX = 1;
 
-    public final int PFD_MAIN_PLANE = 0;
-    public final int PFD_OVERLAY_PLANE = 1;
-    public final int PFD_UNDERLAY_PLANE = (-1);
+    int PFD_MAIN_PLANE = 0;
+    int PFD_OVERLAY_PLANE = 1;
+    int PFD_UNDERLAY_PLANE = (-1);
 
-    public final int PFD_DOUBLEBUFFER = 0x00000001;
-    public final int PFD_STEREO = 0x00000002;
-    public final int PFD_DRAW_TO_WINDOW = 0x00000004;
-    public final int PFD_DRAW_TO_BITMAP = 0x00000008;
-    public final int PFD_SUPPORT_GDI = 0x00000010;
-    public final int PFD_SUPPORT_OPENGL = 0x00000020;
-    public final int PFD_GENERIC_FORMAT = 0x00000040;
-    public final int PFD_NEED_PALETTE = 0x00000080;
-    public final int PFD_NEED_SYSTEM_PALETTE = 0x00000100;
-    public final int PFD_SWAP_EXCHANGE = 0x00000200;
-    public final int PFD_SWAP_COPY = 0x00000400;
-    public final int PFD_SWAP_LAYER_BUFFERS = 0x00000800;
-    public final int PFD_GENERIC_ACCELERATED = 0x00001000;
-    public final int PFD_SUPPORT_DIRECTDRAW = 0x00002000;
+    int PFD_DOUBLEBUFFER = 0x00000001;
+    int PFD_STEREO = 0x00000002;
+    int PFD_DRAW_TO_WINDOW = 0x00000004;
+    int PFD_DRAW_TO_BITMAP = 0x00000008;
+    int PFD_SUPPORT_GDI = 0x00000010;
+    int PFD_SUPPORT_OPENGL = 0x00000020;
+    int PFD_GENERIC_FORMAT = 0x00000040;
+    int PFD_NEED_PALETTE = 0x00000080;
+    int PFD_NEED_SYSTEM_PALETTE = 0x00000100;
+    int PFD_SWAP_EXCHANGE = 0x00000200;
+    int PFD_SWAP_COPY = 0x00000400;
+    int PFD_SWAP_LAYER_BUFFERS = 0x00000800;
+    int PFD_GENERIC_ACCELERATED = 0x00001000;
+    int PFD_SUPPORT_DIRECTDRAW = 0x00002000;
 
-    public class BITMAPINFOHEADER extends Structure {
+    class BITMAPINFOHEADER extends Structure {
         public int biSize = size();
         public int biWidth;
         public int biHeight;
@@ -121,7 +123,7 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
     
-    public class RGBQUAD extends Structure {
+    class RGBQUAD extends Structure {
         public byte rgbBlue;
         public byte rgbGreen;
         public byte rgbRed;
@@ -131,7 +133,7 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
     
-    public class BITMAPINFO extends Structure {
+    class BITMAPINFO extends Structure {
         public BITMAPINFOHEADER bmiHeader = new BITMAPINFOHEADER();
         public RGBQUAD[] bmiColors = new RGBQUAD[1];
         protected List getFieldOrder() {
@@ -143,7 +145,7 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
     
-    public class ICONINFO extends Structure {
+    class ICONINFO extends Structure {
         public boolean fIcon;
         public int xHotspot;
         public int yHotspot;
@@ -155,7 +157,7 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
     
-    public class BITMAP extends Structure {
+    class BITMAP extends Structure {
         public NativeLong bmType;
         public NativeLong bmWidth;
         public NativeLong bmHeight;
@@ -169,7 +171,7 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
     
-    public class DIBSECTION extends Structure {
+    class DIBSECTION extends Structure {
         public BITMAP           dsBm;
         public BITMAPINFOHEADER dsBmih;
         public int[]            dsBitfields = new int[3];
@@ -180,13 +182,13 @@ public interface WinGDI extends StdCallLibrary {
         }
     }
 
-    public int DIB_RGB_COLORS = 0;
-    public int DIB_PAL_COLORS = 1;
+    int DIB_RGB_COLORS = 0;
+    int DIB_PAL_COLORS = 1;
 
     /**
      * The PIXELFORMATDESCRIPTOR structure describes the pixel format of a drawing surface.
      */
-    public static class PIXELFORMATDESCRIPTOR extends Structure {
+    class PIXELFORMATDESCRIPTOR extends Structure {
         public PIXELFORMATDESCRIPTOR() {
             super();
             nSize = (short) size();

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -1541,6 +1541,6 @@ public class Advapi32Test extends TestCase {
     	assertFalse("CreateProcessWithLogonW should have returned false because the username was bogus.", result);
     	
     	// should fail with "the user name or password is incorrect" (error 1326)
-    	assertEquals("GetLastError() should have returned ERROR_LOGON_FAILURE because the username was bogus.", Native.getLastError(), W32Errors.ERROR_LOGON_FAILURE);
+    	assertEquals("GetLastError() should have returned ERROR_LOGON_FAILURE because the username was bogus.", W32Errors.ERROR_LOGON_FAILURE, Native.getLastError());
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -1527,9 +1527,8 @@ public class Advapi32Test extends TestCase {
     
     public void testCreateProcessWithLogonW() {
     	String winDir = Kernel32Util.getEnvironmentVariable("WINDIR");
-    	if (winDir == null || !(new File(winDir).exists())) {
-    		throw new IllegalStateException("WINDIR environment variable did not properly resolve to a directory.");
-    	}
+    	assertNotNull("No WINDIR value returned", winDir);
+    	assertTrue("Specified WINDIR does not exist: " + winDir, new File(winDir).exists());
     	
     	STARTUPINFO si = new STARTUPINFO();
     	si.lpDesktop = null;
@@ -1539,9 +1538,9 @@ public class Advapi32Test extends TestCase {
     	boolean result = Advapi32.INSTANCE.CreateProcessWithLogonW("A" + System.currentTimeMillis(), "localhost", "12345", Advapi32.LOGON_WITH_PROFILE, new File(winDir, "notepad.exe").getAbsolutePath(), "", 0, null, "", si, results); 
     
     	// we tried to run notepad as a bogus user, so it should fail.
-    	assertFalse(result);
+    	assertFalse("CreateProcessWithLogonW should have returned false because the username was bogus.", result);
     	
     	// should fail with "the user name or password is incorrect" (error 1326)
-    	assertEquals(Native.getLastError(), W32Errors.ERROR_LOGON_FAILURE);
+    	assertEquals("GetLastError() should have returned ERROR_LOGON_FAILURE because the username was bogus.", Native.getLastError(), W32Errors.ERROR_LOGON_FAILURE);
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -12,24 +12,55 @@
  */
 package com.sun.jna.platform.win32;
 
+import static com.sun.jna.platform.win32.WinBase.CREATE_FOR_IMPORT;
+import static com.sun.jna.platform.win32.WinBase.FILE_DIR_DISALOWED;
+import static com.sun.jna.platform.win32.WinBase.FILE_ENCRYPTABLE;
+import static com.sun.jna.platform.win32.WinBase.FILE_IS_ENCRYPTED;
+import static com.sun.jna.platform.win32.WinBase.FILE_READ_ONLY;
+import static com.sun.jna.platform.win32.WinNT.DACL_SECURITY_INFORMATION;
+import static com.sun.jna.platform.win32.WinNT.FILE_ALL_ACCESS;
+import static com.sun.jna.platform.win32.WinNT.FILE_GENERIC_EXECUTE;
+import static com.sun.jna.platform.win32.WinNT.FILE_GENERIC_READ;
+import static com.sun.jna.platform.win32.WinNT.FILE_GENERIC_WRITE;
+import static com.sun.jna.platform.win32.WinNT.GENERIC_ALL;
+import static com.sun.jna.platform.win32.WinNT.GENERIC_EXECUTE;
+import static com.sun.jna.platform.win32.WinNT.GENERIC_READ;
+import static com.sun.jna.platform.win32.WinNT.GENERIC_WRITE;
+import static com.sun.jna.platform.win32.WinNT.GROUP_SECURITY_INFORMATION;
+import static com.sun.jna.platform.win32.WinNT.OWNER_SECURITY_INFORMATION;
+import static com.sun.jna.platform.win32.WinNT.SACL_SECURITY_INFORMATION;
+import static com.sun.jna.platform.win32.WinNT.SE_RESTORE_NAME;
+import static com.sun.jna.platform.win32.WinNT.SE_SECURITY_NAME;
+import static com.sun.jna.platform.win32.WinNT.TOKEN_ADJUST_PRIVILEGES;
+import static com.sun.jna.platform.win32.WinNT.TOKEN_DUPLICATE;
+import static com.sun.jna.platform.win32.WinNT.TOKEN_IMPERSONATE;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
 
-import junit.framework.TestCase;
-
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.LMAccess.USER_INFO_1;
+import com.sun.jna.platform.win32.WinBase.FE_EXPORT_FUNC;
+import com.sun.jna.platform.win32.WinBase.FE_IMPORT_FUNC;
 import com.sun.jna.platform.win32.WinBase.FILETIME;
+import com.sun.jna.platform.win32.WinBase.PROCESS_INFORMATION;
+import com.sun.jna.platform.win32.WinBase.STARTUPINFO;
+import com.sun.jna.platform.win32.WinDef.BOOLByReference;
 import com.sun.jna.platform.win32.WinDef.DWORD;
+import com.sun.jna.platform.win32.WinDef.DWORDByReference;
+import com.sun.jna.platform.win32.WinDef.ULONG;
+import com.sun.jna.platform.win32.WinDef.ULONGByReference;
 import com.sun.jna.platform.win32.WinNT.EVENTLOGRECORD;
+import com.sun.jna.platform.win32.WinNT.GENERIC_MAPPING;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
+import com.sun.jna.platform.win32.WinNT.PRIVILEGE_SET;
 import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.platform.win32.WinNT.PSIDByReference;
 import com.sun.jna.platform.win32.WinNT.SECURITY_IMPERSONATION_LEVEL;
@@ -46,7 +77,7 @@ import com.sun.jna.ptr.ByteByReference;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
-import static com.sun.jna.platform.win32.WinNT.*;
+import junit.framework.TestCase;
 
 /**
  * @author dblock[at]dblock[dot]org
@@ -1492,5 +1523,25 @@ public class Advapi32Test extends TestCase {
         }
         fileWriter.close();
         return file;
+    }
+    
+    public void testCreateProcessWithLogonW() {
+    	String winDir = Kernel32Util.getEnvironmentVariable("WINDIR");
+    	if (winDir == null || !(new File(winDir).exists())) {
+    		throw new IllegalStateException("WINDIR environment variable did not properly resolve to a directory.");
+    	}
+    	
+    	STARTUPINFO si = new STARTUPINFO();
+    	si.lpDesktop = null;
+    	PROCESS_INFORMATION results = new PROCESS_INFORMATION();
+    	
+    	// i have the same combination on my luggage
+    	boolean result = Advapi32.INSTANCE.CreateProcessWithLogonW("A" + System.currentTimeMillis(), "localhost", "12345", Advapi32.LOGON_WITH_PROFILE, new File(winDir, "notepad.exe").getAbsolutePath(), "", 0, null, "", si, results); 
+    
+    	// we tried to run notepad as a bogus user, so it should fail.
+    	assertFalse(result);
+    	
+    	// should fail with "the user name or password is incorrect" (error 1326)
+    	assertEquals(Native.getLastError(), W32Errors.ERROR_LOGON_FAILURE);
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
@@ -75,8 +75,8 @@ public class Crypt32Test extends TestCase {
 
 	public void testCertAddEncodedCertificateToSystemStore() {
 		// try to install a non-existent certificate
-		assertFalse(Crypt32.INSTANCE.CertAddEncodedCertificateToSystemStore("ROOT", null, new DWORD(0)));
+		assertFalse("Attempting to install a non-existent certificate should have returned false and set GetLastError()", Crypt32.INSTANCE.CertAddEncodedCertificateToSystemStore("ROOT", null, 0));
 		// should fail with "unexpected end of data"
-		assertEquals(WinCrypt.CRYPT_E_ASN1_EOD, Native.getLastError());
+		assertEquals("GetLastError() should have been set to CRYPT_E_ASN1_EOD ('ASN.1 unexpected end of data' in WinCrypt.h)", WinCrypt.CRYPT_E_ASN1_EOD, Native.getLastError());
 	}
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
@@ -12,10 +12,20 @@
  */
 package com.sun.jna.platform.win32;
 
-import junit.framework.TestCase;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
 
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinCrypt.DATA_BLOB;
+import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.ptr.PointerByReference;
+
+import junit.framework.TestCase;
 
 /**
  * @author dblock[at]dblock[dot]org
@@ -61,5 +71,12 @@ public class Crypt32Test extends TestCase {
     	Kernel32.INSTANCE.LocalFree(pDataEncrypted.pbData);
     	Kernel32.INSTANCE.LocalFree(pDataDecrypted.pbData);
     	Kernel32.INSTANCE.LocalFree(pDescription.getValue());
-    }    
+    }  
+
+	public void testCertAddEncodedCertificateToSystemStore() {
+		// try to install a non-existent certificate
+		assertFalse(Crypt32.INSTANCE.CertAddEncodedCertificateToSystemStore("ROOT", null, new DWORD(0)));
+		// should fail with "unexpected end of data"
+		assertEquals(WinCrypt.CRYPT_E_ASN1_EOD, Native.getLastError());
+	}
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
@@ -33,10 +33,12 @@ public class GDI32UtilTest extends AbstractWin32TestSupport {
 		HWND desktopWindow = User32.INSTANCE.GetDesktopWindow();
 		assertNotNull("Failed to obtain desktop window handle", desktopWindow);
 		BufferedImage image = GDI32Util.getScreenshot(desktopWindow);
-		// We'll validate that the image is "good" by checking for 20 distinct
-		// colors.
-		// BufferedImages normally start life as one uniform color so if that's
-		// not the case then something copied over - but since this is a whole-desktop screenshot we can't be sure what.
+		// Since this test involves taking a whole-desktop screenshot
+		// we can't be sure what the image will be exactly.
+		// We'll validate that the image is "good" 
+		// by checking for 20 distinct colors.
+		// BufferedImages normally start life as one uniform color 
+		// so if that's not the case then some data was indeed copied over as a result of the getScreenshot() function.
 		List<Integer> distinctPixels = new ArrayList<Integer>();
 		for (int x = 0; x < image.getWidth(); x++) {
 			for (int y = 0; y < image.getHeight(); y++) {
@@ -49,6 +51,6 @@ public class GDI32UtilTest extends AbstractWin32TestSupport {
 				}
 			}
 		}
-		assertTrue("Number of distinct pixels was below 20. It was " + distinctPixels.size(), distinctPixels.size() > 20);
+		assertTrue("Number of distinct pixels was not above 20.", distinctPixels.size() > 20);
 	}
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
@@ -41,7 +41,6 @@ public class GDI32UtilTest extends TestCase {
 				int pixel = image.getRGB(x, y);
 				if (!distinctPixels.contains(pixel)) {
 					distinctPixels.add(pixel);
-					System.out.println(x + " " + y);
 				}
 				if (distinctPixels.size() > 20) {
 					break;

--- a/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
@@ -16,25 +16,27 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
 import com.sun.jna.platform.win32.WinDef.HWND;
 
-import junit.framework.TestCase;
-
-public class GDI32UtilTest extends TestCase {
+public class GDI32UtilTest extends AbstractWin32TestSupport {
 
 	public static void main(String[] args) {
-		junit.textui.TestRunner.run(GDI32Test.class);
+		JUnitCore jUnitCore = new JUnitCore();
+		jUnitCore.run(GDI32UtilTest.class);
 	}
 
+	@Test
 	public void testGetScreenshot() {
 		HWND desktopWindow = User32.INSTANCE.GetDesktopWindow();
-		assertNotNull(desktopWindow);
+		assertNotNull("Failed to obtain desktop window handle", desktopWindow);
 		BufferedImage image = GDI32Util.getScreenshot(desktopWindow);
-
 		// We'll validate that the image is "good" by checking for 20 distinct
 		// colors.
 		// BufferedImages normally start life as one uniform color so if that's
-		// not the case then something copied over.
+		// not the case then something copied over - but since this is a whole-desktop screenshot we can't be sure what.
 		List<Integer> distinctPixels = new ArrayList<Integer>();
 		for (int x = 0; x < image.getWidth(); x++) {
 			for (int y = 0; y < image.getHeight(); y++) {
@@ -47,6 +49,6 @@ public class GDI32UtilTest extends TestCase {
 				}
 			}
 		}
-		assertTrue(distinctPixels.size() > 20);
+		assertTrue("Number of distinct pixels was below 20. It was " + distinctPixels.size(), distinctPixels.size() > 20);
 	}
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/GDI32UtilTest.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2015 Michael Freeman, All Rights Reserved
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.  
+ */
+package com.sun.jna.platform.win32;
+
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sun.jna.platform.win32.WinDef.HWND;
+
+import junit.framework.TestCase;
+
+public class GDI32UtilTest extends TestCase {
+
+	public static void main(String[] args) {
+		junit.textui.TestRunner.run(GDI32Test.class);
+	}
+
+	public void testGetScreenshot() {
+		HWND desktopWindow = User32.INSTANCE.GetDesktopWindow();
+		assertNotNull(desktopWindow);
+		BufferedImage image = GDI32Util.getScreenshot(desktopWindow);
+
+		// We'll validate that the image is "good" by checking for 20 distinct
+		// colors.
+		// BufferedImages normally start life as one uniform color so if that's
+		// not the case then something copied over.
+		List<Integer> distinctPixels = new ArrayList<Integer>();
+		for (int x = 0; x < image.getWidth(); x++) {
+			for (int y = 0; y < image.getHeight(); y++) {
+				int pixel = image.getRGB(x, y);
+				if (!distinctPixels.contains(pixel)) {
+					distinctPixels.add(pixel);
+					System.out.println(x + " " + y);
+				}
+				if (distinctPixels.size() > 20) {
+					break;
+				}
+			}
+		}
+		assertTrue(distinctPixels.size() > 20);
+	}
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
@@ -187,10 +187,10 @@ public class Shell32Test extends TestCase {
 			// to avoid opening something and having hProcess come up null
 			// (meaning we opened something but can't close it)
 			// we will do a negative test with a bogus action.
-			lpExecInfo.lpVerb = new WString("0p3n");
+			lpExecInfo.lpVerb = "0p3n";
 			lpExecInfo.nShow = User32.SW_SHOWDEFAULT;
 			lpExecInfo.fMask = Shell32.SEE_MASK_NOCLOSEPROCESS | Shell32.SEE_MASK_FLAG_NO_UI;
-			lpExecInfo.lpFile = new WString(file.getAbsolutePath());
+			lpExecInfo.lpFile = file.getAbsolutePath();
 
 			assertFalse("ShellExecuteEx should have returned false - action verb was bogus.",
 					Shell32.INSTANCE.ShellExecuteEx(lpExecInfo));

--- a/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
@@ -148,7 +148,7 @@ public class Shell32Test extends TestCase {
 	}
 
 	public void testSHEmptyRecycleBin() {
-		File file = new File(System.getProperty("java.io.tmpdir") + System.nanoTime() + ".txt");
+		File file = new File(System.getProperty("java.io.tmpdir"), System.nanoTime() + ".txt");
 		try {
 			// Create a file and immediately send it to the recycle bin.
 			try {
@@ -160,12 +160,12 @@ public class Shell32Test extends TestCase {
 
 			int result = Shell32.INSTANCE.SHEmptyRecycleBin(null, null,
 					Shell32.SHERB_NOCONFIRMATION | Shell32.SHERB_NOPROGRESSUI | Shell32.SHERB_NOSOUND);
-			// for reasons I can not find documented, the function returns the
-			// following:
-			// -2147418113 when the recycle bin has no items in it
+			// for reasons I can not find documented on MSDN, 
+			// the function returns the following:
 			// 0 when the recycle bin has items in it
-			assertTrue("Result should have been 0 when emptying Recycle Bin - there should have been a file in it.",
-					result == 0);
+			// -2147418113 when the recycle bin has no items in it
+			assertEquals("Result should have been ERROR_SUCCESS when emptying Recycle Bin - there should have been a file in it.",
+					 W32Errors.ERROR_SUCCESS, result);
 		} finally {
 			// if the file wasn't sent to the recycle bin, delete it.
 			if (file.exists()) {
@@ -175,7 +175,7 @@ public class Shell32Test extends TestCase {
 	}
 
 	public void testShellExecuteEx() {
-		File file = new File(System.getProperty("java.io.tmpdir") + System.nanoTime() + ".txt");
+		File file = new File(System.getProperty("java.io.tmpdir"), System.nanoTime() + ".txt");
 		try {
 			try {
 				fillTempFile(file);
@@ -194,8 +194,8 @@ public class Shell32Test extends TestCase {
 
 			assertFalse("ShellExecuteEx should have returned false - action verb was bogus.",
 					Shell32.INSTANCE.ShellExecuteEx(lpExecInfo));
-			assertTrue("GetLastError() should have been set to ERROR_NO_ASSOCIATION because of bogus action",
-					Native.getLastError() == W32Errors.ERROR_NO_ASSOCIATION);
+			assertEquals("GetLastError() should have been set to ERROR_NO_ASSOCIATION because of bogus action",
+					W32Errors.ERROR_NO_ASSOCIATION, Native.getLastError());
 		} finally {
 			if (file.exists()) {
 				file.delete();
@@ -205,7 +205,7 @@ public class Shell32Test extends TestCase {
 	}
 
 	/**
-	 * Creates (if needed) and fills the specified file with some content
+	 * Creates (if needed) and fills the specified file with some content (10 lines of the same text)
 	 * 
 	 * @param file
 	 *            The file to fill with content
@@ -215,9 +215,13 @@ public class Shell32Test extends TestCase {
 	private void fillTempFile(File file) throws IOException {
 		file.createNewFile();
 		FileWriter fileWriter = new FileWriter(file);
-		for (int i = 0; i < 10; i++) {
-			fileWriter.write("Sample text " + i + System.getProperty("line.separator"));
+		try {
+			for (int i = 0; i < 10; i++) {
+				fileWriter.write("Sample line of text");
+				fileWriter.write(System.getProperty("line.separator"));
+			}
+		} finally {
+			fileWriter.close();
 		}
-		fileWriter.close();
 	}
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
@@ -243,7 +243,7 @@ public class User32Test extends AbstractWin32TestSupport {
 		assertTrue(User32.INSTANCE.LockWorkStation().booleanValue());
     }
 
-    @Ignore("Shutsdown the workstation")
+    @Ignore("Shuts down the workstation")
     @Test
     public final void testExitWindows() {
 		assertTrue(User32.INSTANCE.ExitWindowsEx(new UINT(WinUser.EWX_LOGOFF), new DWORD(0x00030000)).booleanValue()); //This only tries to log off.
@@ -300,8 +300,9 @@ public class User32Test extends AbstractWin32TestSupport {
 		assertNotEquals(0, result);
 	}
 
+	@Test
 	public void testGetDesktopWindow() {
 		HWND desktopWindow = User32.INSTANCE.GetDesktopWindow();
-		assertNotNull(desktopWindow);
+		assertNotNull("Failed to get desktop window HWND", desktopWindow);
 	}
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
@@ -299,4 +299,9 @@ public class User32Test extends AbstractWin32TestSupport {
 
 		assertNotEquals(0, result);
 	}
+
+	public void testGetDesktopWindow() {
+		HWND desktopWindow = User32.INSTANCE.GetDesktopWindow();
+		assertNotNull(desktopWindow);
+	}
 }


### PR DESCRIPTION
* Advapi32
	* Added LOGON_WITH_PROFILE constant
	* Added LOGON_NETCREDENTIALS_ONLY constant
	* Added CreateProcessWithLogonW(String, String, String, int, String, String, int, Pointer, String, STARTUPINFO, PROCESS_INFORMATION)
		* No Unit Test - I would have to make it create a user to be 100% able to run a process as another user and that would be a security issue I figure.
* Crypt32
	* Added CertAddEncodedCertificateToSystemStore(String, Pointer, DWORD)
		* No Unit Test - I doubt anyone would want the security risk of a unit test installing a root certificate.
* GDI32
	* Added SRCCOPY constant
	* Added BitBlt(HDC, int, int, int, int, HDC, int, int, int)
		* No direct unit test - the test for GDI32Util.getScreenshot() seemed to cover it just fine.
	* Added GDI32Util.getScreenshot(HWND)
		* Added unit test as GDI32UtilTest.testGetScreenshot()
* Shell32
	* Added SHERB_NOCONFIRMATION constant
	* Added SHERB_NOPROGRESSUI constant
	* Added SHERB_NOSOUND constant
	* Added SEE_MASK_NOCLOSEPROCESS constant
	* Added SHEmptyRecycleBin(HANDLE, String, int)
		* No unit test - no idea how to tell if the recycle bin is empty afterwards
	* Added ShellExecuteEx(SHELLEXECUTEINFO)
		* No unit test - there are a bunch of cases where the hProcess member in SHELLEXECUTEINFO isn't set - not sure how to control for that
* ShellAPI
	* Added SHELLEXECUTEINFO structure
* User32
	* Added GetDesktopWindow()
		* Added test as User32Test.testGetDesktopWindow()
* WinGDI
	* Added HGDI_ERROR
	* Removed superfluous "public" and "public final" from WinGDI

==================================

Hopefully this is more manageable and more acceptable than my last way-too-large pull request