### PR TITLE
Refiid byvalue

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMBindingBaseObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMBindingBaseObject.java
@@ -86,7 +86,7 @@ public class COMBindingBaseObject extends COMInvoker {
 
             if (COMUtils.SUCCEEDED(hr)) {
                 this.iUnknown = new Unknown(this.pUnknown.getValue());
-                hr = iUnknown.QueryInterface(new REFIID.ByValue( IDispatch.IID_IDISPATCH),
+                hr = iUnknown.QueryInterface(new REFIID( IDispatch.IID_IDISPATCH),
                         this.pDispatch);
             } else {
                 hr = Ole32.INSTANCE.CoCreateInstance(clsid, null, dwClsContext,
@@ -129,7 +129,7 @@ public class COMBindingBaseObject extends COMInvoker {
 
             if (COMUtils.SUCCEEDED(hr)) {
                 this.iUnknown = new Unknown(this.pUnknown.getValue());
-                hr = iUnknown.QueryInterface(new REFIID.ByValue(IDispatch.IID_IDISPATCH),
+                hr = iUnknown.QueryInterface(new REFIID(IDispatch.IID_IDISPATCH),
                         this.pDispatch);
             } else {
                 hr = Ole32.INSTANCE.CoCreateInstance(clsid, null, dwClsContext,
@@ -211,7 +211,7 @@ public class COMBindingBaseObject extends COMInvoker {
         DISPIDByReference pdispID = new DISPIDByReference();
 
         // Get DISPID for name passed...
-        HRESULT hr = pDisp.GetIDsOfNames(new REFIID.ByValue(Guid.IID_NULL), ptName, 1,
+        HRESULT hr = pDisp.GetIDsOfNames(new REFIID(Guid.IID_NULL), ptName, 1,
                 LOCALE_USER_DEFAULT, pdispID);
 
         COMUtils.checkRC(hr);
@@ -263,7 +263,7 @@ public class COMBindingBaseObject extends COMInvoker {
         }
 
         // Make the call!
-        HRESULT hr = pDisp.Invoke(dispId, new REFIID.ByValue(Guid.IID_NULL), LOCALE_SYSTEM_DEFAULT,
+        HRESULT hr = pDisp.Invoke(dispId, new REFIID(Guid.IID_NULL), LOCALE_SYSTEM_DEFAULT,
                 new WinDef.WORD(nType), dp, pvResult, pExcepInfo, puArgErr);
 
         COMUtils.checkRC(hr, pExcepInfo, puArgErr);

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMEarlyBindingObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMEarlyBindingObject.java
@@ -59,7 +59,7 @@ public class COMEarlyBindingObject extends COMBindingBaseObject implements
     }
 
     @Override
-    public HRESULT QueryInterface(REFIID.ByValue riid, PointerByReference ppvObject) {
+    public HRESULT QueryInterface(REFIID riid, PointerByReference ppvObject) {
         return this.getIDispatch().QueryInterface(riid, ppvObject);
     }
 
@@ -85,14 +85,14 @@ public class COMEarlyBindingObject extends COMBindingBaseObject implements
     }
 
     @Override
-    public HRESULT GetIDsOfNames(REFIID.ByValue riid, WString[] rgszNames, int cNames,
+    public HRESULT GetIDsOfNames(REFIID riid, WString[] rgszNames, int cNames,
             LCID lcid, DISPIDByReference rgDispId) {
         return this.getIDispatch().GetIDsOfNames(riid, rgszNames, cNames, lcid,
                 rgDispId);
     }
 
     @Override
-    public HRESULT Invoke(DISPID dispIdMember, REFIID.ByValue riid, LCID lcid,
+    public HRESULT Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,
             WORD wFlags, DISPPARAMS.ByReference pDispParams,
             VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
             IntByReference puArgErr) {

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/Dispatch.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/Dispatch.java
@@ -99,7 +99,7 @@ public class Dispatch extends Unknown implements IDispatch {
      *            the rg disp id
      * @return the hresult
      */
-    public HRESULT GetIDsOfNames(REFIID.ByValue riid, WString[] rgszNames, int cNames,
+    public HRESULT GetIDsOfNames(REFIID riid, WString[] rgszNames, int cNames,
             LCID lcid, DISPIDByReference rgDispId) {
         return (HRESULT) this._invokeNativeObject(5,
                 new Object[] { this.getPointer(), riid, rgszNames, cNames,
@@ -127,7 +127,7 @@ public class Dispatch extends Unknown implements IDispatch {
      *            the pu arg err
      * @return the hresult
      */
-    public HRESULT Invoke(DISPID dispIdMember, REFIID.ByValue riid, LCID lcid,
+    public HRESULT Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,
             WORD wFlags, DISPPARAMS.ByReference pDispParams,
             VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
             IntByReference puArgErr) {

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/DispatchListener.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/DispatchListener.java
@@ -54,7 +54,7 @@ public class DispatchListener extends Structure {
 	protected void initVTable(final IDispatchCallback callback) {
 		this.vtbl.QueryInterfaceCallback = new DispatchVTable.QueryInterfaceCallback() {
 			@Override
-			public HRESULT invoke(Pointer thisPointer, REFIID.ByValue refid, PointerByReference ppvObject) {
+			public HRESULT invoke(Pointer thisPointer, REFIID refid, PointerByReference ppvObject) {
 				return callback.QueryInterface(refid, ppvObject);
 			}
 		};
@@ -84,14 +84,14 @@ public class DispatchListener extends Structure {
 		};
 		this.vtbl.GetIDsOfNamesCallback = new DispatchVTable.GetIDsOfNamesCallback() {
 			@Override
-			public HRESULT invoke(Pointer thisPointer, REFIID.ByValue riid, WString[] rgszNames, int cNames, LCID lcid,
+			public HRESULT invoke(Pointer thisPointer, REFIID riid, WString[] rgszNames, int cNames, LCID lcid,
 					DISPIDByReference rgDispId) {
 				return callback.GetIDsOfNames(riid, rgszNames, cNames, lcid, rgDispId);
 			}
 		};
 		this.vtbl.InvokeCallback = new DispatchVTable.InvokeCallback() {
 			@Override
-			public HRESULT invoke(Pointer thisPointer, DISPID dispIdMember, REFIID.ByValue riid, LCID lcid, WORD wFlags,
+			public HRESULT invoke(Pointer thisPointer, DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
 					DISPPARAMS.ByReference pDispParams, VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
 		            IntByReference puArgErr) {
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/DispatchVTable.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/DispatchVTable.java
@@ -57,7 +57,7 @@ public class DispatchVTable extends Structure {
 	}
 
 	public static interface QueryInterfaceCallback extends StdCallLibrary.StdCallCallback {
-		WinNT.HRESULT invoke(Pointer thisPointer, REFIID.ByValue refid, PointerByReference ppvObject);
+		WinNT.HRESULT invoke(Pointer thisPointer, REFIID refid, PointerByReference ppvObject);
 	}
 
 	public static interface AddRefCallback extends StdCallLibrary.StdCallCallback {
@@ -77,12 +77,12 @@ public class DispatchVTable extends Structure {
 	}
 
 	public static interface GetIDsOfNamesCallback extends StdCallLibrary.StdCallCallback {
-		WinNT.HRESULT invoke(Pointer thisPointer, REFIID.ByValue riid, WString[] rgszNames, int cNames, LCID lcid,
+		WinNT.HRESULT invoke(Pointer thisPointer, REFIID riid, WString[] rgszNames, int cNames, LCID lcid,
 				DISPIDByReference rgDispId);
 	}
 
 	public static interface InvokeCallback extends StdCallLibrary.StdCallCallback {
-		WinNT.HRESULT invoke(Pointer thisPointer, DISPID dispIdMember, REFIID.ByValue riid, LCID lcid, WORD wFlags,
+		WinNT.HRESULT invoke(Pointer thisPointer, DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
 				DISPPARAMS.ByReference pDispParams, VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
 				IntByReference puArgErr);
 	}

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IDispatch.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IDispatch.java
@@ -31,10 +31,10 @@ import com.sun.jna.ptr.PointerByReference;
 // TODO: Auto-generated Javadoc
 /**
  * Wrapper class for the IDispatch interface
- * 
+ *
  * IDispatch.GetTypeInfoCount 12 IDispatch.GetTypeInfo 16
  * IDispatch.GetIDsOfNames 20 IDispatch.Invoke 24
- * 
+ *
  * @author Tobias Wolf, wolf.tobias@gmx.net
  */
 public interface IDispatch extends IUnknown {
@@ -42,15 +42,102 @@ public interface IDispatch extends IUnknown {
     public final static IID IID_IDISPATCH = new IID(
             "00020400-0000-0000-C000-000000000046");
 
+    /**
+     * Retrieves the number of type information interfaces that an object provides (either 0 or 1).
+     *
+     * @param pctinfo The number of type information interfaces provided by the object. If the object provides type information, this number is 1; otherwise the number is 0.
+     * @return This method can return one of these values.
+     * S_OK
+     * Success.
+     * E_NOTIMPL
+     * Failure.
+     */
     public HRESULT GetTypeInfoCount(UINTByReference pctinfo);
 
+    /**
+     * Retrieves the type information for an object, which can then be used to get the type information for an interface.
+     *
+     * @param iTInfo  The type information to return. Pass 0 to retrieve type information for the IDispatch implementation.
+     * @param lcid    The locale identifier for the type information.
+     *                An object may be able to return different type information for different languages. This is important
+     *                for classes that support localized member names. For classes that do not support localized member names,
+     *                this parameter can be ignored.
+     * @param ppTInfo The requested type information object.
+     * @return S_OK
+     * Success.
+     * DISP_E_BADINDEX
+     * The iTInfo parameter was not 0.
+     */
     public HRESULT GetTypeInfo(UINT iTInfo, LCID lcid,
             PointerByReference ppTInfo);
 
-    public HRESULT GetIDsOfNames(REFIID.ByValue riid, WString[] rgszNames, int cNames,
+    /**
+     * Maps a single member and an optional set of argument names to a corresponding set of integer DISPIDs, which can be used
+     * on subsequent calls to Invoke. The dispatch function DispGetIDsOfNames provides a standard implementation of GetIDsOfNames.
+     *
+     * @param riid      Reserved for future use. Must be IID_NULL.
+     * @param rgszNames The array of names to be mapped.
+     * @param cNames    The count of the names to be mapped.
+     * @param lcid      The locale context in which to interpret the names.
+     * @param rgDispId  Caller-allocated array, each element of which contains an identifier (ID) corresponding to one of the names passed in
+     *                  the rgszNames array. The first element represents the member name. The subsequent elements represent each of the member's parameters.
+     * @return
+     */
+    public HRESULT GetIDsOfNames(REFIID riid, WString[] rgszNames, int cNames,
             LCID lcid, DISPIDByReference rgDispId);
 
-    public HRESULT Invoke(DISPID dispIdMember, REFIID.ByValue riid, LCID lcid,
+    /**
+     * Provides access to properties and methods exposed by an object. The dispatch function DispInvoke provides a standard implementation of Invoke.
+     *
+     * @param dispIdMember Identifies the member. Use GetIDsOfNames or the object's documentation to obtain the dispatch identifier.
+     * @param riid         Reserved for future use. Must be IID_NULL.
+     * @param lcid         The locale context in which to interpret arguments. The lcid is used by the GetIDsOfNames function, and is also
+     *                     passed to Invoke to allow the object to interpret its arguments specific to a locale.
+     *                     <p/>
+     *                     Applications that do not support multiple national languages can ignore this parameter. For more information,
+     *                     refer to Supporting Multiple National Languages and Exposing ActiveX Objects.
+     * @param wFlags       Flags describing the context of the Invoke call.
+     *                     DISPATCH_METHOD
+     *                     The member is invoked as a method. If a property has the same name, both this and the DISPATCH_PROPERTYGET flag can be set.
+     *                     DISPATCH_PROPERTYGET
+     *                     The member is retrieved as a property or data member.
+     *                     DISPATCH_PROPERTYPUT
+     *                     The member is changed as a property or data member.
+     *                     DISPATCH_PROPERTYPUTREF
+     *                     The member is changed by a reference assignment, rather than a value assignment. This flag is valid only when the property accepts a reference to an object.
+     * @param pDispParams  Pointer to a DISPPARAMS structure containing an array of arguments, an array of argument DISPIDs for named arguments, and counts for the number of elements in the arrays.
+     * @param pVarResult   Pointer to the location where the result is to be stored, or NULL if the caller expects no result. This argument is ignored if DISPATCH_PROPERTYPUT or DISPATCH_PROPERTYPUTREF is specified.
+     * @param pExcepInfo   Pointer to a structure that contains exception information. This structure should be filled in if DISP_E_EXCEPTION is returned. Can be NULL.
+     * @param puArgErr     The index within rgvarg of the first argument that has an error. Arguments are stored in pDispParams->rgvarg in reverse order,
+     *                     so the first argument is the one with the highest index in the array. This parameter is returned only when the resulting return
+     *                     value is DISP_E_TYPEMISMATCH or DISP_E_PARAMNOTFOUND. This argument can be set to null. For details, see Returning Errors.
+     * @return This method can return one of these values.
+     * S_OK
+     * Success.
+     * DISP_E_BADPARAMCOUNT
+     * The number of elements provided to DISPPARAMS is different from the number of arguments accepted by the method or property.
+     * DISP_E_BADVARTYPE
+     * One of the arguments in DISPPARAMS is not a valid variant type.
+     * DISP_E_EXCEPTION
+     * The application needs to raise an exception. In this case, the structure passed in pexcepinfo should be filled in.
+     * DISP_E_MEMBERNOTFOUND
+     * The requested member does not exist.
+     * DISP_E_NONAMEDARGS
+     * This implementation of IDispatch does not support named arguments.
+     * DISP_E_OVERFLOW
+     * One of the arguments in DISPPARAMS could not be coerced to the specified type.
+     * DISP_E_PARAMNOTFOUND
+     * One of the parameter IDs does not correspond to a parameter on the method. In this case, puArgErr is set to the first argument that contains the error.
+     * DISP_E_TYPEMISMATCH
+     * One or more of the arguments could not be coerced. The index of the first parameter with the incorrect type within rgvarg is returned in puArgErr.
+     * DISP_E_UNKNOWNINTERFACE
+     * The interface identifier passed in riid is not IID_NULL.
+     * DISP_E_UNKNOWNLCID
+     * The member being invoked interprets string arguments according to the LCID, and the LCID is not recognized. If the LCID is not needed to interpret arguments, this error should not be returned
+     * DISP_E_PARAMNOTOPTIONAL
+     * A required parameter was omitted.
+     */
+    public HRESULT Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,
             WORD wFlags, DISPPARAMS.ByReference pDispParams,
             VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
             IntByReference puArgErr);

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/ITypeLib.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/ITypeLib.java
@@ -71,7 +71,7 @@ public interface ITypeLib extends IUnknown {
     /* [annotation][out][in] */
     BSTRByReference szNameBuf,
     /* [in] */ULONG lHashVal,
-    /* [length_is][size_is][out] */ITypeInfo[] ppTInfo,
+    /* [length_is][size_is][out] */PointerByReference ppTInfo,
     /* [length_is][size_is][out] */MEMBERID[] rgMemId,
     /* [out][in] */USHORTByReference pcFound);
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IUnknown.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IUnknown.java
@@ -32,7 +32,7 @@ public interface IUnknown {
     public final static IID IID_IUNKNOWN = new IID(
             "{00000000-0000-0000-C000-000000000046}");
 
-    public HRESULT QueryInterface(REFIID.ByValue riid, PointerByReference ppvObject);
+    public HRESULT QueryInterface(REFIID riid, PointerByReference ppvObject);
 
     public int AddRef();
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLib.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLib.java
@@ -217,7 +217,7 @@ public class TypeLib extends Unknown implements ITypeLib {
     /* [annotation][out][in] */
     BSTRByReference szNameBuf,
     /* [in] */ULONG lHashVal,
-    /* [length_is][size_is][out] */ITypeInfo[] ppTInfo,
+    /* [length_is][size_is][out] */PointerByReference ppTInfo,
     /* [length_is][size_is][out] */MEMBERID[] rgMemId,
     /* [out][in] */USHORTByReference pcFound) {
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
@@ -12,6 +12,7 @@
  */
 package com.sun.jna.platform.win32.COM;
 
+import com.sun.jna.Pointer;
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.CLSID;
 import com.sun.jna.platform.win32.Kernel32;
@@ -380,7 +381,7 @@ public class TypeLibUtil {
         COMUtils.checkRC(hr);
 
         found = pcFound.getValue().shortValue();
-        /* [length_is][size_is][out] */ITypeInfo[] ppTInfo = new ITypeInfo[found];
+        /* [length_is][size_is][out] */PointerByReference ppTInfo = new PointerByReference();
         /* [length_is][size_is][out] */MEMBERID[] rgMemId = new MEMBERID[found];
         hr = this.typelib.FindName(szNameBuf, lHashVal, ppTInfo, rgMemId,
                 pcFound);
@@ -404,7 +405,7 @@ public class TypeLibUtil {
         private String nameBuf;
 
         /** The p t info. */
-        private ITypeInfo[] pTInfo;
+        private PointerByReference pTInfo;
 
         /** The rg mem id. */
         private MEMBERID[] rgMemId;
@@ -414,18 +415,16 @@ public class TypeLibUtil {
 
         /**
          * Instantiates a new find name.
-         * 
-         * @param nameBuf
+         *  @param nameBuf
          *            the name buf
          * @param pTInfo
          *            the t info
          * @param rgMemId
-         *            the rg mem id
+ *            the rg mem id
          * @param pcFound
-         *            the pc found
          */
-        public FindName(String nameBuf, ITypeInfo[] pTInfo, MEMBERID[] rgMemId,
-                short pcFound) {
+        public FindName(String nameBuf, PointerByReference pTInfo, MEMBERID[] rgMemId,
+                        short pcFound) {
             this.nameBuf = nameBuf;
             this.pTInfo = pTInfo;
             this.rgMemId = rgMemId;
@@ -447,7 +446,14 @@ public class TypeLibUtil {
          * @return the t info
          */
         public ITypeInfo[] getTInfo() {
-            return pTInfo;
+
+            Pointer pVals = pTInfo.getValue();
+            ITypeInfo[] values=new ITypeInfo[pcFound];
+            for(int i=0;i<pcFound;i++)
+            {
+                values[i]=new TypeInfo(pVals.getPointer(i*Pointer.SIZE));
+            }
+            return values;
         }
 
         /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/Unknown.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/Unknown.java
@@ -56,7 +56,7 @@ public class Unknown extends COMInvoker implements IUnknown {
      *            the ppv object
      * @return the hresult
      */
-    public HRESULT QueryInterface(REFIID.ByValue riid, PointerByReference ppvObject) {
+    public HRESULT QueryInterface(REFIID riid, PointerByReference ppvObject) {
         return (HRESULT) this._invokeNativeObject(0,
                 new Object[] { this.getPointer(), riid, ppvObject },
                 HRESULT.class);

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/UnknownListener.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/UnknownListener.java
@@ -45,7 +45,7 @@ public class UnknownListener extends Structure {
 	protected void initVTable(final IUnknownCallback callback) {
 		this.vtbl.QueryInterfaceCallback = new UnknownVTable.QueryInterfaceCallback() {
 			@Override
-			public HRESULT invoke(Pointer thisPointer, REFIID.ByValue refid, PointerByReference ppvObject) {
+			public HRESULT invoke(Pointer thisPointer, REFIID refid, PointerByReference ppvObject) {
 				return callback.QueryInterface(refid, ppvObject);
 			}
 		};

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/UnknownVTable.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/UnknownVTable.java
@@ -36,7 +36,7 @@ public class UnknownVTable extends Structure {
 	}
 
 	public static interface QueryInterfaceCallback extends StdCallLibrary.StdCallCallback {
-		WinNT.HRESULT invoke(Pointer thisPointer, REFIID.ByValue refid, PointerByReference ppvObject);
+		WinNT.HRESULT invoke(Pointer thisPointer, REFIID refid, PointerByReference ppvObject);
 	}
 
 	public static interface AddRefCallback extends StdCallLibrary.StdCallCallback {

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
@@ -85,12 +85,12 @@ public class CallbackProxy implements IDispatchCallback {
 	Factory factory;
 	Class<?> comEventCallbackInterface;
 	IComEventCallbackListener comEventCallbackListener;
-	REFIID.ByValue listenedToRiid;
+	REFIID listenedToRiid;
 	public DispatchListener dispatchListener;
 	Map<DISPID, Method> dsipIdMap;
 	ExecutorService executorService;
 
-	REFIID.ByValue createRIID(Class<?> comEventCallbackInterface) {
+	REFIID createRIID(Class<?> comEventCallbackInterface) {
 		ComInterface comInterfaceAnnotation = comEventCallbackInterface.getAnnotation(ComInterface.class);
 		if (null == comInterfaceAnnotation) {
 			throw new COMException(
@@ -100,7 +100,7 @@ public class CallbackProxy implements IDispatchCallback {
 		if (null == iidStr || iidStr.isEmpty()) {
 			throw new COMException("ComInterface must define a value for iid");
 		}
-		return new REFIID.ByValue(new IID(iidStr).getPointer());
+		return new REFIID(new IID(iidStr).getPointer());
 	}
 
 	Map<DISPID, Method> createDispIdMap(Class<?> comEventCallbackInterface) {
@@ -125,7 +125,7 @@ public class CallbackProxy implements IDispatchCallback {
 		return -1;
 	}
 
-	void invokeOnThread(final DISPID dispIdMember, final REFIID.ByValue riid, LCID lcid, WORD wFlags,
+	void invokeOnThread(final DISPID dispIdMember, final REFIID riid, LCID lcid, WORD wFlags,
 			final DISPPARAMS.ByReference pDispParams) {
 		// decode arguments
 		// must decode them on this thread, and create a proxy for any COM objects (IDispatch)
@@ -142,7 +142,7 @@ public class CallbackProxy implements IDispatchCallback {
 					//get raw IUnknown interface
 					PointerByReference ppvObject = new PointerByReference();
 					IID iid = com.sun.jna.platform.win32.COM.IUnknown.IID_IUNKNOWN;
-					dispatch.QueryInterface(new REFIID.ByValue(iid), ppvObject);
+					dispatch.QueryInterface(new REFIID(iid), ppvObject);
 					Unknown rawUnk = new Unknown(ppvObject.getValue());
 					long unknownId = Pointer.nativeValue( rawUnk.getPointer() );
 					int n = rawUnk.Release();
@@ -222,13 +222,13 @@ public class CallbackProxy implements IDispatchCallback {
 	}
 
 	@Override
-	public HRESULT GetIDsOfNames(REFIID.ByValue riid, WString[] rgszNames, int cNames, LCID lcid,
+	public HRESULT GetIDsOfNames(REFIID riid, WString[] rgszNames, int cNames, LCID lcid,
 			DISPIDByReference rgDispId) {
 		return new HRESULT(WinError.E_NOTIMPL);
 	}
 
 	@Override
-	public HRESULT Invoke(DISPID dispIdMember, REFIID.ByValue riid, LCID lcid, WORD wFlags,
+	public HRESULT Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
 			DISPPARAMS.ByReference pDispParams, VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
 			IntByReference puArgErr) {
 
@@ -239,7 +239,7 @@ public class CallbackProxy implements IDispatchCallback {
 
 	// ------------------------ IUnknown ------------------------------
 	@Override
-	public HRESULT QueryInterface(REFIID.ByValue refid, PointerByReference ppvObject) {
+	public HRESULT QueryInterface(REFIID refid, PointerByReference ppvObject) {
 		if (null == ppvObject) {
 			return new HRESULT(WinError.E_POINTER);
 		}

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
@@ -116,7 +116,7 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 					@Override
 					public HRESULT call() throws Exception {
 						IID iid = com.sun.jna.platform.win32.COM.IUnknown.IID_IUNKNOWN;
-						return ProxyObject.this.getRawDispatch().QueryInterface(new REFIID.ByValue(iid), ppvObject);
+						return ProxyObject.this.getRawDispatch().QueryInterface(new REFIID(iid), ppvObject);
 					}
 				});
 				
@@ -439,7 +439,7 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 			HRESULT hr = this.comThread.execute(new Callable<HRESULT>() {
 				@Override
 				public HRESULT call() throws Exception {
-					return ProxyObject.this.getRawDispatch().QueryInterface(new REFIID.ByValue(iid), ppvObject);
+					return ProxyObject.this.getRawDispatch().QueryInterface(new REFIID(iid), ppvObject);
 				}
 			});
 
@@ -564,7 +564,7 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 			HRESULT hr = this.comThread.execute(new Callable<HRESULT>() {
 				@Override
 				public HRESULT call() throws Exception {
-					HRESULT hr = pDisp.GetIDsOfNames(new REFIID.ByValue(Guid.IID_NULL), ptName, 1, LOCALE_USER_DEFAULT,
+					HRESULT hr = pDisp.GetIDsOfNames(new REFIID(Guid.IID_NULL), ptName, 1, LOCALE_USER_DEFAULT,
 							pdispID);
 					return hr;
 				}
@@ -630,7 +630,7 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 			HRESULT hr = this.comThread.execute(new Callable<HRESULT>() {
 				@Override
 				public HRESULT call() throws Exception {
-					return pDisp.Invoke(dispId, new REFIID.ByValue(Guid.IID_NULL), LOCALE_SYSTEM_DEFAULT,
+					return pDisp.Invoke(dispId, new REFIID(Guid.IID_NULL), LOCALE_SYSTEM_DEFAULT,
 							new WinDef.WORD(nType), dp, pvResult, pExcepInfo, puArgErr);
 				}
 			});

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shlwapi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shlwapi.java
@@ -6,12 +6,12 @@ package com.sun.jna.platform.win32;
 
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import com.sun.jna.platform.win32.Shell32;
-import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
+import com.sun.jna.platform.win32.WinNT.*;
 
-public interface Shlwapi extends WinNT {
+public interface Shlwapi extends StdCallLibrary {
     Shlwapi INSTANCE = (Shlwapi) Native.loadLibrary("Shlwapi", Shlwapi.class, W32APIOptions.UNICODE_OPTIONS);
 
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ComEventCallbacks_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ComEventCallbacks_Test.java
@@ -80,13 +80,13 @@ public class ComEventCallbacks_Test {
 		}
 
 		@Override
-		public HRESULT GetIDsOfNames(REFIID.ByValue riid, WString[] rgszNames, int cNames, LCID lcid, DISPIDByReference rgDispId) {
+		public HRESULT GetIDsOfNames(REFIID riid, WString[] rgszNames, int cNames, LCID lcid, DISPIDByReference rgDispId) {
 			return new HRESULT(WinError.E_NOTIMPL);
 		}
 
 		public boolean Invoke_called = false;
 		@Override
-		public HRESULT Invoke(DISPID dispIdMember, REFIID.ByValue riid, LCID lcid,
+		public HRESULT Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,
 	            WORD wFlags, DISPPARAMS.ByReference pDispParams,
 	            VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
 	            IntByReference puArgErr) {
@@ -99,7 +99,7 @@ public class ComEventCallbacks_Test {
 		//------------------------ IUnknown ------------------------------
 		public boolean QueryInterface_called = false;
 		@Override
-		public HRESULT QueryInterface(REFIID.ByValue refid, PointerByReference ppvObject) {
+		public HRESULT QueryInterface(REFIID refid, PointerByReference ppvObject) {
 			this.QueryInterface_called = true;
 			if (null==ppvObject) {
 				return new HRESULT(WinError.E_POINTER);
@@ -107,7 +107,7 @@ public class ComEventCallbacks_Test {
 
 			String s = refid.toGuidString();
 			IID appEvnts4 = new IID(APPLICATION_EVENTS_4);
-			REFIID.ByValue riid = new REFIID.ByValue(appEvnts4.getPointer());
+			REFIID riid = new REFIID(appEvnts4.getPointer());
 
 			if (refid.equals(riid)) {
 				ppvObject.setValue(this.getPointer());
@@ -151,7 +151,7 @@ public class ComEventCallbacks_Test {
 		Unknown unk = new Unknown(ppWordApp.getValue());
 		PointerByReference ppCpc = new PointerByReference();
 		IID cpcIID = new IID("{B196B284-BAB4-101A-B69C-00AA00341D07}");
-		hr = unk.QueryInterface(new REFIID.ByValue(cpcIID), ppCpc);
+		hr = unk.QueryInterface(new REFIID(cpcIID), ppCpc);
 		COMUtils.checkRC(hr);
 		ConnectionPointContainer cpc = new ConnectionPointContainer(ppCpc.getValue());
 
@@ -176,7 +176,7 @@ public class ComEventCallbacks_Test {
 		// Call Quit
 		Dispatch d = new Dispatch(ppWordApp.getValue());
 		DISPID dispIdMember = new DISPID(1105); // Quit
-		REFIID.ByValue niid = new REFIID.ByValue(Guid.IID_NULL);
+		REFIID niid = new REFIID(Guid.IID_NULL);
 		LCID lcid = Kernel32.INSTANCE.GetSystemDefaultLCID();
 		WinDef.WORD wFlags = new WinDef.WORD(1);
 		DISPPARAMS.ByReference pDispParams = new DISPPARAMS.ByReference();

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ConnectionPointContainer_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ConnectionPointContainer_Test.java
@@ -67,7 +67,7 @@ public class ConnectionPointContainer_Test {
 		// Close Word
 		Dispatch d = new Dispatch(this.ppWordApp.getValue());
 		DISPID dispIdMember = new DISPID(1105); // Quit
-		REFIID.ByValue riid = new REFIID.ByValue(Guid.IID_NULL);
+		REFIID riid = new REFIID(Guid.IID_NULL);
 		LCID lcid = Kernel32.INSTANCE.GetSystemDefaultLCID();
 		WinDef.WORD wFlags = new WinDef.WORD(1);
 		DISPPARAMS.ByReference pDispParams = new DISPPARAMS.ByReference();
@@ -84,7 +84,7 @@ public class ConnectionPointContainer_Test {
 		Unknown unk = new Unknown(this.ppWordApp.getValue());
 		PointerByReference ppCpc = new PointerByReference();
 		IID cpcIID = new IID("{B196B284-BAB4-101A-B69C-00AA00341D07}");
-		HRESULT hr = unk.QueryInterface(new REFIID.ByValue(cpcIID), ppCpc);
+		HRESULT hr = unk.QueryInterface(new REFIID(cpcIID), ppCpc);
 		COMUtils.checkRC(hr);
 		ConnectionPointContainer cpc = new ConnectionPointContainer(ppCpc.getValue());
 	}
@@ -95,7 +95,7 @@ public class ConnectionPointContainer_Test {
 		Unknown unk = new Unknown(this.ppWordApp.getValue());
 		PointerByReference ppCpc = new PointerByReference();
 		IID cpcIID = new IID("{B196B284-BAB4-101A-B69C-00AA00341D07}");
-		HRESULT hr = unk.QueryInterface(new REFIID.ByValue(cpcIID), ppCpc);
+		HRESULT hr = unk.QueryInterface(new REFIID(cpcIID), ppCpc);
 		COMUtils.checkRC(hr);
 		ConnectionPointContainer cpc = new ConnectionPointContainer(ppCpc.getValue());
 
@@ -114,7 +114,7 @@ public class ConnectionPointContainer_Test {
 		Unknown unk = new Unknown(this.ppWordApp.getValue());
 		PointerByReference ppCpc = new PointerByReference();
 		IID cpcIID = new IID("{B196B284-BAB4-101A-B69C-00AA00341D07}");
-		HRESULT hr = unk.QueryInterface(new REFIID.ByValue(cpcIID), ppCpc);
+		HRESULT hr = unk.QueryInterface(new REFIID(cpcIID), ppCpc);
 		COMUtils.checkRC(hr);
 		ConnectionPointContainer cpc = new ConnectionPointContainer(ppCpc.getValue());
 
@@ -153,13 +153,13 @@ public class ConnectionPointContainer_Test {
 		}
 
 		@Override
-		public HRESULT GetIDsOfNames(REFIID.ByValue riid, WString[] rgszNames, int cNames, LCID lcid, DISPIDByReference rgDispId) {
+		public HRESULT GetIDsOfNames(REFIID riid, WString[] rgszNames, int cNames, LCID lcid, DISPIDByReference rgDispId) {
 			return new HRESULT(WinError.E_NOTIMPL);
 		}
 
 		public boolean Invoke_called = false;
 		@Override
-		public HRESULT Invoke(DISPID dispIdMember, REFIID.ByValue riid, LCID lcid, WORD wFlags,
+		public HRESULT Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
 				DISPPARAMS.ByReference pDispParams, VARIANT.ByReference pVarResult, EXCEPINFO.ByReference pExcepInfo,
 	            IntByReference puArgErr) {
 			this.Invoke_called = true;
@@ -170,7 +170,7 @@ public class ConnectionPointContainer_Test {
 		//------------------------ IUnknown ------------------------------
 		public boolean QueryInterface_called = false;
 		@Override
-		public HRESULT QueryInterface(REFIID.ByValue refid, PointerByReference ppvObject) {
+		public HRESULT QueryInterface(REFIID refid, PointerByReference ppvObject) {
 			this.QueryInterface_called = true;
 			if (null==ppvObject) {
 				return new HRESULT(WinError.E_POINTER);
@@ -178,7 +178,7 @@ public class ConnectionPointContainer_Test {
 
 			String s = refid.toGuidString();
 			IID appEvnts4 = new IID("{00020A01-0000-0000-C000-000000000046}");
-			REFIID.ByValue riid = new REFIID.ByValue(appEvnts4.getPointer());
+			REFIID riid = new REFIID(appEvnts4.getPointer());
 
 			if (refid.equals(riid)) {
 				return WinError.S_OK;
@@ -214,7 +214,7 @@ public class ConnectionPointContainer_Test {
 		Unknown unk = new Unknown(this.ppWordApp.getValue());
 		PointerByReference ppCpc = new PointerByReference();
 		IID cpcIID = new IID("{B196B284-BAB4-101A-B69C-00AA00341D07}");
-		HRESULT hr = unk.QueryInterface(new REFIID.ByValue(cpcIID), ppCpc);
+		HRESULT hr = unk.QueryInterface(new REFIID(cpcIID), ppCpc);
 		COMUtils.checkRC(hr);
 		ConnectionPointContainer cpc = new ConnectionPointContainer(ppCpc.getValue());
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IDispatchTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IDispatchTest.java
@@ -102,7 +102,7 @@ public class IDispatchTest extends TestCase {
         WString[] ptName = new WString[] { new WString("Application") };
         DISPIDByReference pdispID = new DISPIDByReference();
 
-        HRESULT hr = dispatch.GetIDsOfNames(new REFIID.ByValue(Guid.IID_NULL), ptName, 1, LOCALE_SYSTEM_DEFAULT, pdispID);
+        HRESULT hr = dispatch.GetIDsOfNames(new REFIID(Guid.IID_NULL), ptName, 1, LOCALE_SYSTEM_DEFAULT, pdispID);
         COMUtils.checkRC(hr);
         assertEquals(0, hr.intValue());
     }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ITypeLibTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ITypeLibTest.java
@@ -130,8 +130,9 @@ public class ITypeLibTest extends TestCase {
         BSTRByReference szNameBuf = new BSTRByReference(OleAuto.INSTANCE.SysAllocString("Application"));
         ULONG lHashVal = new ULONG(0);
         USHORTByReference pcFound = new USHORTByReference((short)20);
-
-        HRESULT hr = shellTypeLib.FindName(szNameBuf, lHashVal, null, null, pcFound);
+        PointerByReference ppTInfo = new PointerByReference();
+        MEMBERID[] rgMemId = new MEMBERID[20];
+        HRESULT hr = shellTypeLib.FindName(szNameBuf, lHashVal, ppTInfo, rgMemId, pcFound);
 
         COMUtils.checkRC(hr);
         //System.out.println("szNameBuf: " + szNameBuf);

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IUnknownTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IUnknownTest.java
@@ -66,7 +66,7 @@ public class IUnknownTest extends TestCase {
     public void testQueryInterface() {
         Unknown iUnknown = this.createIUnknown();
         PointerByReference ppvObject = new PointerByReference();
-        iUnknown.QueryInterface(new REFIID.ByValue(IUnknown.IID_IUNKNOWN), ppvObject);
+        iUnknown.QueryInterface(new REFIID(IUnknown.IID_IUNKNOWN), ppvObject);
 
         assertTrue("ppvObject:" + ppvObject.toString(), ppvObject != null);
     }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/RunningObjectTable_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/RunningObjectTable_Test.java
@@ -125,7 +125,7 @@ public class RunningObjectTable_Test {
 			
 			IUnknown unk = new Unknown(ppunkObject.getValue());
 			PointerByReference ppvObject = new PointerByReference();
-			hr = unk.QueryInterface(new REFIID.ByValue(IUnknown.IID_IUNKNOWN), ppvObject);
+			hr = unk.QueryInterface(new REFIID(IUnknown.IID_IUNKNOWN), ppvObject);
 			assertEquals(0, hr.intValue());
 			assertNotNull(ppvObject.getValue());
 			


### PR DESCRIPTION
Remove a ton of JVM crashes by using REFIID instead of REFIID.ByValue. REFIID is a REference to IID, so most definitely not a ByValue type.

Fixed https://github.com/java-native-access/jna/issues/407 too. Many of the COM tests remain broken, will see if I have time to look at them later. They all need to be ported from MS Word to Shell or something else guaranteed to be installed.