### PR TITLE
Initial support for Wininet.dll and enumeration of its' / IE's cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Features
 * [#552](https://github.com/java-native-access/jna/pull/552): Added `Module32FirstW` and `Module32NextW` to `com.sun.jna.platform.win32.Kernel32` (and helper to `com.sun.jna.platform.win32.Kernel32Util`) and `MODULEENTRY32W` structure to `com.sun.jna.platform.win32.Tlhelp32` - [@mlfreeman2](https://github.com/mlfreeman2).
 * [#564](https://github.com/java-native-access/jna/pull/564): Use generic definition of Native#loadLibrary [@lgoldstein](https://github.com/lgoldstein)
 * [#562](https://github.com/java-native-access/jna/pull/562): Added `com.sun.jna.platform.win32.VersionUtil` with `getFileVersionInfo` utility method to get file major, minor, revision, and build version parts - [@mlfreeman2](https://github.com/mlfreeman2).
+* [#563](https://github.com/java-native-access/jna/pull/563): Added `com.sun.jna.platform.win32.Wininet` with the following 4 methods: `FindFirstUrlCacheEntry`, `DeleteUrlCacheEntry`, `FindCloseUrlCache`, `FindNextUrlCacheEntry`, and the `INTERNET_CACHE_ENTRY_INFO` structure, and a helper in `com.sun.jna.platform.win32.WininetUtil` for parsing WinInet's cache - [@mlfreeman2](https://github.com/mlfreeman2).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Wininet.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Wininet.java
@@ -1,0 +1,370 @@
+/* Copyright (c) 2015 Michael Freeman, All Rights Reserved
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.  
+ */
+package com.sun.jna.platform.win32;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.Union;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIOptions;
+
+/**
+ * Functions in WinInet.dll
+ */
+public interface Wininet extends StdCallLibrary {
+    /**
+     * A usable instance of this interface
+     */
+    Wininet INSTANCE = Native.loadLibrary("wininet", Wininet.class, W32APIOptions.DEFAULT_OPTIONS);
+
+    /**
+     * Normal cache entry; can be deleted to recover space for new entries.
+     */
+    int NORMAL_CACHE_ENTRY        = 1;
+
+    /**
+     * Sticky cache entry that is exempt from scavenging for the amount of time
+     * specified by dwExemptDelta.<br>
+     * The default value set by CommitUrlCacheEntryA and CommitUrlCacheEntryW is
+     * one day.
+     */
+    int STICKY_CACHE_ENTRY        = 4;
+
+    /**
+     * Cache entry file that has been edited externally. This cache entry type
+     * is exempt from scavenging.
+     */
+    int EDITED_CACHE_ENTRY        = 8;
+
+    /**
+     * Not currently implemented.
+     */
+    int TRACK_OFFLINE_CACHE_ENTRY = 16;
+
+    /**
+     * Not currently implemented.
+     */
+    int TRACK_ONLINE_CACHE_ENTRY  = 32;
+
+    /**
+     * Partial response cache entry.
+     */
+    int SPARSE_CACHE_ENTRY        = 65536;
+
+    /**
+     * Cookie cache entry.
+     */
+    int COOKIE_CACHE_ENTRY        = 1048576;
+
+    /**
+     * Visited link cache entry.
+     */
+    int URLHISTORY_CACHE_ENTRY    = 2097152;
+
+    /**
+     * Closes the specified cache enumeration handle.
+     * 
+     * @param hFind
+     *            Handle returned by a previous call to the
+     *            FindFirstUrlCacheEntry function.
+     * @return Returns TRUE if successful, or FALSE otherwise. To get extended
+     *         error information, call GetLastError.
+     */
+    boolean FindCloseUrlCache(HANDLE hFind);
+
+    /**
+     * @param lpszUrlName
+     *            String that contains the name of the source that corresponds
+     *            to the cache entry.
+     * @return Returns TRUE if successful, or FALSE otherwise.<br>
+     *         To get extended error information, call GetLastError.<br>
+     *         Possible error values include the following.<br>
+     *         <ul>
+     *         <li><b>ERROR_ACCESS_DENIED:</b>The file is locked or in use. The
+     *         entry is marked and deleted when the file is unlocked.</li>
+     *         <li><b>ERROR_FILE_NOT_FOUND:</b>The file is not in the cache.
+     *         </li>
+     *         </ul>
+     */
+    boolean DeleteUrlCacheEntry(String lpszUrlName);
+
+    /**
+     * Begins the enumeration of the Internet cache.
+     * 
+     * @param lpszUrlSearchPattern
+     *            A pointer to a string that contains the source name pattern to
+     *            search for.<br>
+     *            This parameter can only be set to "cookie:", "visited:", or
+     *            NULL.<br>
+     *            Set this parameter to "cookie:" to enumerate the cookies or
+     *            "visited:" to enumerate the URL History entries in the cache.
+     *            <br>
+     *            If this parameter is NULL, FindFirstUrlCacheEntry returns all
+     *            content entries in the cache.
+     * @param lpFirstCacheEntryInfo
+     *            Pointer to an INTERNET_CACHE_ENTRY_INFO structure.
+     * @param lpcbCacheEntryInfo
+     *            Pointer to a variable that specifies the size of the
+     *            lpFirstCacheEntryInfo buffer, in bytes.<br>
+     *            When the function returns, the variable contains the number of
+     *            bytes copied to the buffer, or the required size needed to
+     *            retrieve the cache entry, in bytes.
+     * @return Returns a handle that the application can use in the
+     *         FindNextUrlCacheEntry function to retrieve subsequent entries in
+     *         the cache.<br>
+     *         If the function fails, the return value is NULL. To get extended
+     *         error information, call GetLastError.<br>
+     *         ERROR_INSUFFICIENT_BUFFER indicates that the size of
+     *         lpFirstCacheEntryInfo as specified by
+     *         lpdwFirstCacheEntryInfoBufferSize is not sufficient to contain
+     *         all the information.<br>
+     *         The value returned in lpdwFirstCacheEntryInfoBufferSize indicates
+     *         the buffer size necessary to contain all the information.
+     */
+    HANDLE FindFirstUrlCacheEntry(String lpszUrlSearchPattern, INTERNET_CACHE_ENTRY_INFO lpFirstCacheEntryInfo,
+            IntByReference lpcbCacheEntryInfo);
+
+    /**
+     * @param hEnumHandle
+     *            Handle to the enumeration obtained from a previous call to
+     *            FindFirstUrlCacheEntry.
+     * @param lpNextCacheEntryInfo
+     *            Pointer to an INTERNET_CACHE_ENTRY_INFO structure that
+     *            receives information about the cache entry.
+     * @param lpcbCacheEntryInfo
+     *            Pointer to a variable that specifies the size of the
+     *            lpNextCacheEntryInfo buffer, in bytes.<br>
+     *            When the function returns, the variable contains the number of
+     *            bytes copied to the buffer, or the size of the buffer required
+     *            to retrieve the cache entry, in bytes.
+     * @return Returns TRUE if successful, or FALSE otherwise.<br>
+     *         To get extended error information, call GetLastError. <br>
+     *         Possible error values include the following.<br>
+     *         <ul>
+     *         <li><b>ERROR_INSUFFICIENT_BUFFER:</b>The size of
+     *         lpNextCacheEntryInfo as specified by
+     *         lpdwNextCacheEntryInfoBufferSize is not sufficient to contain all
+     *         the information.<br>
+     *         The value returned in lpdwNextCacheEntryInfoBufferSize indicates
+     *         the buffer size necessary to contain all the information.</li>
+     *         <li><b>ERROR_NO_MORE_ITEMS:</b>The enumeration completed.</li>
+     *         </ul>
+     */
+    boolean FindNextUrlCacheEntry(HANDLE hEnumHandle, INTERNET_CACHE_ENTRY_INFO lpNextCacheEntryInfo,
+            IntByReference lpcbCacheEntryInfo);
+
+    /**
+     * Contains information about an entry in the Internet cache.
+     * 
+     * <pre>
+     * <code>
+     * typedef struct _INTERNET_CACHE_ENTRY_INFO {
+     *   DWORD    dwStructSize;
+     *   LPTSTR   lpszSourceUrlName;
+     *   LPTSTR   lpszLocalFileName;
+     *   DWORD    CacheEntryType;
+     *   DWORD    dwUseCount;
+     *   DWORD    dwHitRate;
+     *   DWORD    dwSizeLow;
+     *   DWORD    dwSizeHigh;
+     *   FILETIME LastModifiedTime;
+     *   FILETIME ExpireTime;
+     *   FILETIME LastAccessTime;
+     *   FILETIME LastSyncTime;
+     *   LPTSTR   lpHeaderInfo;
+     *   DWORD    dwHeaderInfoSize;
+     *   LPTSTR   lpszFileExtension;
+     *   union {
+     *     DWORD dwReserved;
+     *     DWORD dwExemptDelta;
+     *   };
+     * } INTERNET_CACHE_ENTRY_INFO, *LPINTERNET_CACHE_ENTRY_INFO;
+     * 
+     *     </code>
+     * </pre>
+     * 
+     * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa385134(v=
+     *      vs.85).aspx
+     */
+    static class INTERNET_CACHE_ENTRY_INFO extends Structure {
+        /**
+         * Size of this structure, in bytes. This value can be used to help
+         * determine the version of the cache system.
+         */
+        public int               dwStructSize;
+
+        /**
+         * Pointer to a null-terminated string that contains the URL name. The
+         * string occupies the memory area at the end of this structure.
+         */
+        public Pointer           lpszSourceUrlName;
+
+        /**
+         * Pointer to a null-terminated string that contains the local file
+         * name. The string occupies the memory area at the end of this
+         * structure.
+         */
+        public Pointer           lpszLocalFileName;
+
+        /**
+         * A bitmask indicating the type of cache entry and its properties.<br>
+         * The cache entry types include: history entries
+         * (URLHISTORY_CACHE_ENTRY), cookie entries (COOKIE_CACHE_ENTRY), and
+         * normal cached content (NORMAL_CACHE_ENTRY). <br>
+         * <br>
+         * This member can be zero or more of the following property flags, and
+         * cache type flags listed below.
+         * <ul>
+         * <li><b>EDITED_CACHE_ENTRY:</b> Cache entry file that has been edited
+         * externally. This cache entry type is exempt from scavenging.</li>
+         * <li><b>SPARSE_CACHE_ENTRY:</b> Partial response cache entry.</li>
+         * <li><b>STICKY_CACHE_ENTRY:</b> Sticky cache entry that is exempt from
+         * scavenging for the amount of time specified by dwExemptDelta.<br>
+         * The default value set by CommitUrlCacheEntryA and
+         * CommitUrlCacheEntryW is one day.</li>
+         * <li><b>TRACK_OFFLINE_CACHE_ENTRY:</b> Not currently implemented.</li>
+         * <li><b>TRACK_ONLINE_CACHE_ENTRY:</b> Not currently implemented.</li>
+         * </ul>
+         * <br>
+         * The following list contains the cache type flags.
+         * <ul>
+         * <li><b>COOKIE_CACHE_ENTRY:</b> Cookie cache entry.</li>
+         * <li><b>NORMAL_CACHE_ENTRY:</b> Normal cache entry; can be deleted to
+         * recover space for new entries.</li>
+         * <li><b>URLHISTORY_CACHE_ENTRY:</b> Visited link cache entry.</li>
+         * </ul>
+         */
+        public int               CacheEntryType;
+
+        /**
+         * Current number of WinInet callers using the cache entry.
+         */
+        public int               dwUseCount;
+
+        /**
+         * Number of times the cache entry was retrieved.
+         */
+        public int               dwHitRate;
+
+        /**
+         * Low-order portion of the file size, in bytes.
+         */
+        public int               dwSizeLow;
+
+        /**
+         * High-order portion of the file size, in bytes.
+         */
+        public int               dwSizeHigh;
+
+        /**
+         * FILETIME structure that contains the last modified time of this URL,
+         * in Greenwich mean time format.
+         */
+        public Kernel32.FILETIME LastModifiedTime;
+
+        /**
+         * FILETIME structure that contains the expiration time of this file, in
+         * Greenwich mean time format.
+         */
+        public Kernel32.FILETIME ExpireTime;
+
+        /**
+         * FILETIME structure that contains the last accessed time, in Greenwich
+         * mean time format.
+         */
+        public Kernel32.FILETIME LastAccessTime;
+
+        /**
+         * FILETIME structure that contains the last time the cache was
+         * synchronized.
+         */
+        public Kernel32.FILETIME LastSyncTime;
+
+        /**
+         * Pointer to a buffer that contains the header information. The buffer
+         * occupies the memory at the end of this structure.
+         */
+        public Pointer           lpHeaderInfo;
+
+        /**
+         * Size of the lpHeaderInfo buffer, in TCHARs.
+         */
+        public int               dwHeaderInfoSize;
+
+        /**
+         * Pointer to a string that contains the file name extension used to
+         * retrieve the data as a file. The string occupies the memory area at
+         * the end of this structure.
+         */
+        public Pointer           lpszFileExtension;
+
+        /**
+         * A union of the last two distinct fields in INTERNET_CACHE_ENTRY_INFO
+         */
+        public UNION             u;
+
+        /**
+         * Additional data (the path and URLs mentioned previously, and more)
+         */
+        public byte[]            additional;
+
+        public INTERNET_CACHE_ENTRY_INFO(int size) {
+            additional = new byte[size];
+        }
+
+        /**
+         * A union of the last two distinct fields in INTERNET_CACHE_ENTRY_INFO
+         * 
+         * <pre>
+         * <code>
+         *             union {
+         *                 DWORD dwReserved;
+         *                 DWORD dwExemptDelta;
+         *             };</code>
+         * </pre>
+         */
+        public static class UNION extends Union {
+            /**
+             * Reserved. Must be zero.
+             */
+            public int dwReserved;
+
+            /**
+             * Exemption time from the last accessed time, in seconds.
+             */
+            public int dwExemptDelta;
+        }
+
+        @Override
+        protected List getFieldOrder() {
+            return Arrays.asList("dwStructSize", "lpszSourceUrlName", "lpszLocalFileName",
+                    "CacheEntryType", "dwUseCount", "dwHitRate", "dwSizeLow", "dwSizeHigh", "LastModifiedTime",
+                    "ExpireTime", "LastAccessTime", "LastSyncTime", "lpHeaderInfo", "dwHeaderInfoSize",
+                    "lpszFileExtension", "u", "additional");
+        }
+
+        @Override
+        public String toString() {
+            return (lpszLocalFileName == null ? "" : lpszLocalFileName.getWideString(0) + " => ")
+                    + (lpszSourceUrlName == null ? "null" : lpszSourceUrlName.getWideString(0));
+        }
+
+    }
+
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/WininetUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WininetUtil.java
@@ -1,0 +1,126 @@
+/* Copyright (c) 2015 Michael Freeman, All Rights Reserved
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.  
+ */
+package com.sun.jna.platform.win32;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.sun.jna.Native;
+import com.sun.jna.platform.win32.Wininet.INTERNET_CACHE_ENTRY_INFO;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.ptr.IntByReference;
+
+/**
+ * Reusable functions that use WinInet
+ */
+public class WininetUtil {
+    /**
+     * Helper function for traversing wininet's cache and returning all entries.
+     * <br>
+     * Some entries are cookies, some entries are history items, and some are
+     * actual files.<br>
+     * 
+     * @return A map of cache URL => local file (or URL => empty string for
+     *         cookie and history entries)
+     */
+    public static Map<String, String> getCache() {
+        List<INTERNET_CACHE_ENTRY_INFO> items = new ArrayList<Wininet.INTERNET_CACHE_ENTRY_INFO>();
+
+        HANDLE cacheHandle = null;
+        Win32Exception we = null;
+        int lastError = 0;
+
+        // return
+        Map<String, String> cacheItems = new LinkedHashMap<String, String>();
+
+        try {
+            IntByReference size = new IntByReference();
+
+            // for every entry, we call the API twice:
+            // once to get the size into the IntByReference
+            // then again to get the actual item
+            cacheHandle = Wininet.INSTANCE.FindFirstUrlCacheEntry(null, null, size);
+            lastError = Native.getLastError();
+            
+            // if there's nothing in the cache, we're done.
+            if (lastError == WinError.ERROR_NO_MORE_ITEMS) {
+                return cacheItems;
+            } else if (lastError != WinError.ERROR_SUCCESS && lastError != WinError.ERROR_INSUFFICIENT_BUFFER) {
+                throw new Win32Exception(lastError);
+            }
+
+            INTERNET_CACHE_ENTRY_INFO entry = new INTERNET_CACHE_ENTRY_INFO(size.getValue());
+            cacheHandle = Wininet.INSTANCE.FindFirstUrlCacheEntry(null, entry, size);
+
+            if (cacheHandle == null) {
+                throw new Win32Exception(Native.getLastError());
+            }
+
+            items.add(entry);
+
+            while (true) {
+                size = new IntByReference();
+
+                // for every entry, we call the API twice:
+                // once to get the size into the IntByReference
+                // then again to get the actual item
+                boolean result = Wininet.INSTANCE.FindNextUrlCacheEntry(cacheHandle, null, size);
+
+                if (!result) {
+                    lastError = Native.getLastError();
+                    if (lastError == WinError.ERROR_NO_MORE_ITEMS) {
+                        break;
+                    } else if (lastError != WinError.ERROR_SUCCESS && lastError != WinError.ERROR_INSUFFICIENT_BUFFER) {
+                        throw new Win32Exception(lastError);
+                    }
+                }
+
+                entry = new INTERNET_CACHE_ENTRY_INFO(size.getValue());
+                result = Wininet.INSTANCE.FindNextUrlCacheEntry(cacheHandle, entry, size);
+
+                if (!result) {
+                    lastError = Native.getLastError();
+                    if (lastError == WinError.ERROR_NO_MORE_ITEMS) {
+                        break;
+                    } else if (lastError != WinError.ERROR_SUCCESS && lastError != WinError.ERROR_INSUFFICIENT_BUFFER) {
+                        throw new Win32Exception(lastError);
+                    }
+                }
+                items.add(entry);
+            }
+
+            for (INTERNET_CACHE_ENTRY_INFO item : items) {
+                cacheItems.put(item.lpszSourceUrlName.getWideString(0), item.lpszLocalFileName == null ? "" : item.lpszLocalFileName.getWideString(0));
+            }
+
+        } catch (Win32Exception e) {
+            we = e;
+        } finally {
+            if (cacheHandle != null) {
+                if (!Wininet.INSTANCE.FindCloseUrlCache(cacheHandle)) {
+                    if (we != null) {
+                        Win32Exception e = new Win32Exception(Native.getLastError());
+                        e.addSuppressed(we);
+                        we = e;
+                    }
+                }
+            }
+        }
+        if (we != null) {
+            throw we;
+        }
+        return cacheItems;
+    }
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/WininetTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/WininetTest.java
@@ -1,0 +1,118 @@
+/* Copyright (c) 2015 Michael Freeman, All Rights Reserved
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.  
+ */
+package com.sun.jna.platform.win32;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+import com.sun.jna.Native;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.platform.win32.Wininet.INTERNET_CACHE_ENTRY_INFO;
+import com.sun.jna.ptr.IntByReference;
+
+public class WininetTest extends AbstractWin32TestSupport {
+
+    public static void main(String[] args) {
+        JUnitCore jUnitCore = new JUnitCore();
+        jUnitCore.run(WininetTest.class);
+    }
+
+    @Test
+    public void testFindCloseUrlCache() {
+        boolean result = Wininet.INSTANCE.FindCloseUrlCache(null);
+        int lastError = Native.getLastError();
+        assertFalse("FindCloseUrlCache should return false with an invalid handle.", result);
+        assertEquals("GetLastError should return ERROR_INVALID_HANDLE", WinError.ERROR_INVALID_HANDLE, lastError);
+    }
+
+    @Test
+    public void testDeleteUrlCacheEntry() {
+        boolean result = Wininet.INSTANCE.DeleteUrlCacheEntry("c:\\tempWinInetTest");
+        int lastError = Native.getLastError();
+        assertFalse("DeleteUrlCacheEntry should return false with a bogus path.", result);
+        assertEquals("GetLastError should return ERROR_FILE_NOT_FOUND", WinError.ERROR_FILE_NOT_FOUND, lastError);
+    }
+
+    @Test
+    public void testFindFirstUrlCacheEntry() {
+        IntByReference size = new IntByReference();
+        HANDLE cacheHandle = Wininet.INSTANCE.FindFirstUrlCacheEntry(null, null, size);
+        int lastError = Native.getLastError();
+        // ERROR_INSUFFICIENT_BUFFER is returned when there are items in the cache
+        // ERROR_NO_MORE_ITEMS is returned when the cache is empty.
+        // Both are acceptable for a mapping test where the state of the cache would be unknown.
+        assertTrue("GetLastError should have returned ERROR_INSUFFICIENT_BUFFER or ERROR_NO_MORE_ITEMS.", lastError ==  WinError.ERROR_INSUFFICIENT_BUFFER || lastError == WinError.ERROR_NO_MORE_ITEMS);
+        assertNull("FindFirstUrlCacheEntry should have returned null.", cacheHandle);
+    }
+
+    @Test
+    public void testFindNextUrlCacheEntry() {
+        HANDLE cacheHandle = null;
+        try {
+            IntByReference size = new IntByReference();
+            int lastError = 0;
+
+            // for every entry, we call the API twice:
+            // once to get the size into the IntByReference
+            // then again to get the actual item
+            cacheHandle = Wininet.INSTANCE.FindFirstUrlCacheEntry(null, null, size);
+            lastError = Native.getLastError();
+            assertNull("FindFirstUrlCacheEntry should have returned null.", cacheHandle);
+            
+            // if the Wininet cache is empty, exercise FindNextUrlCacheEntry with an invalid handle 
+            // just to ensure the mapping gets tested
+            if (lastError == WinError.ERROR_NO_MORE_ITEMS) {
+                boolean result = Wininet.INSTANCE.FindNextUrlCacheEntry(null, null, size);
+                lastError = Native.getLastError();
+                assertFalse("FindNextUrlCacheEntry should have returned false.", result);
+                assertEquals("GetLastError should have returned ERROR_INVALID_PARAMETER.",
+                        WinError.ERROR_INVALID_PARAMETER, lastError);              
+                return;
+            }
+            
+            assertEquals("GetLastError should have returned ERROR_INSUFFICIENT_BUFFER.",
+                    WinError.ERROR_INSUFFICIENT_BUFFER, lastError);
+
+            INTERNET_CACHE_ENTRY_INFO entry = new INTERNET_CACHE_ENTRY_INFO(size.getValue());
+            cacheHandle = Wininet.INSTANCE.FindFirstUrlCacheEntry(null, entry, size);
+            lastError = Native.getLastError();
+
+            assertNotNull("FindFirstUrlCacheEntry should not have returned null.", cacheHandle);
+            assertEquals("GetLastError should have returned ERROR_SUCCESS.", WinError.ERROR_SUCCESS, lastError);
+
+            size = new IntByReference();
+
+            // for every entry, we call the API twice:
+            // once to get the size into the IntByReference
+            // then again to get the actual item
+            boolean result = Wininet.INSTANCE.FindNextUrlCacheEntry(cacheHandle, null, size);
+            lastError = Native.getLastError();
+            assertFalse("FindNextUrlCacheEntry should have returned false.", result);
+            assertEquals("GetLastError should have returned ERROR_INSUFFICIENT_BUFFER.",
+                    WinError.ERROR_INSUFFICIENT_BUFFER, lastError);
+
+            entry = new INTERNET_CACHE_ENTRY_INFO(size.getValue());
+            result = Wininet.INSTANCE.FindNextUrlCacheEntry(cacheHandle, entry, size);
+            lastError = Native.getLastError();
+            assertTrue("FindNextUrlCacheEntry should have returned true.", result);
+            assertEquals("GetLastError should have returned ERROR_SUCCESS.", WinError.ERROR_SUCCESS, lastError);
+
+        } finally {
+            if (cacheHandle != null) {
+                if (!Wininet.INSTANCE.FindCloseUrlCache(cacheHandle)) {
+                    throw new Win32Exception(Native.getLastError());
+                }
+            }
+        }
+    }
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/WininetUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/WininetUtilTest.java
@@ -1,0 +1,69 @@
+/* Copyright (c) 2015 Michael Freeman, All Rights Reserved
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.  
+ */
+package com.sun.jna.platform.win32;
+
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+public class WininetUtilTest extends AbstractWin32TestSupport {
+
+    public static void main(String[] args) {
+        JUnitCore jUnitCore = new JUnitCore();
+        jUnitCore.run(WininetUtilTest.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        // Launch IE in a manner that should ensure it opens even if the system
+        // default browser is Chrome, Firefox, or something else.
+        // Launching IE to a page ensures there will be content in the WinInet
+        // cache.
+        Runtime.getRuntime().exec("cmd /c start iexplore.exe -nomerge -nohome \"http://www.google.com\"");
+
+        // There's no easy way to monitor IE and see when it's done loading
+        // google.com, so just give it 10 seconds.
+        // Google keeps the homepage simple so 10 seconds should be enough time
+        // to get something into a cache.
+        Thread.sleep(10000);
+    }
+
+    @Test
+    public void testGetCache() throws Exception {
+
+        Map<String, String> ieCache = WininetUtil.getCache();
+        assertNotNull("WinInet cache should have some items in it.", ieCache.size() > 1);
+
+        boolean historyEntryFound = false;
+        boolean googleLogoOrOtherImageFound = false;
+        for (String URL : ieCache.keySet()) {
+            if (URL.startsWith("Visited:") && URL.contains("www.google.com")) {
+                historyEntryFound = true;
+            } else if (URL.contains("google.com") && (URL.endsWith("png") || URL.endsWith("jpg"))) {
+                googleLogoOrOtherImageFound = true;
+            }
+        }
+
+        assertTrue("Google logo (or other image) should have been found in the browser cache.", googleLogoOrOtherImageFound);
+        assertTrue("History entry for google.com should have been found in the browser cache.", historyEntryFound);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // only kill the freshly opened Google window, unless someone has two IE windows open to Google.
+        Runtime.getRuntime().exec("taskkill.exe /f /im iexplore.exe /fi \"windowtitle eq Google*\"");
+    }
+}


### PR DESCRIPTION
Adds Wininet interface with the following functions in Wininet.dll:
* `FindFirstUrlCacheEntry`
* `DeleteUrlCacheEntry` 
* `FindCloseUrlCache`
* `FindNextUrlCacheEntry`

Also includes the `INTERNET_CACHE_ENTRY_INFO` structure in Wininet.h

Also includes a helper function for parsing WinInet's / IE's cache.

And last but not least, also includes tests for helper util method and all individual functions in Wininet.