### PR TITLE
Clean up w32 platform-specific tests 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -307,6 +307,7 @@
       <path id="test.libs">
         <fileset dir="lib">
           <include name="junit.jar"/>
+          <include name="hamcrest-core-1.3.jar"/>
         </fileset>
         <fileset dir="lib/test"/>
         <pathelement path="${classes}"/>
@@ -520,7 +521,7 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
     <subant target="jar" failonerror="true">
       <property name="file.reference.jna.build" location="${build}"/>
       <property name="file.reference.jna.jar" location="${build}/${jar}"/>
-      <property name="libs.junit.classpath" location="lib/junit.jar"/>
+      <property name="libs.junit.classpath" refid="test.libs"/>
       <property name="javac.source" value="${platform.compatibility}"/>
       <property name="javac.target" value="${platform.compatibility}"/>
       <!-- OSGi manifest properties -->
@@ -543,7 +544,7 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
     <subant target="jar" failonerror="true">
       <property name="file.reference.jna.build" location="${build}"/>
       <property name="file.reference.jna.jar" location="${build}/${jar}"/>
-      <property name="libs.junit.classpath" location="lib/junit.jar"/>
+      <property name="libs.junit.classpath" refid="test.libs"/>
       <fileset dir="${contrib}" includes="*/build.xml" excludes="platform/build.xml"/>
     </subant>
   </target>
@@ -971,6 +972,9 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
     <condition property="tests.exclude" value="${tests.stdcall}">
       <and><os family="windows"/><not><os arch="x86"/></not></and>
     </condition>
+    <condition property="tests.platform" value="**/mac/**/*Test.java">
+      <os family="mac"/>
+    </condition>
     <condition property="tests.platform" value="**/unix/*Test.java">
       <and>
         <os family="unix"/>
@@ -1025,7 +1029,7 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
     <subant target="test" failonerror="true" inheritall="true" inheritrefs="true">
       <property name="file.reference.jna.build" location="${build}"/>
       <property name="file.reference.jna.jar" location="${build}/${jar}"/>
-      <property name="libs.junit.classpath" location="lib/junit.jar"/>
+      <property name="libs.junit.classpath" refid="test.libs"/>
       <property name="javac.source" value="${test.compatibility}"/>
       <property name="javac.target" value="${test.compatibility}"/>
       <fileset dir="${contrib}" includes="platform/build.xml"/>

--- a/build.xml
+++ b/build.xml
@@ -975,7 +975,7 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
     <condition property="tests.platform" value="**/mac/**/*Test.java">
       <os family="mac"/>
     </condition>
-    <condition property="tests.platform" value="**/unix/*Test.java">
+    <condition property="tests.platform" value="**/unix/**/*Test.java">
       <and>
         <os family="unix"/>
         <not><os family="mac"/></not>

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -111,13 +111,13 @@ com.sun.jna.platform.wince
       <property name="build.test.results.dir.abs" location="${build.test.results.dir}"/>
       <mkdir dir="${build.test.results.dir.abs}"/>
       <echo>Saving test results in ${build.test.results.dir.abs}</echo>
-      <condition property="tests.platform" value="**/mac/**">
+      <condition property="tests.platform" value="**/mac/**Test.java">
         <os family="mac"/>
       </condition>
-      <condition property="tests.platform" value="**/win32/**">
+      <condition property="tests.platform" value="**/win32/**Test.java">
         <os family="windows"/>
       </condition>
-      <condition property="tests.platform" value="**/unix/**">
+      <condition property="tests.platform" value="**/unix/**Test.java">
         <os family="unix"/>
       </condition>
       <property name="tests.platform" value=""/>
@@ -155,7 +155,7 @@ com.sun.jna.platform.wince
           <fileset dir="${test.src.dir}" excludes="${tests.exclude-patterns}">
             <!-- Until StructureFieldOrderTest gets fixed up a little -->
             <exclude name="**/StructureFieldOrderTest.java"/>
-            <include name="com/sun/jna/platform/*Test.java"/>
+            <exclude name="com/sun/jna/platform/AbstractWin32TestSupport.java"/>
             <include name="${tests.platform}"/>
             <exclude name="${tests.exclude}"/>
           </fileset>

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -111,13 +111,13 @@ com.sun.jna.platform.wince
       <property name="build.test.results.dir.abs" location="${build.test.results.dir}"/>
       <mkdir dir="${build.test.results.dir.abs}"/>
       <echo>Saving test results in ${build.test.results.dir.abs}</echo>
-      <condition property="tests.platform" value="**/mac/**Test.java">
+      <condition property="tests.platform" value="**/mac/**/*Test.java">
         <os family="mac"/>
       </condition>
-      <condition property="tests.platform" value="**/win32/**Test.java">
+      <condition property="tests.platform" value="**/win32/**/*Test.java">
         <os family="windows"/>
       </condition>
-      <condition property="tests.platform" value="**/unix/**Test.java">
+      <condition property="tests.platform" value="**/unix/**/*Test.java">
         <os family="unix"/>
       </condition>
       <property name="tests.platform" value=""/>

--- a/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
@@ -83,8 +83,11 @@ import com.sun.jna.platform.win32.WinDef.HDC;
 import com.sun.jna.platform.win32.WinDef.HICON;
 import com.sun.jna.platform.win32.WinDef.HRGN;
 import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinDef.LPARAM;
+import com.sun.jna.platform.win32.WinDef.LRESULT;
 import com.sun.jna.platform.win32.WinDef.POINT;
 import com.sun.jna.platform.win32.WinDef.RECT;
+import com.sun.jna.platform.win32.WinDef.WPARAM;
 import com.sun.jna.platform.win32.WinGDI;
 import com.sun.jna.platform.win32.WinGDI.BITMAP;
 import com.sun.jna.platform.win32.WinGDI.BITMAPINFO;
@@ -1050,205 +1053,215 @@ public class WindowUtils {
             setWindowRegion(w, region);
         }
 
