### PR TITLE
Fix PictFormat assignment error in X11 libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Features
 
 Bug Fixes
 ---------
+* [#549](https://github.com/java-native-access/jna/pull/549): Fixed bug in types derived from XID - [@twall](https://github.com/twall).
 
 Release 4.2.1
 =============

--- a/contrib/platform/src/com/sun/jna/platform/unix/X11.java
+++ b/contrib/platform/src/com/sun/jna/platform/unix/X11.java
@@ -35,8 +35,19 @@ public interface X11 extends Library {
 
     class VisualID extends NativeLong {
         private static final long serialVersionUID = 1L;
+        public static final VisualID None = null;
         public VisualID() { this(0); }
         public VisualID(long value) { super(value, true); }
+        protected boolean isNone(Object o) {
+            return o == null
+                || (o instanceof Number
+                    && ((Number)o).longValue() == X11.None);
+        }
+        public Object fromNative(Object nativeValue, FromNativeContext context) {
+            if (isNone(nativeValue))
+                return None;
+            return new VisualID(((Number)nativeValue).longValue());
+        }
     }
 
     class XID extends NativeLong {
@@ -286,8 +297,14 @@ public interface X11 extends Library {
         }
         class PictFormat extends XID {
             private static final long serialVersionUID = 1L;
+            public static final PictFormat None = null;
             public PictFormat(long value) { super(value); }
             public PictFormat() { this(0); }
+            public Object fromNative(Object nativeValue, FromNativeContext context) {
+                if (isNone(nativeValue))
+                    return None;
+                return new PictFormat(((Number)nativeValue).longValue());
+            }
         }
         class XRenderPictFormat extends Structure {
             public PictFormat id;

--- a/contrib/platform/test/com/sun/jna/platform/unix/X11Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/unix/X11Test.java
@@ -1,0 +1,36 @@
+/* Copyright (c) 2015 Timothy Wall, All Rights Reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * <p/>
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package com.sun.jna.platform.unix;
+
+import junit.framework.TestCase;
+
+/**
+ * Exercise the {@link X11} class.
+ *
+ * @author twalljava@java.net
+ */
+// @SuppressWarnings("unused")
+public class X11Test extends TestCase {
+
+    public void testXrender() {
+        X11.Xrender.XRenderPictFormat s = new X11.Xrender.XRenderPictFormat();
+        s.getPointer().setInt(0, 25);
+        s.read();
+    }
+
+    public static void main(java.lang.String[] argList) {
+        junit.textui.TestRunner.run(X11Test.class);
+    }
+}
+
+


### PR DESCRIPTION
When deriving from a native-mapped struct, need to provide an updated fromNative method