### PR TITLE
539: Added Missing Windows kernel32 method: QueryFullProcessImageName

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Features
 * [#535](https://github.com/java-native-access/jna/pull/535): Added `BitBlt` to `com.sun.jna.platform.win32.GDI32`, Added `com.sun.jna.platform.win32.GDI32Util` and added `getScreenshot()` to it - [@mlfreeman2](https://github.com/mlfreeman2).
 * [#535](https://github.com/java-native-access/jna/pull/535): Added `SHEmptyRecycleBin`, `ShellExecuteEx` to `com.sun.jna.platform.win32.Shell32` - [@mlfreeman2](https://github.com/mlfreeman2).
 * [#535](https://github.com/java-native-access/jna/pull/535): Added `GetDesktopWindow` to `com.sun.jna.platform.win32.User32` - [@mlfreeman2](https://github.com/mlfreeman2).
-* [#539](https://github.com/java-native-access/jna/pull/539): Added Missing Windows kernel32 method: QueryFullProcessImageName
+* [#540](https://github.com/java-native-access/jna/pull/539): Added Missing Windows kernel32 method: QueryFullProcessImageName - [@yossieilaty](https://github.com/yossieilaty).
 
 Bug Fixes
 ---------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Features
 * [#535](https://github.com/java-native-access/jna/pull/535): Added `BitBlt` to `com.sun.jna.platform.win32.GDI32`, Added `com.sun.jna.platform.win32.GDI32Util` and added `getScreenshot()` to it - [@mlfreeman2](https://github.com/mlfreeman2).
 * [#535](https://github.com/java-native-access/jna/pull/535): Added `SHEmptyRecycleBin`, `ShellExecuteEx` to `com.sun.jna.platform.win32.Shell32` - [@mlfreeman2](https://github.com/mlfreeman2).
 * [#535](https://github.com/java-native-access/jna/pull/535): Added `GetDesktopWindow` to `com.sun.jna.platform.win32.User32` - [@mlfreeman2](https://github.com/mlfreeman2).
+* [#539](https://github.com/java-native-access/jna/pull/539): Added Missing Windows kernel32 method: QueryFullProcessImageName
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -1212,6 +1212,26 @@ public interface Kernel32 extends WinNT, Wincon {
      *         GetLastError.
      */
     HANDLE OpenProcess(int fdwAccess, boolean fInherit, int IDProcess);
+    
+    /**
+     * This function retrieves the full path of the executable file of a given process.
+     * 
+     * @param hProcess
+     * 			Handle for the running process
+     * @param dwFlags
+     * 			0 - The name should use the Win32 path format.
+     * 			1(PROCESS_NAME_NATIVE) - The name should use the native system path format. 
+     * @param lpExeName
+     * 			pre-allocated character buffer for the returned path
+     * @param lpdwSize
+     * 			input: the size of the allocated buffer
+     * 			output: the length of the returned path in characters 
+     * 
+     * @return true if successful false if not. To get extended error information, 
+     * 		   call GetLastError. 
+     */
+    boolean QueryFullProcessImageName(HANDLE hProcess, int dwFlags, char[] lpExeName, IntByReference lpdwSize);
+
 
     /**
      * The GetTempPath function retrieves the path of the directory designated

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -1246,7 +1246,7 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      * 			Handle for the running process
      * @param dwFlags
      * 			0 - The name should use the Win32 path format.
-     * 			1(PROCESS_NAME_NATIVE) - The name should use the native system path format. 
+     * 			1(WinNT.PROCESS_NAME_NATIVE) - The name should use the native system path format. 
      * @param lpExeName
      * 			pre-allocated character buffer for the returned path
      * @param lpdwSize

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
@@ -678,4 +678,25 @@ public abstract class Kernel32Util implements WinDef {
         
         return volumeGUIDPath.substring(VOLUME_GUID_PATH_PREFIX.length(), volumeGUIDPath.length() - VOLUME_GUID_PATH_SUFFIX.length());
     }
+    
+    /**
+     * 
+     * This function retrieves the full path of the executable file of a given process.
+     * 
+     * @param hProcess
+     * 			Handle for the running process
+     * @param dwFlags
+     * 			0 - The name should use the Win32 path format.
+     * 			1(PROCESS_NAME_NATIVE) - The name should use the native system path format. 
+     * 
+     * @return the full path of the process's executable file of null if failed. To get extended error information, 
+     * 		   call GetLastError. 
+     */
+    public static final String QueryFullProcessImageName(HANDLE hProcess, int dwFlags) {
+        char[] path = new char[WinDef.MAX_PATH];
+        IntByReference lpdwSize = new IntByReference(path.length);
+        if (Kernel32.INSTANCE.QueryFullProcessImageName(hProcess, 0, path, lpdwSize))
+            return new String(path).substring(0, lpdwSize.getValue());
+    	return null;
+    }
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
@@ -687,7 +687,7 @@ public abstract class Kernel32Util implements WinDef {
      * 			Handle for the running process
      * @param dwFlags
      * 			0 - The name should use the Win32 path format.
-     * 			1(PROCESS_NAME_NATIVE) - The name should use the native system path format. 
+     * 			1(WinNT.PROCESS_NAME_NATIVE) - The name should use the native system path format. 
      * 
      * @return the full path of the process's executable file of null if failed. To get extended error information, 
      * 		   call GetLastError. 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
@@ -697,6 +697,6 @@ public abstract class Kernel32Util implements WinDef {
         IntByReference lpdwSize = new IntByReference(path.length);
         if (Kernel32.INSTANCE.QueryFullProcessImageName(hProcess, 0, path, lpdwSize))
             return new String(path).substring(0, lpdwSize.getValue());
-    	return null;
+        throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
     }
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -2177,6 +2177,11 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
 	int PROCESS_TERMINATE = 0x00000001;
 
 	/**
+	 * Required for getting process path
+	 */
+	int PROCESS_NAME_NATIVE = 0x00000001;
+	
+	/**
 	 * Required to perform an operation on the address space of a process (see
 	 * {@code Kernel32.VirtualProtectEx()} and
 	 * {@link Kernel32#WriteProcessMemory}

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -2177,8 +2177,9 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
 	 */
 	int PROCESS_TERMINATE = 0x00000001;
 
-	/**
-	 * Required for getting process path
+    /**
+	 * Required for getting process exe path in native system path format
+	 * {@code Kernel32.QueryFullProcessImageName()}.
 	 */
 	int PROCESS_NAME_NATIVE = 0x00000001;
 	

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -331,11 +331,13 @@ public class Kernel32Test extends TestCase {
     public void testQueryFullProcessImageName() {
     	HANDLE h = Kernel32.INSTANCE.OpenProcess(0, false,
     			Kernel32.INSTANCE.GetCurrentProcessId());
-    	char[] path = new char[1024];
+    	assertNotNull("Failed (" + Kernel32.INSTANCE.GetLastError() + ") to get process handle", h);
+    	
+    	char[] path = new char[WinDef.MAX_PATH];
         IntByReference lpdwSize = new IntByReference(path.length);
         boolean b = Kernel32.INSTANCE.QueryFullProcessImageName(h, 0, path, lpdwSize);
-        assertTrue(b);
-        assertTrue(lpdwSize.getValue() > 0);
+        assertTrue("Failed (" + Kernel32.INSTANCE.GetLastError() + ") to query process image name", b);
+        assertTrue("Failed to query process image name, empty path returned", lpdwSize.getValue() > 0);
     }
 
     public void testGetTempPath() {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -329,11 +329,10 @@ public class Kernel32Test extends TestCase {
     }
 
     public void testQueryFullProcessImageName() {
-    	HANDLE h = Kernel32.INSTANCE.OpenProcess(0, false,
-    			Kernel32.INSTANCE.GetCurrentProcessId());
-    	assertNotNull("Failed (" + Kernel32.INSTANCE.GetLastError() + ") to get process handle", h);
+        HANDLE h = Kernel32.INSTANCE.OpenProcess(0, false, Kernel32.INSTANCE.GetCurrentProcessId());
+        assertNotNull("Failed (" + Kernel32.INSTANCE.GetLastError() + ") to get process handle", h);
     	
-    	char[] path = new char[WinDef.MAX_PATH];
+        char[] path = new char[WinDef.MAX_PATH];
         IntByReference lpdwSize = new IntByReference(path.length);
         boolean b = Kernel32.INSTANCE.QueryFullProcessImageName(h, 0, path, lpdwSize);
         assertTrue("Failed (" + Kernel32.INSTANCE.GetLastError() + ") to query process image name", b);

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -328,6 +328,16 @@ public class Kernel32Test extends TestCase {
     	assertEquals(WinError.ERROR_ACCESS_DENIED, Kernel32.INSTANCE.GetLastError());
     }
 
+    public void testQueryFullProcessImageName() {
+    	HANDLE h = Kernel32.INSTANCE.OpenProcess(0, false,
+    			Kernel32.INSTANCE.GetCurrentProcessId());
+    	char[] path = new char[1024];
+        IntByReference lpdwSize = new IntByReference(path.length);
+        boolean b = Kernel32.INSTANCE.QueryFullProcessImageName(h, 0, path, lpdwSize);
+        assertTrue(b);
+        assertTrue(lpdwSize.getValue() > 0);
+    }
+
     public void testGetTempPath() {
     	char[] buffer = new char[WinDef.MAX_PATH];
     	assertTrue(Kernel32.INSTANCE.GetTempPath(new DWORD(WinDef.MAX_PATH), buffer).intValue() > 0);

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
 
+import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.LARGE_INTEGER;
+import com.sun.jna.ptr.IntByReference;
 
 import junit.framework.TestCase;
 
@@ -252,5 +254,13 @@ public class Kernel32UtilTest extends TestCase {
         } finally {
             reader.close();
         }        
+    }
+    
+    public final void testQueryFullProcessImageName() {
+        HANDLE h = Kernel32.INSTANCE.OpenProcess(0, false, Kernel32.INSTANCE.GetCurrentProcessId());
+        assertNotNull("Failed (" + Kernel32.INSTANCE.GetLastError() + ") to get process handle", h);
+
+        String name = Kernel32Util.QueryFullProcessImageName(h, 0);
+        assertTrue("Failed to query process image name, empty path returned", name.length() > 0);
     }
 }


### PR DESCRIPTION
Added mapping for Win32 Kernel API GetProcessImageFileName as described in MSDN page: https://msdn.microsoft.com/en-us/library/windows/desktop/ms683217(v=vs.85).aspx.

This method is used to retrieve the full path of an executable of a running process