-		@Override
-		public BufferedImage getWindowIcon(final HWND hwnd) {
-			// request different kind of icons if any solution fails
-			final DWORDByReference hIconNumber = new DWORDByReference();
-			long result = User32.INSTANCE.SendMessageTimeout(hwnd,
-					WinUser.WM_GETICON, WinUser.ICON_BIG, 0,
-					WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
-			if (result == 0)
-				result = User32.INSTANCE.SendMessageTimeout(hwnd,
-						WinUser.WM_GETICON, WinUser.ICON_SMALL, 0,
-						WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
-			if (result == 0)
-				result = User32.INSTANCE.SendMessageTimeout(hwnd,
-						WinUser.WM_GETICON, WinUser.ICON_SMALL2, 0,
-						WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
-			if (result == 0) {
-				result = User32.INSTANCE.GetClassLongPtr(hwnd,
-						WinUser.GCLP_HICON);
-				hIconNumber.getValue().setValue(result);
-			}
-			if (result == 0) {
-				result = User32.INSTANCE.GetClassLongPtr(hwnd,
-						WinUser.GCLP_HICONSM);
-				hIconNumber.getValue().setValue(result);
-			}
-			if (result == 0)
-				return null;
-
-			// draw native icon into Java image
-			final HICON hIcon = new HICON(new Pointer(hIconNumber.getValue()
-					.longValue()));
-			final Dimension iconSize = getIconSize(hIcon);
-			if (iconSize.width == 0 || iconSize.height == 0)
-				return null;
-
-			final int width = iconSize.width;
-			final int height = iconSize.height;
-			final short depth = 24;
-
-			final byte[] lpBitsColor = new byte[width * height * depth / 8];
-			final Pointer lpBitsColorPtr = new Memory(lpBitsColor.length);
-			final byte[] lpBitsMask = new byte[width * height * depth / 8];
-			final Pointer lpBitsMaskPtr = new Memory(lpBitsMask.length);
-			final BITMAPINFO bitmapInfo = new BITMAPINFO();
-			final BITMAPINFOHEADER hdr = new BITMAPINFOHEADER();
-			
-			bitmapInfo.bmiHeader = hdr;
-			hdr.biWidth = width;
-			hdr.biHeight = height;
-			hdr.biPlanes = 1;
-			hdr.biBitCount = depth;
-			hdr.biCompression = 0;
-			hdr.write();
-			bitmapInfo.write();
-
-			final HDC hDC = User32.INSTANCE.GetDC(null);
-			final ICONINFO iconInfo = new ICONINFO();
-			User32.INSTANCE.GetIconInfo(hIcon, iconInfo);
-			iconInfo.read();
-			GDI32.INSTANCE.GetDIBits(hDC, iconInfo.hbmColor, 0, height,
-					lpBitsColorPtr, bitmapInfo, 0);
-			lpBitsColorPtr.read(0, lpBitsColor, 0, lpBitsColor.length);
-			GDI32.INSTANCE.GetDIBits(hDC, iconInfo.hbmMask, 0, height,
-					lpBitsMaskPtr, bitmapInfo, 0);
-			lpBitsMaskPtr.read(0, lpBitsMask, 0, lpBitsMask.length);
-			final BufferedImage image = new BufferedImage(width, height,
-					BufferedImage.TYPE_INT_ARGB);
-
-			int r, g, b, a, argb;
-			int x = 0, y = height - 1;
-			for (int i = 0; i < lpBitsColor.length; i = i + 3) {
-				b = lpBitsColor[i] & 0xFF;
-				g = lpBitsColor[i + 1] & 0xFF;
-				r = lpBitsColor[i + 2] & 0xFF;
-				a = 0xFF - lpBitsMask[i] & 0xFF;
-				argb = (a << 24) | (r << 16) | (g << 8) | b;
-				image.setRGB(x, y, argb);
-				x = (x + 1) % width;
-				if (x == 0)
-					y--;
-			}
-
-			User32.INSTANCE.ReleaseDC(null, hDC);
-
-			return image;
-		}
-
-		@Override
-		public Dimension getIconSize(final HICON hIcon) {
-			final ICONINFO iconInfo = new ICONINFO();
-			try {
-				if (!User32.INSTANCE.GetIconInfo(hIcon, iconInfo))
-					return new Dimension();
-				iconInfo.read();
-
-				final BITMAP bmp = new BITMAP();
-				if (iconInfo.hbmColor != null
-						&& iconInfo.hbmColor.getPointer() != Pointer.NULL) {
-					final int nWrittenBytes = GDI32.INSTANCE.GetObject(
-							iconInfo.hbmColor, bmp.size(), bmp.getPointer());
-					bmp.read();
-					if (nWrittenBytes > 0)
-						return new Dimension(bmp.bmWidth.intValue(),
-								bmp.bmHeight.intValue());
-				} else if (iconInfo.hbmMask != null
-						&& iconInfo.hbmMask.getPointer() != Pointer.NULL) {
-					final int nWrittenBytes = GDI32.INSTANCE.GetObject(
-							iconInfo.hbmMask, bmp.size(), bmp.getPointer());
-					bmp.read();
-					if (nWrittenBytes > 0)
-						return new Dimension(bmp.bmWidth.intValue(), bmp.bmHeight.intValue() / 2);
-				}
-			} finally {
-				if (iconInfo.hbmColor != null
-						&& iconInfo.hbmColor.getPointer() != Pointer.NULL)
-					GDI32.INSTANCE.DeleteObject(iconInfo.hbmColor);
-				if (iconInfo.hbmMask != null
-						&& iconInfo.hbmMask.getPointer() != Pointer.NULL)
-					GDI32.INSTANCE.DeleteObject(iconInfo.hbmMask);
-			}
-
-			return new Dimension();
-		}
-
-		@Override
-		public List<DesktopWindow> getAllWindows(
-				final boolean onlyVisibleWindows) {
-			final List<DesktopWindow> result = new LinkedList<DesktopWindow>();
-
-			final WNDENUMPROC lpEnumFunc = new WNDENUMPROC() {
-				@Override
-				public boolean callback(final HWND hwnd, final Pointer arg1) {
-					try {
-						final boolean visible = !onlyVisibleWindows
-								|| User32.INSTANCE.IsWindowVisible(hwnd);
-						if (visible) {
-							final String title = getWindowTitle(hwnd);
-							final String filePath = getProcessFilePath(hwnd);
-							final Rectangle locAndSize = getWindowLocationAndSize(hwnd);
-							result.add(new DesktopWindow(hwnd, title, filePath,
-									locAndSize));
-						}
-					} catch (final Exception e) {
-						e.printStackTrace();
-					}
-
-					return true;
-				}
-			};
-
-			if (!User32.INSTANCE.EnumWindows(lpEnumFunc, null))
-				throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-
-			return result;
-		}
-
-		@Override
-		public String getWindowTitle(final HWND hwnd) {
-			final int requiredLength = User32.INSTANCE
-					.GetWindowTextLength(hwnd) + 1;
-			final char[] title = new char[requiredLength];
-			final int length = User32.INSTANCE.GetWindowText(hwnd, title,
-					title.length);
-
-			return Native.toString(Arrays.copyOfRange(title, 0, length));
-		}
-
-		@Override
-		public String getProcessFilePath(final HWND hwnd) {
-			final char[] filePath = new char[1025];
-			final IntByReference pid = new IntByReference();
-			User32.INSTANCE.GetWindowThreadProcessId(hwnd, pid);
-
-			final HANDLE process = Kernel32.INSTANCE.OpenProcess(
-					WinNT.PROCESS_QUERY_INFORMATION | WinNT.PROCESS_VM_READ,
-					false, pid.getValue());
-			if (process == null
-					&& Kernel32.INSTANCE.GetLastError() != WinNT.ERROR_ACCESS_DENIED)
-				throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-
-			final int length = Psapi.INSTANCE.GetModuleFileNameExW(process,
-					null, filePath, filePath.length);
-			if (length == 0
-					&& Kernel32.INSTANCE.GetLastError() != WinNT.ERROR_INVALID_HANDLE)
-				throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-
-			return Native.toString(filePath).trim();
-		}
-
-		@Override
-		public Rectangle getWindowLocationAndSize(final HWND hwnd) {
-			final RECT lpRect = new RECT();
-			if (!User32.INSTANCE.GetWindowRect(hwnd, lpRect))
-				throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-
-			return new Rectangle(lpRect.left, lpRect.top, Math.abs(lpRect.right
-					- lpRect.left), Math.abs(lpRect.bottom - lpRect.top));
-		}
-	}
+        @Override
+        public BufferedImage getWindowIcon(final HWND hwnd) {
+            // request different kind of icons if any solution fails
+            final DWORDByReference hIconNumber = new DWORDByReference();
+            LRESULT result = User32.INSTANCE
+                .SendMessageTimeout(hwnd,
+                                    WinUser.WM_GETICON,
+                                    new WPARAM(WinUser.ICON_BIG),
+                                    new LPARAM(0),
+                                    WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
+            if (result.intValue() == 0)
+                result = User32.INSTANCE
+                    .SendMessageTimeout(hwnd,
+                                        WinUser.WM_GETICON,
+                                        new WPARAM(WinUser.ICON_SMALL),
+                                        new LPARAM(0),
+                                        WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
+            if (result.intValue() == 0)
+                result = User32.INSTANCE
+                    .SendMessageTimeout(hwnd,
+                                        WinUser.WM_GETICON,
+                                        new WPARAM(WinUser.ICON_SMALL2),
+                                        new LPARAM(0),
+                                        WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
+            if (result.intValue() == 0) {
+                result = new LRESULT(User32.INSTANCE
+                                     .GetClassLongPtr(hwnd,
+                                                      WinUser.GCLP_HICON).intValue());
+                hIconNumber.getValue().setValue(result.intValue());
+            }
+            if (result.intValue() == 0) {
+                result = new LRESULT(User32.INSTANCE
+                                     .GetClassLongPtr(hwnd,
+                                                      WinUser.GCLP_HICONSM).intValue());
+                hIconNumber.getValue().setValue(result.intValue());
+            }
+            if (result.intValue() == 0)
+                return null;
+            
+            // draw native icon into Java image
+            final HICON hIcon = new HICON(new Pointer(hIconNumber.getValue()
+                                                      .longValue()));
+            final Dimension iconSize = getIconSize(hIcon);
+            if (iconSize.width == 0 || iconSize.height == 0)
+                return null;
+            
+            final int width = iconSize.width;
+            final int height = iconSize.height;
+            final short depth = 24;
+            
+            final byte[] lpBitsColor = new byte[width * height * depth / 8];
+            final Pointer lpBitsColorPtr = new Memory(lpBitsColor.length);
+            final byte[] lpBitsMask = new byte[width * height * depth / 8];
+            final Pointer lpBitsMaskPtr = new Memory(lpBitsMask.length);
+            final BITMAPINFO bitmapInfo = new BITMAPINFO();
+            final BITMAPINFOHEADER hdr = new BITMAPINFOHEADER();
+            
+            bitmapInfo.bmiHeader = hdr;
+            hdr.biWidth = width;
+            hdr.biHeight = height;
+            hdr.biPlanes = 1;
+            hdr.biBitCount = depth;
+            hdr.biCompression = 0;
+            hdr.write();
+            bitmapInfo.write();
+            
+            final HDC hDC = User32.INSTANCE.GetDC(null);
+            final ICONINFO iconInfo = new ICONINFO();
+            User32.INSTANCE.GetIconInfo(hIcon, iconInfo);
+            iconInfo.read();
+            GDI32.INSTANCE.GetDIBits(hDC, iconInfo.hbmColor, 0, height,
+                                     lpBitsColorPtr, bitmapInfo, 0);
+            lpBitsColorPtr.read(0, lpBitsColor, 0, lpBitsColor.length);
+            GDI32.INSTANCE.GetDIBits(hDC, iconInfo.hbmMask, 0, height,
+                                     lpBitsMaskPtr, bitmapInfo, 0);
+            lpBitsMaskPtr.read(0, lpBitsMask, 0, lpBitsMask.length);
+            final BufferedImage image = new BufferedImage(width, height,
+                                                          BufferedImage.TYPE_INT_ARGB);
+            
+            int r, g, b, a, argb;
+            int x = 0, y = height - 1;
+            for (int i = 0; i < lpBitsColor.length; i = i + 3) {
+                b = lpBitsColor[i] & 0xFF;
+                g = lpBitsColor[i + 1] & 0xFF;
+                r = lpBitsColor[i + 2] & 0xFF;
+                a = 0xFF - lpBitsMask[i] & 0xFF;
+                argb = (a << 24) | (r << 16) | (g << 8) | b;
+                image.setRGB(x, y, argb);
+                x = (x + 1) % width;
+                if (x == 0)
+                    y--;
+            }
+            
+            User32.INSTANCE.ReleaseDC(null, hDC);
+            
+            return image;
+        }
+        
+        @Override
+        public Dimension getIconSize(final HICON hIcon) {
+            final ICONINFO iconInfo = new ICONINFO();
+            try {
+                if (!User32.INSTANCE.GetIconInfo(hIcon, iconInfo))
+                    return new Dimension();
+                iconInfo.read();
+                
+                final BITMAP bmp = new BITMAP();
+                if (iconInfo.hbmColor != null
+                    && iconInfo.hbmColor.getPointer() != Pointer.NULL) {
+                    final int nWrittenBytes = GDI32.INSTANCE.GetObject(
+                                                                       iconInfo.hbmColor, bmp.size(), bmp.getPointer());
+                    bmp.read();
+                    if (nWrittenBytes > 0)
+                        return new Dimension(bmp.bmWidth.intValue(),
+                                             bmp.bmHeight.intValue());
+                } else if (iconInfo.hbmMask != null
+                           && iconInfo.hbmMask.getPointer() != Pointer.NULL) {
+                    final int nWrittenBytes = GDI32.INSTANCE.GetObject(
+                                                                       iconInfo.hbmMask, bmp.size(), bmp.getPointer());
+                    bmp.read();
+                    if (nWrittenBytes > 0)
+                        return new Dimension(bmp.bmWidth.intValue(), bmp.bmHeight.intValue() / 2);
+                }
+            } finally {
+                if (iconInfo.hbmColor != null
+                    && iconInfo.hbmColor.getPointer() != Pointer.NULL)
+                    GDI32.INSTANCE.DeleteObject(iconInfo.hbmColor);
+                if (iconInfo.hbmMask != null
+                    && iconInfo.hbmMask.getPointer() != Pointer.NULL)
+                    GDI32.INSTANCE.DeleteObject(iconInfo.hbmMask);
+            }
+            
+            return new Dimension();
+        }
+        
+        @Override
+        public List<DesktopWindow> getAllWindows(final boolean onlyVisibleWindows) {
+            final List<DesktopWindow> result = new LinkedList<DesktopWindow>();
+            
+            final WNDENUMPROC lpEnumFunc = new WNDENUMPROC() {
+                @Override
+                public boolean callback(final HWND hwnd, final Pointer arg1) {
+                    try {
+                        final boolean visible = !onlyVisibleWindows
+                            || User32.INSTANCE.IsWindowVisible(hwnd);
+                        if (visible) {
+                            final String title = getWindowTitle(hwnd);
+                            final String filePath = getProcessFilePath(hwnd);
+                            final Rectangle locAndSize = getWindowLocationAndSize(hwnd);
+                            result.add(new DesktopWindow(hwnd, title, filePath,
+                                                         locAndSize));
+                        }
+                    } catch (final Exception e) {
+                        // FIXME properly handle whatever error is raised
+                        e.printStackTrace();
+                    }
+                    
+                    return true;
+                }
+            };
+            
+            if (!User32.INSTANCE.EnumWindows(lpEnumFunc, null))
+                throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+            
+            return result;
+        }
+        
+        @Override
+        public String getWindowTitle(final HWND hwnd) {
+            final int requiredLength = User32.INSTANCE
+                .GetWindowTextLength(hwnd) + 1;
+            final char[] title = new char[requiredLength];
+            final int length = User32.INSTANCE.GetWindowText(hwnd, title,
+                                                             title.length);
+            
+            return Native.toString(Arrays.copyOfRange(title, 0, length));
+        }
+        
+        @Override
+        public String getProcessFilePath(final HWND hwnd) {
+            final char[] filePath = new char[2048];
+            final IntByReference pid = new IntByReference();
+            User32.INSTANCE.GetWindowThreadProcessId(hwnd, pid);
+            
+            final HANDLE process = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION | WinNT.PROCESS_VM_READ,
+                                                                 false, pid.getValue());
+            if (process == null
+                && Kernel32.INSTANCE.GetLastError() != WinNT.ERROR_ACCESS_DENIED) {
+                throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+            }            
+            final int length = Psapi.INSTANCE.GetModuleFileNameExW(process,
+                                                                   null, filePath, filePath.length);
+            if (length == 0
+                && Kernel32.INSTANCE.GetLastError() != WinNT.ERROR_INVALID_HANDLE) {
+                throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+            }            
+            return Native.toString(filePath).trim();
+        }
+        
+        @Override
+        public Rectangle getWindowLocationAndSize(final HWND hwnd) {
+            final RECT lpRect = new RECT();
+            if (!User32.INSTANCE.GetWindowRect(hwnd, lpRect))
+                throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+            
+            return new Rectangle(lpRect.left, lpRect.top, Math.abs(lpRect.right
+                                                                   - lpRect.left), Math.abs(lpRect.bottom - lpRect.top));
+        }
+    }
 
     private static class MacWindowUtils extends NativeWindowUtils {
         public boolean isWindowAlphaSupported() {
@@ -1497,6 +1510,7 @@ public class WindowUtils {
                 return ((Number)o).longValue();
             }
             catch (Exception e) {
+                // FIXME properly handle this error
                 e.printStackTrace();
                 return -1;
             }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -50,7 +50,7 @@ import static com.sun.jna.platform.win32.WinNT.PRIVILEGE_SET;
  */
 public interface Advapi32 extends StdCallLibrary {
 	Advapi32 INSTANCE = (Advapi32) Native.loadLibrary("Advapi32",
-			Advapi32.class, W32APIOptions.UNICODE_OPTIONS);
+			Advapi32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	public static final int MAX_KEY_LENGTH = 255;
 	public static final int MAX_VALUE_NAME = 16383;
@@ -1581,6 +1581,10 @@ public interface Advapi32 extends StdCallLibrary {
 	 *            otherwise, none of the descriptor is returned.
 	 * @return whether the call succeeded
 	 */
+	public boolean GetFileSecurity(String lpFileName,
+			int RequestedInformation, Pointer pointer, int nLength,
+			IntByReference lpnLengthNeeded);
+        /** @deprecated Use the String version */
 	public boolean GetFileSecurity(WString lpFileName,
 			int RequestedInformation, Pointer pointer, int nLength,
 			IntByReference lpnLengthNeeded);
@@ -1796,6 +1800,8 @@ public interface Advapi32 extends StdCallLibrary {
 	 * function fails, the return value is zero. To get extended error
 	 * information, call GetLastError.
 	 */
+	public boolean EncryptFile(String lpFileName);
+        /** @deprecated Use the String version */
 	public boolean EncryptFile(WString lpFileName);
 
 	/**
@@ -1809,6 +1815,8 @@ public interface Advapi32 extends StdCallLibrary {
 	 * function fails, the return value is zero. To get extended error
 	 * information, call GetLastError.
 	 */
+	public boolean DecryptFile(String lpFileName, DWORD dwReserved);
+        /** @deprecated Use the String version */
 	public boolean DecryptFile(WString lpFileName, DWORD dwReserved);
 
 	/**
@@ -1823,6 +1831,8 @@ public interface Advapi32 extends StdCallLibrary {
 	 * function fails, the return value is zero. To get extended error
 	 * information, call GetLastError.
 	 */
+	public boolean FileEncryptionStatus(String lpFileName, DWORDByReference lpStatus);
+        /** @deprecated Use the String version */
 	public boolean FileEncryptionStatus(WString lpFileName, DWORDByReference lpStatus);
 
 	/**
@@ -1840,6 +1850,8 @@ public interface Advapi32 extends StdCallLibrary {
 	 * function fails, the return value is zero. To get extended error
 	 * information, call GetLastError.
 	 */
+	public boolean EncryptionDisable(String DirPath, boolean Disable);
+        /** @deprecated Use the String version */
 	public boolean EncryptionDisable(WString DirPath, boolean Disable);
 
 	/**
@@ -1862,8 +1874,11 @@ public interface Advapi32 extends StdCallLibrary {
 	 * FormatMessage with the FORMAT_MESSAGE_FROM_SYSTEM flag to get a generic
 	 * text description of the error.
 	 */
+	public int OpenEncryptedFileRaw(String lpFileName, ULONG ulFlags,
+                                        PointerByReference pvContext);
+        /** @deprecated Use the String version */
 	public int OpenEncryptedFileRaw(WString lpFileName, ULONG ulFlags,
-                                  PointerByReference pvContext);
+                                        PointerByReference pvContext);
 
 	/**
 	 * Backs up (export) encrypted files. This is one of a group of Encrypted File

--- a/contrib/platform/src/com/sun/jna/platform/win32/BaseTSD.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/BaseTSD.java
@@ -15,18 +15,18 @@ package com.sun.jna.platform.win32;
 import com.sun.jna.IntegerType;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.ByReference;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
 * Based on basetsd.h (various types)
 * @author dblock[at]dblock[dot]org
 */
 @SuppressWarnings("serial")
-public interface BaseTSD extends StdCallLibrary {
+public interface BaseTSD {
+
     /**
-* Signed long type for pointer precision.
-* Use when casting a pointer to a long to perform pointer arithmetic.
-*/
+     * Signed long type for pointer precision.
+     * Use when casting a pointer to a long to perform pointer arithmetic.
+     */
     public static class LONG_PTR extends IntegerType {
         public LONG_PTR() {
             this(0);

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
@@ -520,7 +520,7 @@ public class TypeLibUtil {
      * 
      * @return the help context
      */
-    public long getHelpContext() {
+    public int getHelpContext() {
         return helpContext;
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
@@ -28,7 +28,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface Crypt32 extends StdCallLibrary {
 	
 	Crypt32 INSTANCE = (Crypt32) Native.loadLibrary("Crypt32",
-			Crypt32.class, W32APIOptions.UNICODE_OPTIONS);
+			Crypt32.class, W32APIOptions.DEFAULT_OPTIONS);
 	
 	/**
 	 * The CryptProtectData function performs encryption on the data in a DATA_BLOB

--- a/contrib/platform/src/com/sun/jna/platform/win32/DBT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/DBT.java
@@ -22,7 +22,6 @@ import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.WinDef.LONG;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinUser.HDEVNOTIFY;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Based on dbt.h (various types)
@@ -30,7 +29,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * @author Tobias Wolf, wolf.tobias@gmx.net
  */
 @SuppressWarnings("serial")
-public interface DBT extends StdCallLibrary {
+public interface DBT {
 
     /** The dbt no disk space. */
     int DBT_NO_DISK_SPACE = 0x0047;

--- a/contrib/platform/src/com/sun/jna/platform/win32/DsGetDC.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/DsGetDC.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.win32.StdCallLibrary;
@@ -27,7 +26,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * 
  * @author dblock[at]dblock.org
  */
-public interface DsGetDC extends StdCallLibrary {
+public interface DsGetDC {
 
     /**
      * The DOMAIN_CONTROLLER_INFO structure is used with the DsGetDcName
@@ -48,7 +47,7 @@ public interface DsGetDC extends StdCallLibrary {
         }
 
         /**
-         * Pointer to a null-terminated WString that specifies the computer name
+         * Pointer to a null-terminated string that specifies the computer name
          * of the discovered domain controller. The returned computer name is
          * prefixed with "\\". The DNS-style name, for example,
          * "\\phoenix.fabrikam.com", is returned, if available. If the DNS-style
@@ -57,16 +56,16 @@ public interface DsGetDC extends StdCallLibrary {
          * 4.0 domain or if the domain does not support the IP family of
          * protocols.
          */
-        public WString DomainControllerName;
+        public String DomainControllerName;
         /**
-         * Pointer to a null-terminated WString that specifies the address of
+         * Pointer to a null-terminated string that specifies the address of
          * the discovered domain controller. The address is prefixed with "\\".
-         * This WString is one of the types defined by the
+         * This string is one of the types defined by the
          * DomainControllerAddressType member.
          */
-        public WString DomainControllerAddress;
+        public String DomainControllerAddress;
         /**
-         * Indicates the type of WString that is contained in the
+         * Indicates the type of string that is contained in the
          * DomainControllerAddress member.
          */
         public int DomainControllerAddressType;
@@ -77,40 +76,40 @@ public interface DsGetDC extends StdCallLibrary {
          */
         public GUID DomainGuid;
         /**
-         * Pointer to a null-terminated WString that specifies the name of the
+         * Pointer to a null-terminated string that specifies the name of the
          * domain. The DNS-style name, for example, "fabrikam.com", is returned
          * if available. Otherwise, the flat-style name, for example,
          * "fabrikam", is returned. This name may be different than the
          * requested domain name if the domain has been renamed.
          */
-        public WString DomainName;
+        public String DomainName;
         /**
-         * Pointer to a null-terminated WString that specifies the name of the
+         * Pointer to a null-terminated string that specifies the name of the
          * domain at the root of the DS tree. The DNS-style name, for example,
          * "fabrikam.com", is returned if available. Otherwise, the flat-style
          * name, for example, "fabrikam" is returned.
          */
-        public WString DnsForestName;
+        public String DnsForestName;
         /**
          * Contains a set of flags that describe the domain controller.
          */
         public int Flags;
         /**
-         * Pointer to a null-terminated WString that specifies the name of the
+         * Pointer to a null-terminated string that specifies the name of the
          * site where the domain controller is located. This member may be NULL
          * if the domain controller is not in a site; for example, the domain
          * controller is a Windows NT 4.0 domain controller.
          */
-        public WString DcSiteName;
+        public String DcSiteName;
         /**
-         * Pointer to a null-terminated WString that specifies the name of the
+         * Pointer to a null-terminated string that specifies the name of the
          * site that the computer belongs to. The computer is specified in the
          * ComputerName parameter passed to DsGetDcName. This member may be NULL
          * if the site that contains the computer cannot be found; for example,
          * if the DS administrator has not associated the subnet that the
          * computer is in with a valid site.
          */
-        public WString ClientSiteName;
+        public String ClientSiteName;
 
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "DomainControllerName",
@@ -182,12 +181,12 @@ public interface DsGetDC extends StdCallLibrary {
          * Pointer to a null-terminated string that contains the NetBIOS name of
          * the domain.
          */
-        public WString NetbiosDomainName;
+        public String NetbiosDomainName;
         /**
          * Pointer to a null-terminated string that contains the DNS name of the
          * domain. This member may be NULL.
          */
-        public WString DnsDomainName;
+        public String DnsDomainName;
         /**
          * Contains a set of flags that specify more data about the domain
          * trust.

--- a/contrib/platform/src/com/sun/jna/platform/win32/GL.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/GL.java
@@ -12,12 +12,10 @@
  */
 package com.sun.jna.platform.win32;
 
-import com.sun.jna.win32.StdCallLibrary;
-
 /**
  * Definitions for WinOpenGL
  */
-public interface GL extends StdCallLibrary {
+public interface GL {
     public final int GL_VENDOR = 0x1F00;
     public final int GL_RENDERER = 0x1F01;
     public final int GL_VERSION = 0x1F02;

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -18,17 +18,18 @@ import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.W32APIOptions;
+import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Interface definitions for <code>kernel32.dll</code>. Includes additional
  * alternate mappings from {@link WinNT} which make use of NIO buffers,
  * {@link Wincon} for console API.
  */
-public interface Kernel32 extends WinNT, Wincon {
+public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
 
     /** The instance. */
     Kernel32 INSTANCE = (Kernel32) Native.loadLibrary("kernel32",
-            Kernel32.class, W32APIOptions.UNICODE_OPTIONS);
+            Kernel32.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Reads data from the specified file or input/output (I/O) device. Reads

--- a/contrib/platform/src/com/sun/jna/platform/win32/LMAccess.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/LMAccess.java
@@ -17,16 +17,14 @@ import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinNT.PSID;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from LMAccess.h.
  * Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  */
-public interface LMAccess extends StdCallLibrary {
+public interface LMAccess {
 	
     public static class LOCALGROUP_INFO_0 extends Structure {
         public LOCALGROUP_INFO_0() {
@@ -38,7 +36,7 @@ public interface LMAccess extends StdCallLibrary {
             read();
         }
                     
-        public WString lgrui0_name;
+        public String lgrui0_name;
         
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "lgrui0_name" });
@@ -55,8 +53,8 @@ public interface LMAccess extends StdCallLibrary {
             read();
         }
 
-        public WString lgrui1_name;
-        public WString lgrui1_comment;
+        public String lgrui1_name;
+        public String lgrui1_comment;
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "lgrui1_name", "lgrui1_comment" });
         }
@@ -89,7 +87,7 @@ public interface LMAccess extends StdCallLibrary {
         /**
          * Pointer to a Unicode string that specifies the name of the user account. 
          */
-        public WString usri0_name;
+        public String usri0_name;
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "usri0_name" });
         }
@@ -114,12 +112,12 @@ public interface LMAccess extends StdCallLibrary {
          * Pointer to a Unicode string that specifies the name of the user 
          * account.
          */
-        public WString usri1_name;
+        public String usri1_name;
         /**
          * Pointer to a Unicode string that specifies the password of the user
          * indicated by the usri1_name member. 
          */
-        public WString usri1_password;
+        public String usri1_password;
         /**
          * Specifies a DWORD value that indicates the number of seconds that have 
          * elapsed since the usri1_password member was last changed.
@@ -134,12 +132,12 @@ public interface LMAccess extends StdCallLibrary {
          * Pointer to a Unicode string specifying the path of the home directory 
          * for the user specified in the usri1_name member. 
          */
-        public WString usri1_home_dir;
+        public String usri1_home_dir;
         /**
          * Pointer to a Unicode string that contains a comment to associate with 
          * the user account.
          */
-        public WString usri1_comment;
+        public String usri1_comment;
         /**
          * Specifies a DWORD value that determines several features.
          */
@@ -148,7 +146,7 @@ public interface LMAccess extends StdCallLibrary {
          * Pointer to a Unicode string specifying the path for the user's 
          * logon script file. 
          */
-        public WString usri1_script_path;
+        public String usri1_script_path;
 
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "usri1_name", "usri1_password", "usri1_password_age", "usri1_priv", "usri1_home_dir", "usri1_comment", "usri1_flags", "usri1_script_path" });
@@ -178,17 +176,17 @@ public interface LMAccess extends StdCallLibrary {
          * A pointer to a Unicode string that specifies the name of the user account. 
          * Calls to the NetUserSetInfo function ignore this member.
          */
-        public WString usri23_name;
+        public String usri23_name;
         /** 
          * A pointer to a Unicode string that contains the full name of the user. 
          * This string can be a null string, or it can have any number of characters before the terminating null character.
          */
-        public WString usri23_full_name;
+        public String usri23_full_name;
         /** 
          * A pointer to a Unicode string that contains a comment associated with the user account. 
          * This string can be a null string, or it can have any number of characters before the terminating null character.
          */
-        public WString usri23_comment;
+        public String usri23_comment;
         /** 
          * This member can be one or more of the following values. 
          * Note that setting user account control flags may require certain privileges and control access rights. 
@@ -246,7 +244,7 @@ public interface LMAccess extends StdCallLibrary {
         /**
          * Pointer to a null-terminated Unicode character string that specifies a name. 
          */
-        public WString grui0_name;
+        public String grui0_name;
         
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "grui0_name" });
@@ -269,7 +267,7 @@ public interface LMAccess extends StdCallLibrary {
         /**
          * Pointer to a Unicode string specifying the name of a local group to which the user belongs. 
          */
-        public WString lgrui0_name;
+        public String lgrui0_name;
         
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "lgrui0_name" });
@@ -295,7 +293,7 @@ public interface LMAccess extends StdCallLibrary {
          * Pointer to a null-terminated Unicode character string that specifies 
          * the name of the global group.
          */
-        public WString grpi0_name;
+        public String grpi0_name;
         
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "grpi0_name" });
@@ -320,13 +318,13 @@ public interface LMAccess extends StdCallLibrary {
          * Pointer to a null-terminated Unicode character string that specifies 
          * the name of the global group. 
          */
-        public WString grpi1_name;
+        public String grpi1_name;
         /**
          * Pointer to a null-terminated Unicode character string that specifies 
          * a remark associated with the global group. This member can be a null 
          * string. The comment can contain MAXCOMMENTSZ characters. 
          */
-        public WString grpi1_comment;
+        public String grpi1_comment;
 
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "grpi1_name", "grpi1_comment" });
@@ -351,13 +349,13 @@ public interface LMAccess extends StdCallLibrary {
          * Pointer to a null-terminated Unicode character string that 
          * specifies the name of the global group.
          */
-        public WString grpi2_name;
+        public String grpi2_name;
         /**
          * Pointer to a null-terminated Unicode character string that contains a 
          * remark associated with the global group. This member can be a null string. 
          * The comment can contain MAXCOMMENTSZ characters. 
          */
-        public WString grpi2_comment;
+        public String grpi2_comment;
         /**
          * Specifies a DWORD value that contains the relative identifier (RID) of 
          * the global group.
@@ -392,13 +390,13 @@ public interface LMAccess extends StdCallLibrary {
          * Pointer to a null-terminated Unicode character string that 
          * specifies the name of the global group. 
          */
-        public WString grpi3_name;
+        public String grpi3_name;
         /**
          * Pointer to a null-terminated Unicode character string that 
          * contains a remark associated with the global group. This member can be 
          * a null string. The comment can contain MAXCOMMENTSZ characters. 
          */
-        public WString grpi3_comment;
+        public String grpi3_comment;
         /**
          * Pointer to a SID structure that contains the security identifier (SID) that 
          * uniquely identifies the global group.

--- a/contrib/platform/src/com/sun/jna/platform/win32/LMCons.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/LMCons.java
@@ -12,14 +12,12 @@
  */
 package com.sun.jna.platform.win32;
 
-import com.sun.jna.win32.StdCallLibrary;
-
 /**
  * Ported from LMCons.h.
  * @author dblock[at]dblock.org
  * Windows SDK 6.0A
  */
-public interface LMCons extends StdCallLibrary {
+public interface LMCons {
     int  NETBIOS_NAME_LEN = 16;            // NetBIOS net name (bytes)
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/LMErr.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/LMErr.java
@@ -12,14 +12,12 @@
  */
 package com.sun.jna.platform.win32;
 
-import com.sun.jna.win32.StdCallLibrary;
-
 /**
  * Ported from LMErr.h.
  * @author dblock[at]dblock.org
  * Windows SDK 6.0A
  */
-public interface LMErr extends StdCallLibrary {
+public interface LMErr {
     int NERR_Success =  0;
     int NERR_BASE =  2100;
     

--- a/contrib/platform/src/com/sun/jna/platform/win32/LMJoin.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/LMJoin.java
@@ -12,14 +12,12 @@
  */
 package com.sun.jna.platform.win32;
 
-import com.sun.jna.win32.StdCallLibrary;
-
 /**
  * Ported from LMJoin.h.
  * Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  */
-public interface LMJoin extends StdCallLibrary {
+public interface LMJoin {
 
     /**
      * Status of a workstation.

--- a/contrib/platform/src/com/sun/jna/platform/win32/LMShare.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/LMShare.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.WString;
 import com.sun.jna.win32.StdCallLibrary;
 
 /**
@@ -25,7 +24,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * Windows SDK 7.1
  * @author amarcionek[at]seven10storage.com
  */
-public interface LMShare extends StdCallLibrary {
+public interface LMShare {
 
     //
     // Share types (shi1_type and shi2_type fields).
@@ -78,7 +77,7 @@ public interface LMShare extends StdCallLibrary {
         /**
          * Pointer to a Unicode string specifying the name of a shared resource. Calls to the NetShareSetInfo function ignore this member.
          */
-        public WString shi2_netname;
+        public String shi2_netname;
 
         /**
          * A combination of values that specify the type of share. Calls to the NetShareSetInfo function ignore this member.
@@ -90,7 +89,7 @@ public interface LMShare extends StdCallLibrary {
         /**
          * Pointer to a Unicode string specifying an optional comment about the shared resource.
          */
-        public WString shi2_remark;
+        public String shi2_remark;
 
         /**
          * Specifies a DWORD value that indicates the shared resource's permissions for servers running with share-level security.
@@ -116,14 +115,14 @@ public interface LMShare extends StdCallLibrary {
          * Pointer to a Unicode string that contains the local path for the shared resource. For disks, this member is the path being shared.
          * For print queues, this member is the name of the print queue being shared. Calls to the NetShareSetInfo function ignore this member.
          */
-        public WString shi2_path;
+        public String shi2_path;
 
         /**
          * Pointer to a Unicode string that specifies the share's password (when the server is running with share-level security). If the server is
          * running with user-level security, this member is ignored. Note that Windows does not support share-level security.
          * This member can be no longer than SHPWLEN+1 bytes (including a terminating null character). Calls to the NetShareSetInfo function ignore this member.
          */
-        public WString shi2_passwd;
+        public String shi2_passwd;
         
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "shi2_netname",
@@ -153,7 +152,7 @@ public interface LMShare extends StdCallLibrary {
         /**
          * Pointer to a Unicode string specifying the name of a shared resource. Calls to the NetShareSetInfo function ignore this member.
          */
-        public WString shi502_netname;
+        public String shi502_netname;
 
         /**
          * A combination of values that specify the type of share. Calls to the NetShareSetInfo function ignore this member.
@@ -165,7 +164,7 @@ public interface LMShare extends StdCallLibrary {
         /**
          * Pointer to a Unicode string specifying an optional comment about the shared resource.
          */
-        public WString shi502_remark;
+        public String shi502_remark;
 
         /**
          * Specifies a DWORD value that indicates the shared resource's permissions for servers running with share-level security.
@@ -191,14 +190,14 @@ public interface LMShare extends StdCallLibrary {
          * Pointer to a Unicode string that contains the local path for the shared resource. For disks, this member is the path being shared.
          * For print queues, this member is the name of the print queue being shared. Calls to the NetShareSetInfo function ignore this member.
          */
-        public WString shi502_path;
+        public String shi502_path;
 
         /**
          * Pointer to a Unicode string that specifies the share's password (when the server is running with share-level security). If the server is
          * running with user-level security, this member is ignored. Note that Windows does not support share-level security.
          * This member can be no longer than SHPWLEN+1 bytes (including a terminating null character). Calls to the NetShareSetInfo function ignore this member.
          */
-        public WString shi502_passwd;
+        public String shi502_passwd;
 
         /**
          * Reserved; must be zero. Calls to the NetShareSetInfo function ignore this member.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Mpr.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Mpr.java
@@ -16,7 +16,6 @@ package com.sun.jna.platform.win32;
 
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
@@ -34,7 +33,7 @@ import com.sun.jna.win32.W32APIOptions;
 
 public interface Mpr extends StdCallLibrary {
 
-    Mpr INSTANCE = (Mpr) Native.loadLibrary("Mpr", Mpr.class, W32APIOptions.UNICODE_OPTIONS);
+    Mpr INSTANCE = (Mpr) Native.loadLibrary("Mpr", Mpr.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The WNetOpenEnum function starts an enumeration of network resources or
@@ -182,7 +181,7 @@ public interface Mpr extends StdCallLibrary {
      *         https://msdn.microsoft.com/en-us/library/windows/desktop/aa385474
      *         (v=vs.85).aspx
      */
-    int WNetGetUniversalName(WString lpLocalPath, int dwInfoLevel, Pointer lpBuffer, IntByReference lpBufferSize);
+    int WNetGetUniversalName(String lpLocalPath, int dwInfoLevel, Pointer lpBuffer, IntByReference lpBufferSize);
 
     /**
      * The WNetUseConnection function makes a connection to a network resource.
@@ -299,7 +298,7 @@ public interface Mpr extends StdCallLibrary {
      *         https://msdn.microsoft.com/en-us/library/windows/desktop/aa385482
      *         (v=vs.85).aspx
      */
-    public int WNetUseConnection(HWND hwndOwner, NETRESOURCE lpNETRESOURCE, WString lpPassword, WString lpUserID, int dwFlags,
+    public int WNetUseConnection(HWND hwndOwner, NETRESOURCE lpNETRESOURCE, String lpPassword, String lpUserID, int dwFlags,
             PointerByReference lpAccessName, IntByReference lpBufferSize, IntByReference lpResult);
 
     /**
@@ -380,7 +379,7 @@ public interface Mpr extends StdCallLibrary {
      *            [in] Set of bit flags describing the connection. This
      *            parameter can be any combination of the values in ConnectFlag.
      */
-    public int WNetAddConnection3(HWND hwndOwner, NETRESOURCE lpNETRESOURCE, WString lpPassword, WString lpUserID, int dwFlags);
+    public int WNetAddConnection3(HWND hwndOwner, NETRESOURCE lpNETRESOURCE, String lpPassword, String lpUserID, int dwFlags);
 
     /**
      * The WNetCancelConnection2 function cancels an existing network
@@ -417,5 +416,5 @@ public interface Mpr extends StdCallLibrary {
      *         https://msdn.microsoft.com/en-us/library/windows/desktop/aa385482
      *         (v=vs.85).aspx
      */
-    public int WNetCancelConnection2(WString lpName, int dwFlags, boolean fForce);
+    public int WNetCancelConnection2(String lpName, int dwFlags, boolean fForce);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Msi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Msi.java
@@ -21,7 +21,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface Msi extends StdCallLibrary {
 
     Msi INSTANCE = (Msi)
-        Native.loadLibrary("msi", Msi.class, W32APIOptions.UNICODE_OPTIONS);
+        Native.loadLibrary("msi", Msi.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The component being requested is disabled on the computer.

--- a/contrib/platform/src/com/sun/jna/platform/win32/NTSecApi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/NTSecApi.java
@@ -21,14 +21,13 @@ import com.sun.jna.Structure;
 import com.sun.jna.Union;
 import com.sun.jna.platform.win32.WinNT.LARGE_INTEGER;
 import com.sun.jna.platform.win32.WinNT.PSID;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from NTSecApi.h
  * Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  */
-public interface NTSecApi extends StdCallLibrary {
+public interface NTSecApi {
 	
     /**
      * The LSA_UNICODE_STRING structure is used by various Local Security Authority (LSA) 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Netapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Netapi32.java
@@ -15,7 +15,6 @@ package com.sun.jna.platform.win32;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.DsGetDC.PDOMAIN_CONTROLLER_INFO;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.NTSecApi.PLSA_FOREST_TRUST_INFORMATION;
@@ -31,7 +30,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface Netapi32 extends StdCallLibrary {
 	
 	Netapi32 INSTANCE = (Netapi32) Native.loadLibrary("Netapi32",
-			Netapi32.class, W32APIOptions.UNICODE_OPTIONS);
+			Netapi32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * Retrieves join status information for the specified computer.
@@ -451,7 +450,7 @@ public interface Netapi32 extends StdCallLibrary {
      *  index is not returned on error. For more information, see the NetShareSetInfo function.
      * @return If the function succeeds, the return value is NERR_Success. If the function fails, the return value can be an error code as seen on MSDN.
      */
-    public int NetShareAdd(WString servername, int level, Pointer buf, IntByReference parm_err);
+    public int NetShareAdd(String servername, int level, Pointer buf, IntByReference parm_err);
 
     /**
      * Deletes a share name from a server's list of shared resources, disconnecting all connections to the shared resource.
@@ -466,5 +465,5 @@ public interface Netapi32 extends StdCallLibrary {
      * @return If the function succeeds, the return value is LMErr.NERR_Success.
      *  If the function fails, the return value can be an error code as seen on MSDN.
      */
-    public int NetShareDel(WString servername, WString netname, int reserved);
+    public int NetShareDel(String servername, String netname, int reserved);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/NtDll.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/NtDll.java
@@ -26,7 +26,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface NtDll extends StdCallLibrary {
 	
 	NtDll INSTANCE = (NtDll) Native.loadLibrary("NtDll",
-			NtDll.class, W32APIOptions.UNICODE_OPTIONS);
+			NtDll.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * The ZwQueryKey routine provides information about the class of a registry key, 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
@@ -34,7 +34,7 @@ public interface Ole32 extends StdCallLibrary {
 
     /** The instance. */
     Ole32 INSTANCE = (Ole32) Native.loadLibrary("Ole32", Ole32.class,
-                                                W32APIOptions.UNICODE_OPTIONS);
+                                                W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Creates a GUID, a unique 128-bit integer used for CLSIDs and interface
@@ -217,6 +217,8 @@ public interface Ole32 extends StdCallLibrary {
      * 
      *         REGDB_E_READREGDB The registry could not be opened for reading.
      */
+    HRESULT CLSIDFromString(String lpsz, CLSID.ByReference pclsid);
+    /** @deprecated use the String version */
     HRESULT CLSIDFromString(WString lpsz, CLSID.ByReference pclsid);
 
 	/**

--- a/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
@@ -100,7 +100,7 @@ public interface OleAuto extends StdCallLibrary {
 
 	/** The instance. */
 	OleAuto INSTANCE = (OleAuto) Native.loadLibrary("OleAut32", OleAuto.class,
-			W32APIOptions.UNICODE_OPTIONS);
+			W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * This function allocates a new string and copies the passed string into
@@ -473,6 +473,8 @@ public interface OleAuto extends StdCallLibrary {
 	 *            loaded.
          * @return status
 	 */
+	public HRESULT LoadTypeLib(String szFile, PointerByReference pptlib);
+        /** @deprecated use the String version */
 	public HRESULT LoadTypeLib(WString szFile, PointerByReference pptlib);
 
 	/**

--- a/contrib/platform/src/com/sun/jna/platform/win32/Pdh.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Pdh.java
@@ -33,7 +33,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Pdh extends StdCallLibrary {
     Pdh INSTANCE = (Pdh) Native.loadLibrary("Pdh",
-            Pdh.class, W32APIOptions.UNICODE_OPTIONS);
+            Pdh.class, W32APIOptions.DEFAULT_OPTIONS);
 
 
     /** Maximum counter name length. */

--- a/contrib/platform/src/com/sun/jna/platform/win32/Rasapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Rasapi32.java
@@ -33,7 +33,7 @@ import com.sun.jna.win32.W32APIOptions;
  * Rasapi32.dll Interface.
  */
 public interface Rasapi32 extends StdCallLibrary {
-	Rasapi32 INSTANCE = (Rasapi32) Native.loadLibrary("Rasapi32", Rasapi32.class, W32APIOptions.UNICODE_OPTIONS);
+	Rasapi32 INSTANCE = (Rasapi32) Native.loadLibrary("Rasapi32", Rasapi32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * The RasDial function establishes a RAS connection between a RAS client and a RAS server.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
@@ -30,7 +30,7 @@ import com.sun.jna.win32.W32APIOptions;
  * @author dblock[at]dblock.org
  */
 public interface Secur32 extends StdCallLibrary {
-    Secur32 INSTANCE = (Secur32) Native.loadLibrary("Secur32", Secur32.class, W32APIOptions.UNICODE_OPTIONS);
+    Secur32 INSTANCE = (Secur32) Native.loadLibrary("Secur32", Secur32.class, W32APIOptions.DEFAULT_OPTIONS);
 	
     /**
      * Specifies a format for a directory service object name.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
@@ -30,7 +30,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface Shell32 extends ShellAPI, StdCallLibrary {
 	
     Shell32 INSTANCE = (Shell32) Native.loadLibrary("shell32", Shell32.class, 
-    		W32APIOptions.UNICODE_OPTIONS);
+    		W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * No dialog box confirming the deletion of the objects will be displayed.

--- a/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
@@ -19,7 +19,6 @@ import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.TypeMapper;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.HINSTANCE;
 import com.sun.jna.platform.win32.WinDef.HWND;
@@ -39,7 +38,7 @@ import com.sun.jna.win32.W32APITypeMapper;
 public interface ShellAPI extends StdCallLibrary {
 
     int STRUCTURE_ALIGNMENT = Platform.is64Bit() ? Structure.ALIGN_DEFAULT : Structure.ALIGN_NONE;
-	TypeMapper TYPE_MAPPER = Boolean.getBoolean("w32.ascii") ? W32APITypeMapper.ASCII : W32APITypeMapper.UNICODE;
+    TypeMapper TYPE_MAPPER = Boolean.getBoolean("w32.ascii") ? W32APITypeMapper.ASCII : W32APITypeMapper.UNICODE;
 	
     int FO_MOVE = 0x0001;
     int FO_COPY = 0x0002;
@@ -85,11 +84,11 @@ public interface ShellAPI extends StdCallLibrary {
         /**
          * A pointer to one or more source file names, double null-terminated. 
          */
-        public WString pFrom;
+        public String pFrom;
         /**
          * A pointer to the destination file or directory name.
          */
-        public WString pTo;
+        public String pTo;
         /**
          * Flags that control the file operation.
          */
@@ -110,7 +109,7 @@ public interface ShellAPI extends StdCallLibrary {
         /**
          * A pointer to the title of a progress dialog box. This is a null-terminated string. 
          */
-        public WString lpszProgressTitle;
+        public String lpszProgressTitle;
         
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "hwnd", "wFunc", "pFrom", "pTo", "fFlags", "fAnyOperationsAborted", "pNameMappings", "lpszProgressTitle" });

--- a/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
@@ -18,15 +18,13 @@ import java.util.List;
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.WString;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from Sspi.h.
  * Microsoft Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  */
-public interface Sspi extends StdCallLibrary {
+public interface Sspi {
 
     /**
      * Maximum size in bytes of a security token.
@@ -431,12 +429,12 @@ public interface Sspi extends StdCallLibrary {
         /**
          * Pointer to a null-terminated string that contains the name of the security package.
          */
-        public WString Name;
+        public String Name;
         /**
          * Pointer to a null-terminated string. This can be any additional string passed 
          * back by the package. 
          */
-        public WString Comment;
+        public String Comment;
 		
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "fCapabilities", "wVersion", "wRPCID", "cbMaxToken", "Name", "Comment" }); 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Tlhelp32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Tlhelp32.java
@@ -15,12 +15,11 @@ import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Interface for the Tlhelp32.h header file.
  */
-public interface Tlhelp32 extends StdCallLibrary {
+public interface Tlhelp32 {
 
     /**
      * Includes all heaps of the process specified in th32ProcessID in the snapshot. To enumerate the heaps, see

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32.java
@@ -1303,6 +1303,8 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
      *         If the function fails, the return value is zero. To get extended
      *         error information, call {@link Kernel32#GetLastError}.
      */
+    public boolean UnregisterClass(String lpClassName, HINSTANCE hInstance);
+    /** @deprecated use the String version */
     public boolean UnregisterClass(WString lpClassName, HINSTANCE hInstance);
 
     /**
@@ -1471,6 +1473,11 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
      *         WM_NCCREATE</li>
      *         </ul>
      */
+    public HWND CreateWindowEx(int dwExStyle, String lpClassName,
+                               String lpWindowName, int dwStyle, int x, int y, int nWidth,
+                               int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance,
+                               LPVOID lpParam);
+    /** @deprecated use the String version */
     public HWND CreateWindowEx(int dwExStyle, WString lpClassName,
                                String lpWindowName, int dwStyle, int x, int y, int nWidth,
                                int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance,
@@ -1537,7 +1544,7 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
      *         If the function fails, the return value is zero. To get extended
      *         error information, call {@link Kernel32#GetLastError} .
      */
-    public boolean GetClassInfoEx(HINSTANCE hinst, WString lpszClass,
+    public boolean GetClassInfoEx(HINSTANCE hinst, String lpszClass,
                                   WNDCLASSEX lpwcx);
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32.java
@@ -1980,7 +1980,7 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
 	 *         Windows 2000: If {@link Kernel32#GetLastError()} returns 0, then
 	 *         the function timed out.
 	 */
-	long SendMessageTimeout(HWND hWnd, int msg, long wParam, long lParam,
+        LRESULT SendMessageTimeout(HWND hWnd, int msg, WPARAM wParam, LPARAM lParam,
 			int fuFlags, int uTimeout, DWORDByReference lpdwResult);
 
 	/**
@@ -2006,7 +2006,7 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
 	 *         If the function fails, the return value is zero. To get extended
 	 *         error information, call {@link Kernel32#GetLastError()}.</p>
 	 */
-	long GetClassLongPtr(HWND hWnd, int nIndex);
+	ULONG_PTR GetClassLongPtr(HWND hWnd, int nIndex);
 
 	/**
 	 * @param pRawInputDeviceList

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32Util.java
@@ -12,7 +12,6 @@ package com.sun.jna.platform.win32;
 import java.util.Arrays;
 import java.util.List;
 
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinDef.HINSTANCE;
 import com.sun.jna.platform.win32.WinDef.HMENU;
 import com.sun.jna.platform.win32.WinDef.HWND;
@@ -43,7 +42,7 @@ public final class User32Util {
     public static final HWND createWindowEx(final int exStyle, final String className, final String windowName, final int style, final int x, final int y,
             final int width, final int height, final HWND parent, final HMENU menu, final HINSTANCE instance, final LPVOID param) {
         final HWND hWnd = User32.INSTANCE
-                .CreateWindowEx(exStyle, new WString(className), windowName, style, x, y, width, height, parent, menu, instance, param);
+                .CreateWindowEx(exStyle, className, windowName, style, x, y, width, height, parent, menu, instance, param);
         if (hWnd == null)
             throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
         return hWnd;

--- a/contrib/platform/src/com/sun/jna/platform/win32/VerRsrc.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/VerRsrc.java
@@ -15,12 +15,11 @@ import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Interface for the VerRsrc.h header file.
  */
-public interface VerRsrc extends StdCallLibrary {
+public interface VerRsrc {
 
     /**
      * Contains version information for a file. This information is language and code page independent.

--- a/contrib/platform/src/com/sun/jna/platform/win32/W32FileUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/W32FileUtils.java
@@ -15,7 +15,6 @@ package com.sun.jna.platform.win32;
 import java.io.File;
 import java.io.IOException;
 
-import com.sun.jna.WString;
 import com.sun.jna.platform.FileUtils;
 
 public class W32FileUtils extends FileUtils {
@@ -32,7 +31,7 @@ public class W32FileUtils extends FileUtils {
         for (int i=0;i < paths.length;i++) {
             paths[i] = files[i].getAbsolutePath();
         }
-        fileop.pFrom = new WString(fileop.encodePaths(paths));
+        fileop.pFrom = fileop.encodePaths(paths);
         fileop.fFlags = ShellAPI.FOF_ALLOWUNDO|ShellAPI.FOF_NO_UI;
         int ret = shell.SHFileOperation(fileop);
         if (ret != 0) {

--- a/contrib/platform/src/com/sun/jna/platform/win32/Wdm.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Wdm.java
@@ -18,14 +18,13 @@ import java.util.List;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from Wdm.h.
  * Microsoft Windows DDK.
  * @author dblock[at]dblock.org
  */
-public interface Wdm extends StdCallLibrary {
+public interface Wdm {
 	
     /**
      * The KEY_BASIC_INFORMATION structure defines a subset of 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Win32Exception.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Win32Exception.java
@@ -20,9 +20,9 @@ import com.sun.jna.platform.win32.WinNT.HRESULT;
  */
 public class Win32Exception extends RuntimeException {
 	
-	private static final long serialVersionUID = 1L;
-	
-	private HRESULT _hr;
+    private static final long serialVersionUID = 1L;
+    
+    private HRESULT _hr;
     
     /**
      * Returns the error code of the error.

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -26,13 +26,14 @@ import com.sun.jna.Union;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.ByteByReference;
 import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 
 /**
  * Ported from Winbase.h (kernel32.dll/kernel services).
  * Microsoft Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  */
-public interface WinBase extends StdCallLibrary, WinDef, BaseTSD {
+public interface WinBase extends WinDef, BaseTSD {
 
     /** Constant value representing an invalid HANDLE. */
     HANDLE INVALID_HANDLE_VALUE =
@@ -992,7 +993,7 @@ public interface WinBase extends StdCallLibrary, WinDef, BaseTSD {
     /**
      * Represents a thread entry point local to this process, as a Callback.
      */
-    public interface THREAD_START_ROUTINE extends Callback{
+    public interface THREAD_START_ROUTINE extends StdCallCallback{
     	public DWORD apply( LPVOID lpParameter );
     }
 
@@ -1079,8 +1080,8 @@ public interface WinBase extends StdCallLibrary, WinDef, BaseTSD {
      * ExportCallback writes the encrypted file's data to another storage media,
      * usually for purposes of backing up the file.
      */
-    public interface FE_EXPORT_FUNC extends Callback {
-        public DWORD callback(ByteByReference pbData, Pointer pvCallbackContext,
+    public interface FE_EXPORT_FUNC extends StdCallCallback {
+        public DWORD callback(Pointer pbData, Pointer pvCallbackContext,
                               ULONG ulLength);
     }
 
@@ -1091,8 +1092,8 @@ public interface WinBase extends StdCallLibrary, WinDef, BaseTSD {
      * backup file sequentially and restores the data, and the system continues
      * calling it until it has read all of the backup file data.
      */
-    public interface FE_IMPORT_FUNC extends Callback {
-        public DWORD callback(ByteByReference pbData, Pointer pvCallbackContext,
+    public interface FE_IMPORT_FUNC extends StdCallCallback {
+        public DWORD callback(Pointer pbData, Pointer pvCallbackContext,
                               ULONGByReference ulLength);
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
@@ -20,14 +20,13 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.WinDef.HWND;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from WinCrypt.h.
  * Microsoft Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  */
-public interface WinCrypt extends StdCallLibrary {
+public interface WinCrypt {
 	
     /**
      * The CryptoAPI CRYPTOAPI_BLOB structure is used for an arbitrary array of bytes.

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
@@ -25,7 +25,6 @@ import com.sun.jna.platform.win32.BaseTSD.LONG_PTR;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.ptr.ByReference;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from Windef.h (various macros and types). Microsoft Windows SDK 6.0A.
@@ -33,7 +32,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * @author dblock[at]dblock.org
  */
 @SuppressWarnings("serial")
-public interface WinDef extends StdCallLibrary {
+public interface WinDef {
 
     /** The max path. */
     int MAX_PATH = 260;

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinGDI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinGDI.java
@@ -21,7 +21,6 @@ import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinDef.HBITMAP;
 import com.sun.jna.platform.win32.WinDef.RECT;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from WinGDI.h. 
@@ -29,7 +28,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * @author dblock[at]dblock.org
  * @author Andreas "PAX" L&uuml;ck, onkelpax-git[at]yahoo.de
  */
-public interface WinGDI extends StdCallLibrary {
+public interface WinGDI {
     int RDH_RECTANGLES = 1;
 
     class RGNDATAHEADER extends Structure {

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -26,6 +26,7 @@ import com.sun.jna.PointerType;
 import com.sun.jna.Structure;
 import com.sun.jna.Union;
 import com.sun.jna.ptr.ByReference;
+import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 
 /**
  * This module defines the 32-Bit Windows types and constants that are defined

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinRas.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinRas.java
@@ -26,12 +26,12 @@ import com.sun.jna.platform.win32.WinDef.BOOL;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.LUID;
-import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 
 /**
  * Definitions for RASAPI32
  */
-public interface WinRas extends StdCallLibrary {
+public interface WinRas {
 	public static final int ERROR_BUFFER_TOO_SMALL = 603;
 	public static final int ERROR_CANNOT_FIND_PHONEBOOK_ENTRY = 623;
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinReg.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinReg.java
@@ -15,7 +15,6 @@ package com.sun.jna.platform.win32;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.ByReference;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * This module contains the function prototypes and constant, type and structure 
@@ -24,7 +23,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * Microsoft Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  */
-public interface WinReg extends StdCallLibrary {
+public interface WinReg {
 	
     public static class HKEY extends HANDLE {
         public HKEY() { }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
@@ -19,10 +19,9 @@ import com.sun.jna.Callback;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Union;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
-import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 
 /**
  * Ported from WinUser.h Microsoft Windows SDK 6.0A.
@@ -30,7 +29,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * @author dblock[at]dblock.org
  * @author Andreas "PAX" L&uuml;ck, onkelpax-git[at]yahoo.de
  */
-public interface WinUser extends StdCallLibrary, WinDef {
+public interface WinUser extends WinDef {
     HWND HWND_BROADCAST = new HWND(Pointer.createConstant(0xFFFF));
     HWND HWND_MESSAGE = new HWND(Pointer.createConstant(-3));
 
@@ -1039,7 +1038,7 @@ public interface WinUser extends StdCallLibrary, WinDef {
         public String lpszMenuName;
 
         /** The lpsz class name. */
-        public WString lpszClassName;
+        public String lpszClassName;
 
         /** The h icon sm. */
         public HICON hIconSm;
@@ -1059,7 +1058,7 @@ public interface WinUser extends StdCallLibrary, WinDef {
      *
      * WindowProc is a placeholder for the application-defined function name.
      */
-    public interface WindowProc extends Callback {
+    public interface WindowProc extends StdCallCallback {
 
         /**
          * @param hwnd
@@ -1260,7 +1259,7 @@ public interface WinUser extends StdCallLibrary, WinDef {
      * display monitor. You can then paint into the device context in a manner that is optimal for the 
      * display monitor.
      */
-    public interface MONITORENUMPROC extends Callback
+    public interface MONITORENUMPROC extends StdCallCallback
     {
         /**
          * @param hMonitor A handle to the display monitor. This value will always be non-NULL.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winioctl.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winioctl.java
@@ -15,12 +15,11 @@ import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Interface for the Winioctl.h header file.
  */
-public interface Winioctl extends StdCallLibrary {
+public interface Winioctl {
 
     /**
      * Retrieves the device type, device number, and, for a partitionable device, the partition number of a device.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winnetwk.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winnetwk.java
@@ -19,8 +19,6 @@ import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.WString;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Ported from AccCtrl.h. Microsoft Windows SDK 7.1
@@ -28,7 +26,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * @author amarcionek[at]gmail.com
  */
 
-public abstract class Winnetwk implements StdCallLibrary {
+public abstract class Winnetwk {
 
     /**
      * The scope of the enumeration. This member can be one of the following
@@ -329,7 +327,7 @@ public abstract class Winnetwk implements StdCallLibrary {
          * character string that specifies the name of a local device. This
          * member is NULL if the connection does not use a device.
          */
-        public WString lpLocalName;
+        public String lpLocalName;
 
         /**
          * If the entry is a network resource, this member is a pointer to a
@@ -343,13 +341,13 @@ public abstract class Winnetwk implements StdCallLibrary {
          * The string can be MAX_PATH characters in length, and it must follow
          * the network provider's naming conventions
          */
-        public WString lpRemoteName;
+        public String lpRemoteName;
 
         /**
          * A pointer to a NULL-terminated string that contains a comment
          * supplied by the network provider.
          */
-        public WString lpComment;
+        public String lpComment;
 
         /**
          * A pointer to a NULL-terminated string that contains the name of the
@@ -357,7 +355,7 @@ public abstract class Winnetwk implements StdCallLibrary {
          * provider name is unknown. To retrieve the provider name, you can call
          * the WNetGetProviderName function.
          */
-        public WString lpProvider;
+        public String lpProvider;
     }
 
     //
@@ -396,7 +394,7 @@ public abstract class Winnetwk implements StdCallLibrary {
          * Pointer to the null-terminated UNC name string that identifies a
          * network resource.
          */
-        public WString lpUniversalName;
+        public String lpUniversalName;
 
         @Override
         protected List getFieldOrder() {
@@ -436,18 +434,18 @@ public abstract class Winnetwk implements StdCallLibrary {
          * Pointer to the null-terminated UNC name string that identifies a
          * network resource.
          */
-        public WString lpUniversalName;
+        public String lpUniversalName;
 
         /**
          * Pointer to a null-terminated string that is the name of a network
          * connection.
          */
-        public WString lpConnectionName;
+        public String lpConnectionName;
 
         /**
          * Pointer to a null-terminated name string.
          */
-        public WString lpRemainingPath;
+        public String lpRemainingPath;
 
         @Override
         protected List getFieldOrder() {

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winspool.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winspool.java
@@ -93,7 +93,7 @@ public interface Winspool extends StdCallLibrary {
     int PRINTER_ENUM_HIDE = 0x01000000;
 
     Winspool INSTANCE = (Winspool) Native.loadLibrary("Winspool.drv",
-            Winspool.class, W32APIOptions.UNICODE_OPTIONS);
+            Winspool.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The EnumPrinters function enumerates available printers, print servers,

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winsvc.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winsvc.java
@@ -19,7 +19,6 @@ import java.util.List;
 import com.sun.jna.Memory;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
-import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * This module defines the 32-Bit Windows types and constants that are defined
@@ -28,7 +27,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * Microsoft Windows SDK 7.0A.
  * @author EugineLev
  */
-public interface Winsvc extends StdCallLibrary {	
+public interface Winsvc {	
 
     /**
      *  Contains status information for a service. The ControlService, EnumDependentServices,

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
@@ -19,7 +19,6 @@ import java.util.TreeMap;
 
 import junit.framework.TestCase;
 
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Advapi32Util.Account;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogIterator;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogRecord;
@@ -127,8 +126,8 @@ public class Advapi32UtilTest extends TestCase {
 	
     public void testGetUserGroups() {
     	USER_INFO_1 userInfo = new USER_INFO_1();
-    	userInfo.usri1_name = new WString("JNANetapi32TestUser");
-    	userInfo.usri1_password = new WString("!JNAP$$Wrd0");
+    	userInfo.usri1_name = "JNANetapi32TestUser";
+    	userInfo.usri1_password = "!JNAP$$Wrd0";
     	userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
         // ignore test if not able to add user (need to be administrator to do this).
         if (LMErr.NERR_Success != Netapi32.INSTANCE.NetUserAdd(null, 1, userInfo, null)) {
@@ -161,8 +160,8 @@ public class Advapi32UtilTest extends TestCase {
 	
     public void testGetUserAccount() {
     	USER_INFO_1 userInfo = new USER_INFO_1();
-    	userInfo.usri1_name = new WString("JNANetapi32TestUser");
-    	userInfo.usri1_password = new WString("!JNAP$$Wrd0");
+    	userInfo.usri1_name = "JNANetapi32TestUser";
+    	userInfo.usri1_password = "!JNAP$$Wrd0";
     	userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
         // ignore test if not able to add user (need to be administrator to do this).
         if (LMErr.NERR_Success != Netapi32.INSTANCE.NetUserAdd(null, 1, userInfo, null)) {

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ShellApplicationWindowsTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ShellApplicationWindowsTest.java
@@ -29,7 +29,8 @@ public class ShellApplicationWindowsTest extends TestCase
         
         // IE is open, so there should be at least one present.
         // More may exist if Windows Explorer windows are open.
-        assertTrue(sa.Windows().Count() > 0);
+        assertTrue("No shell application windows found",
+                   sa.Windows().Count() > 0);
         
         boolean pageFound = false;
         for (InternetExplorer ie : sa.Windows())
@@ -43,7 +44,7 @@ public class ShellApplicationWindowsTest extends TestCase
         }
         
         // Finally, did we find our page in the collection?
-        assertTrue(pageFound);
+        assertTrue("No IE page was found", pageFound);
     }
     
     @Override
@@ -183,4 +184,7 @@ public class ShellApplicationWindowsTest extends TestCase
         }
     }
     
+    public static void main(String[] args) {
+        junit.textui.TestRunner.run(ShellApplicationWindowsTest.class);
+    }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Netapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Netapi32Test.java
@@ -14,7 +14,6 @@ package com.sun.jna.platform.win32;
 
 import java.io.File;
 
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.DsGetDC.DS_DOMAIN_TRUSTS;
 import com.sun.jna.platform.win32.DsGetDC.PDOMAIN_CONTROLLER_INFO;
 import com.sun.jna.platform.win32.LMAccess.GROUP_INFO_2;
@@ -150,8 +149,8 @@ public class Netapi32Test extends TestCase {
     
     public void testNetUserAdd() {
     	USER_INFO_1 userInfo = new USER_INFO_1();
-    	userInfo.usri1_name = new WString("JNANetapi32TestUser");
-    	userInfo.usri1_password = new WString("!JNAP$$Wrd0");
+    	userInfo.usri1_name = "JNANetapi32TestUser";
+    	userInfo.usri1_password = "!JNAP$$Wrd0";
     	userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
         // ignore test if not able to add user (need to be administrator to do this).
         if (LMErr.NERR_Success != Netapi32.INSTANCE.NetUserAdd(Kernel32Util.getComputerName(), 1, userInfo, null)) {
@@ -163,8 +162,8 @@ public class Netapi32Test extends TestCase {
     
     public void testNetUserChangePassword() {
     	USER_INFO_1 userInfo = new USER_INFO_1();
-    	userInfo.usri1_name = new WString("JNANetapi32TestUser");
-    	userInfo.usri1_password = new WString("!JNAP$$Wrd0");
+    	userInfo.usri1_name = "JNANetapi32TestUser";
+    	userInfo.usri1_password = "!JNAP$$Wrd0";
     	userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
         // ignore test if not able to add user (need to be administrator to do this).
         if (LMErr.NERR_Success != Netapi32.INSTANCE.NetUserAdd(Kernel32Util.getComputerName(), 1, userInfo, null)) {
@@ -266,14 +265,14 @@ public class Netapi32Test extends TestCase {
         File fileShareFolder = createTempFolder();
 
         SHARE_INFO_2 shi = new SHARE_INFO_2();
-        shi.shi2_netname = new WString(fileShareFolder.getName());
+        shi.shi2_netname = fileShareFolder.getName();
         shi.shi2_type = LMShare.STYPE_DISKTREE;
-        shi.shi2_remark = new WString("");
+        shi.shi2_remark = "";
         shi.shi2_permissions = LMAccess.ACCESS_ALL;
         shi.shi2_max_uses = -1;
         shi.shi2_current_uses = 0;
-        shi.shi2_path = new WString(fileShareFolder.getAbsolutePath());
-        shi.shi2_passwd = new WString("");
+        shi.shi2_path = fileShareFolder.getAbsolutePath();
+        shi.shi2_passwd = "";
 
         // Write from struct to native memory.
         shi.write();
@@ -297,13 +296,13 @@ public class Netapi32Test extends TestCase {
         File fileShareFolder = createTempFolder();
 
         SHARE_INFO_502 shi = new SHARE_INFO_502();
-        shi.shi502_netname = new WString(fileShareFolder.getName());
+        shi.shi502_netname = fileShareFolder.getName();
         shi.shi502_type = LMShare.STYPE_DISKTREE;
-        shi.shi502_remark = new WString("");
+        shi.shi502_remark = "";
         shi.shi502_permissions = LMAccess.ACCESS_ALL;
         shi.shi502_max_uses = -1;
         shi.shi502_current_uses = 0;
-        shi.shi502_path = new WString(fileShareFolder.getAbsolutePath());
+        shi.shi502_path = fileShareFolder.getAbsolutePath();
         shi.shi502_passwd = null;
         shi.shi502_reserved = 0;
         shi.shi502_security_descriptor = null;
@@ -330,14 +329,14 @@ public class Netapi32Test extends TestCase {
         File fileShareFolder = createTempFolder();
 
         SHARE_INFO_2 shi = new SHARE_INFO_2();
-        shi.shi2_netname = new WString(fileShareFolder.getName());
+        shi.shi2_netname = fileShareFolder.getName();
         shi.shi2_type = LMShare.STYPE_DISKTREE;
-        shi.shi2_remark = new WString("");
+        shi.shi2_remark = "";
         shi.shi2_permissions = LMAccess.ACCESS_ALL;
         shi.shi2_max_uses = -1;
         shi.shi2_current_uses = 0;
-        shi.shi2_path = new WString(fileShareFolder.getAbsolutePath());
-        shi.shi2_passwd = new WString("");
+        shi.shi2_path = fileShareFolder.getAbsolutePath();
+        shi.shi2_passwd = "";
 
         // Write from struct to native memory.
         shi.write();

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
@@ -35,6 +35,8 @@ import com.sun.jna.platform.win32.WinDef.HDC;
 import com.sun.jna.platform.win32.WinDef.HICON;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinDef.LPARAM;
+import com.sun.jna.platform.win32.WinDef.LRESULT;
+import com.sun.jna.platform.win32.WinDef.WPARAM;
 import com.sun.jna.platform.win32.WinDef.POINT;
 import com.sun.jna.platform.win32.WinDef.RECT;
 import com.sun.jna.platform.win32.WinDef.UINT;
@@ -45,6 +47,7 @@ import com.sun.jna.platform.win32.WinUser.LASTINPUTINFO;
 import com.sun.jna.platform.win32.WinUser.MONITORENUMPROC;
 import com.sun.jna.platform.win32.WinUser.MONITORINFO;
 import com.sun.jna.platform.win32.WinUser.MONITORINFOEX;
+import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
 
 /**
  * @author dblock[at]dblock[dot]org
@@ -281,9 +284,12 @@ public class User32Test extends AbstractWin32TestSupport {
 		assertNotNull(explorerProc);
 
 		final DWORDByReference hIconNumber = new DWORDByReference();
-		long result = User32.INSTANCE.SendMessageTimeout(
-				explorerProc.getHWND(), WinUser.WM_GETICON, WinUser.ICON_BIG,
-				0, WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
+		LRESULT result = User32.INSTANCE
+                    .SendMessageTimeout(explorerProc.getHWND(),
+                                        WinUser.WM_GETICON,
+                                        new WPARAM(WinUser.ICON_BIG),
+                                        new LPARAM(0),
+                                        WinUser.SMTO_ABORTIFHUNG, 500, hIconNumber);
 
 		assertNotEquals(0, result);
 	}
@@ -292,12 +298,14 @@ public class User32Test extends AbstractWin32TestSupport {
 	public void testGetClassLongPtr() {
 		DesktopWindow explorerProc = getWindowByProcessPath("explorer.exe");
 
-		assertNotNull(explorerProc);
+		assertNotNull("Could not find explorer.exe process",
+                              explorerProc);
 
-		long result = User32.INSTANCE.GetClassLongPtr(explorerProc.getHWND(),
-				WinUser.GCLP_HMODULE);
+		ULONG_PTR result = User32.INSTANCE
+                    .GetClassLongPtr(explorerProc.getHWND(),
+                                     WinUser.GCLP_HMODULE);
 
-		assertNotEquals(0, result);
+		assertNotEquals(0, result.intValue());
 	}
 
 	@Test


### PR DESCRIPTION
* Drop StdCallLibrary inheritance from non-library interfaces
* Prefer String over WString
* Fix some w32 API callback types to be stdcall
* Fix platform test execution from top level 'test-platform' target

Marked common (user32, kernel32, advapi32) methods using `WString` deprecated, maybe should drop them altogether.  `Structure` definitions with `WString` fields have been modified so there's no backward compatibility there.

Still a fair number of failures, but these appear to be due to environmental factors.  Will clean up some of them as part of this PR (where possible).

![screen shot 2015-11-22 at 1 22 10 pm](https://cloud.githubusercontent.com/assets/756909/11325451/195ff23c-911c-11e5-9597-ebab83b1e0b2.png)

![screen shot 2015-11-22 at 2 44 36 pm](https://cloud.githubusercontent.com/assets/756909/11325876/a9442854-9127-11e5-8420-14093b203076.png)
