### PR TITLE
Experimental: Add alignment

### DIFF
--- a/native/libffi/src/x86/ffi.c
+++ b/native/libffi/src/x86/ffi.c
@@ -655,6 +655,9 @@ ffi_prep_incoming_args(char *stack, void **rvalue, void **avalue,
 #endif
     }
 
+  /* Align if necessary */
+  if ((sizeof(void*) - 1) & (size_t) argp)
+    argp = (char *) ALIGN(argp, sizeof(void*));
   return (size_t)argp - (size_t)stack;
 }
 


### PR DESCRIPTION
It seems that this patch will fix my issue https://github.com/java-native-access/jna/issues/553
If I understand that code correctly, there is nearly a similar alignment, just 5 lines above, but this code is only for X86_WIN64. Enabling this by default (instead of my fix) will also fix my problem.

Maybe you can take a look at this.
