### PR TITLE
Fix return type of Native#loadLibrary to match unconstrained generic …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Bug Fixes
 * [#549](https://github.com/java-native-access/jna/pull/549): Fixed bug in types derived from XID - [@twall](https://github.com/twall).
 * [#536](https://github.com/java-native-access/jna/pull/536): Fixed bug in determining the Library and options associated with types defined outside of a Library - [@twall](https://github.com/twall).
 * [#531](https://github.com/java-native-access/jna/pull/531): Ensure direct-mapped callbacks use the right calling convention - [@twall](https://github.com/twall).
+* [#566](https://github.com/java-native-access/jna/pull/566): Fix return type of Native#loadLibrary to match unconstrained generic [@lgoldstein](https://github.com/lgoldstein)
 
 Release 4.2.1
 =============

--- a/contrib/platform/src/com/sun/jna/platform/mac/MacFileUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/MacFileUtils.java
@@ -32,7 +32,7 @@ public class MacFileUtils extends FileUtils {
 
     public interface FileManager extends Library {
 
-        public FileManager INSTANCE = (FileManager)Native.loadLibrary("CoreServices", FileManager.class);
+        FileManager INSTANCE = Native.loadLibrary("CoreServices", FileManager.class);
 
         int kFSFileOperationDefaultOptions = 0;
         int kFSFileOperationsOverwrite = 0x01;

--- a/contrib/platform/src/com/sun/jna/platform/unix/X11.java
+++ b/contrib/platform/src/com/sun/jna/platform/unix/X11.java
@@ -278,7 +278,7 @@ public interface X11 extends Library {
 
     /** Definition (incomplete) of the Xext library. */
     interface Xext extends Library {
-        Xext INSTANCE = (Xext)Native.loadLibrary("Xext", Xext.class);
+        Xext INSTANCE = Native.loadLibrary("Xext", Xext.class);
         // Shape Kinds
         int ShapeBounding = 0;
         int ShapeClip = 1;
@@ -296,7 +296,7 @@ public interface X11 extends Library {
 
     /** Definition (incomplete) of the Xrender library. */
     interface Xrender extends Library {
-        Xrender INSTANCE = (Xrender)Native.loadLibrary("Xrender", Xrender.class);
+        Xrender INSTANCE = Native.loadLibrary("Xrender", Xrender.class);
         class XRenderDirectFormat extends Structure {
             public short red, redMask;
             public short green, greenMask;
@@ -338,7 +338,7 @@ public interface X11 extends Library {
     /** Definition of the Xevie library. */
     interface Xevie extends Library {
         /** Instance of Xevie. Note: This extension has been removed from xorg/xserver on Oct 22, 2008 because it is broken and maintainerless. */
-        Xevie INSTANCE = (Xevie)Native.loadLibrary("Xevie", Xevie.class);
+        Xevie INSTANCE = Native.loadLibrary("Xevie", Xevie.class);
         int XEVIE_UNMODIFIED = 0;
         int XEVIE_MODIFIED   = 1;
         // Bool XevieQueryVersion (Display* display, int* major_version, int* minor_version);
@@ -355,7 +355,7 @@ public interface X11 extends Library {
 
     /** Definition of the XTest library. */
     interface XTest extends Library {
-        XTest INSTANCE = (XTest)Native.loadLibrary("Xtst", XTest.class);///usr/lib/libxcb-xtest.so.0
+        XTest INSTANCE = Native.loadLibrary("Xtst", XTest.class);///usr/lib/libxcb-xtest.so.0
         boolean XTestQueryExtension(Display display, IntByReference event_basep, IntByReference error_basep, IntByReference majorp, IntByReference minorp);
         boolean XTestCompareCursorWithWindow(Display display, Window window, Cursor cursor);
         boolean XTestCompareCurrentCursorWithWindow(Display display, Window window);
@@ -393,7 +393,7 @@ public interface X11 extends Library {
         }
     }
 
-    X11 INSTANCE = (X11)Native.loadLibrary("X11", X11.class);
+    X11 INSTANCE = Native.loadLibrary("X11", X11.class);
 
     /*
       typedef struct {

--- a/contrib/platform/src/com/sun/jna/platform/win32/Msi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Msi.java
@@ -20,78 +20,77 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Msi extends StdCallLibrary {
 
-    Msi INSTANCE = (Msi)
-        Native.loadLibrary("msi", Msi.class, W32APIOptions.DEFAULT_OPTIONS);
+    Msi INSTANCE = Native.loadLibrary("msi", Msi.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The component being requested is disabled on the computer.
      */
-    static int INSTALLSTATE_NOTUSED = -7;
+    int INSTALLSTATE_NOTUSED = -7;
 
     /**
      * The configuration data is corrupt.
      */
-    static int INSTALLSTATE_BADCONFIG = -6;
+    int INSTALLSTATE_BADCONFIG = -6;
 
     /**
      * The installation is suspended or in progress.
      */
-    static int INSTALLSTATE_INCOMPLETE = -5;
+    int INSTALLSTATE_INCOMPLETE = -5;
 
     /**
      * The feature must run from the source, and the source is unavailable.
      */
-    static int INSTALLSTATE_SOURCEABSENT = -4;
+    int INSTALLSTATE_SOURCEABSENT = -4;
 
     /**
      * The return buffer is full.
      */
-    static int INSTALLSTATE_MOREDATA = -3;
+    int INSTALLSTATE_MOREDATA = -3;
 
     /**
      * An invalid parameter was passed to the function.
      */
-    static int INSTALLSTATE_INVALIDARG = -2;
+    int INSTALLSTATE_INVALIDARG = -2;
 
     /**
      * An unrecognized product or feature was specified.
      */
-    static int INSTALLSTATE_UNKNOWN = -1;
+    int INSTALLSTATE_UNKNOWN = -1;
 
     /**
      * The feature is broken.
      */
-    static int INSTALLSTATE_BROKEN =  0;
+    int INSTALLSTATE_BROKEN =  0;
 
     /**
      * The advertised feature.
      */
-    static int INSTALLSTATE_ADVERTISED =  1;
+    int INSTALLSTATE_ADVERTISED =  1;
 
     /**
      * The component is being removed.
      */
-    static int INSTALLSTATE_REMOVED =  1;
+    int INSTALLSTATE_REMOVED =  1;
 
     /**
      * The feature was uninstalled.
      */
-    static int INSTALLSTATE_ABSENT =  2;
+    int INSTALLSTATE_ABSENT =  2;
 
     /**
      * The feature was installed on the local drive.
      */
-    static int INSTALLSTATE_LOCAL =  3;
+    int INSTALLSTATE_LOCAL =  3;
 
     /**
      * The feature must run from the source, CD-ROM, or network.
      */
-    static int INSTALLSTATE_SOURCE =  4;
+    int INSTALLSTATE_SOURCE =  4;
 
     /**
      * The feature is installed in the default location: local or source.
      */
-    static int INSTALLSTATE_DEFAULT =  5;
+    int INSTALLSTATE_DEFAULT =  5;
 
     /**
      * The MsiGetComponentPath function returns the full path to an installed component. If the key path for the

--- a/contrib/platform/src/com/sun/jna/platform/win32/SetupApi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/SetupApi.java
@@ -29,8 +29,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface SetupApi extends StdCallLibrary {
 
-    SetupApi INSTANCE = (SetupApi)
-        Native.loadLibrary("setupapi", SetupApi.class, W32APIOptions.DEFAULT_OPTIONS);
+    SetupApi INSTANCE = Native.loadLibrary("setupapi", SetupApi.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The GUID_DEVINTERFACE_DISK device interface class is defined for hard disk storage devices.
@@ -82,7 +81,6 @@ public interface SetupApi extends StdCallLibrary {
      * Removable.
      */
     int CM_DEVCAP_REMOVABLE = 0x00000004;
-    
 
 	/** make change in all hardware profiles */
 	int DICS_FLAG_GLOBAL = 0x00000001;
@@ -94,23 +92,22 @@ public interface SetupApi extends StdCallLibrary {
 	/**
 	 * Open/Create/Delete device key.
 	 * 
-         * @see #SetupDiOpenDevRegKey
+     * @see #SetupDiOpenDevRegKey
 	 */
-
 	int DIREG_DEV = 0x00000001;
+
 	/**
 	 * Open/Create/Delete driver key
 	 * 
-         * @see #SetupDiOpenDevRegKey
+     * @see #SetupDiOpenDevRegKey
 	 */
-
 	int DIREG_DRV = 0x00000002;
+
 	/**
 	 * Delete both driver and Device key
 	 * 
-         * @see #SetupDiOpenDevRegKey
+     * @see #SetupDiOpenDevRegKey
 	 */
-
 	int DIREG_BOTH = 0x00000004;
 
 	/**
@@ -123,7 +120,6 @@ public interface SetupApi extends StdCallLibrary {
 	 * by the CM_DRP codes in cfgmgr32.h.
 	 */
 	int SPDRP_DEVICEDESC = 0x00000000;
-
 
     /**
      * The SetupDiGetClassDevs function returns a handle to a device information set that contains requested device

--- a/contrib/platform/src/com/sun/jna/platform/win32/Version.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Version.java
@@ -22,8 +22,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Version extends StdCallLibrary {
 
-    Version INSTANCE = (Version)
-        Native.loadLibrary("version", Version.class, W32APIOptions.DEFAULT_OPTIONS);
+    Version INSTANCE = Native.loadLibrary("version", Version.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Determines whether the operating system can retrieve version information for a specified file. If version

--- a/contrib/platform/test/com/sun/jna/platform/win32/VersionUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/VersionUtilTest.java
@@ -23,21 +23,20 @@ public class VersionUtilTest extends TestCase {
     }
 
     public void testGetFileVersionNumbers() {
-        String testFileName = "regedit.exe";
-        File file = new File(System.getenv("SystemRoot"), testFileName);
-        assertTrue("Test file with version info in it should exist.", file.exists());
+        File file = new File(System.getenv("SystemRoot"), "regedit.exe");
+        assertTrue("Test file with version info in it should exist: " + file, file.exists());
 
         VS_FIXEDFILEINFO version = VersionUtil.getFileVersionInfo(file.getAbsolutePath());
         assertNotNull("Version info should have been returned.", version);
 
-        assertTrue("The major file version number should be greater than 0 when pulling version from \"" + testFileName + "\"", version.getFileVersionMajor() > 0);
-        assertTrue("The minor file version number should be greater than or equal to 0 when pulling version from \"" + testFileName + "\"", version.getFileVersionMinor() >= 0);
-        assertTrue("The revision file version number should be greater than or equal to 0 when pulling version from \"" + testFileName + "\"", version.getFileVersionRevision() >= 0);
-        assertTrue("The build file version number should be greater than or equal to 0  when pulling version from \"" + testFileName + "\"", version.getFileVersionBuild() > 0);
-        
-        assertTrue("The major product version number should be greater than 0 when pulling version from \"" + testFileName + "\"", version.getProductVersionMajor() > 0);
-        assertTrue("The minor product version number should be greater than or equal to 0 when pulling version from \"" + testFileName + "\"", version.getProductVersionMinor() >= 0);
-        assertTrue("The revision product version number should be greater than or equal to 0 when pulling version from \"" + testFileName + "\"", version.getProductVersionRevision() >= 0);
-        assertTrue("The build product version number should be greater than or equal to 0  when pulling version from \"" + testFileName + "\"", version.getProductVersionBuild() > 0);
+        assertTrue("The major file version number should be greater than 0 when pulling version from \"" + file + "\"", version.getFileVersionMajor() > 0);
+        assertTrue("The minor file version number should be greater than or equal to 0 when pulling version from \"" + file + "\"", version.getFileVersionMinor() >= 0);
+        assertTrue("The revision file version number should be greater than or equal to 0 when pulling version from \"" + file + "\"", version.getFileVersionRevision() >= 0);
+        assertTrue("The build file version number should be greater than or equal to 0  when pulling version from \"" + file + "\"", version.getFileVersionBuild() > 0);
+
+        assertTrue("The major product version number should be greater than 0 when pulling version from \"" + file + "\"", version.getProductVersionMajor() > 0);
+        assertTrue("The minor product version number should be greater than or equal to 0 when pulling version from \"" + file + "\"", version.getProductVersionMinor() >= 0);
+        assertTrue("The revision product version number should be greater than or equal to 0 when pulling version from \"" + file + "\"", version.getProductVersionRevision() >= 0);
+        assertTrue("The build product version number should be greater than or equal to 0  when pulling version from \"" + file + "\"", version.getProductVersionBuild() > 0);
     }
 }

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -446,7 +446,7 @@ public final class Native implements Version {
      * @throws UnsatisfiedLinkError if the library cannot be found or
      * dependent libraries are missing.
      */
-    public static <T extends Library> T loadLibrary(Class<T> interfaceClass) {
+    public static <T> T loadLibrary(Class<T> interfaceClass) {
         return loadLibrary(null, interfaceClass);
     }
 
@@ -465,7 +465,7 @@ public final class Native implements Version {
      * dependent libraries are missing.
      * @see #loadLibrary(String, Class, Map)
      */
-    public static <T extends Library> T loadLibrary(Class<T> interfaceClass, Map options) {
+    public static <T> T loadLibrary(Class<T> interfaceClass, Map options) {
         return loadLibrary(null, interfaceClass, options);
     }
 
@@ -483,7 +483,7 @@ public final class Native implements Version {
      * dependent libraries are missing.
      * @see #loadLibrary(String, Class, Map)
      */
-    public static <T extends Library> T loadLibrary(String name, Class<T> interfaceClass) {
+    public static <T> T loadLibrary(String name, Class<T> interfaceClass) {
         return loadLibrary(name, interfaceClass, Collections.emptyMap());
     }
 
@@ -503,7 +503,12 @@ public final class Native implements Version {
      * @throws UnsatisfiedLinkError if the library cannot be found or
      * dependent libraries are missing.
      */
-    public static <T extends Library> T loadLibrary(String name, Class<T> interfaceClass, Map options) {
+    public static <T> T loadLibrary(String name, Class<T> interfaceClass, Map options) {
+        if (!Library.class.isAssignableFrom(interfaceClass)) {
+            throw new IllegalArgumentException("Interface (" + interfaceClass.getSimpleName() + ")"
+                    + " of library=" + name + " does not extend " + Library.class.getSimpleName());
+        }
+
         Library.Handler handler = new Library.Handler(name, interfaceClass, options);
         ClassLoader loader = interfaceClass.getClassLoader();
         Object proxy = Proxy.newProxyInstance(loader, new Class[] {interfaceClass}, handler);
@@ -1396,7 +1401,7 @@ public final class Native implements Version {
     /** Unregister the native methods for the given class. */
     private static native void unregister(Class<?> cls, long[] handles);
 
-    private static String getSignature(Class<?> cls) {
+    static String getSignature(Class<?> cls) {
         if (cls.isArray()) {
             return "[" + getSignature(cls.getComponentType());
         }

--- a/test/com/sun/jna/AnnotatedLibraryTest.java
+++ b/test/com/sun/jna/AnnotatedLibraryTest.java
@@ -68,8 +68,7 @@ public class AnnotatedLibraryTest extends TestCase {
         });
         
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
-        AnnotationTestLibrary lib = (AnnotationTestLibrary) 
-            Native.loadLibrary("testlib", AnnotationTestLibrary.class, options);
+        AnnotationTestLibrary lib = Native.loadLibrary("testlib", AnnotationTestLibrary.class, options);
         assertEquals("Failed to convert integer return to boolean TRUE", true,
                      lib.returnInt32Argument(true));
         assertTrue("Failed to get annotation from ParameterContext", hasAnnotation[0]);        

--- a/test/com/sun/jna/ArgumentsMarshalTest.java
+++ b/test/com/sun/jna/ArgumentsMarshalTest.java
@@ -8,7 +8,7 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -29,20 +29,21 @@ public class ArgumentsMarshalTest extends TestCase {
     private static final String UNICODE = "[\0444]";
 
     public static interface TestLibrary extends Library {
-        
+
         class CheckFieldAlignment extends Structure {
-            public static class ByValue extends CheckFieldAlignment 
+            public static class ByValue extends CheckFieldAlignment
                 implements Structure.ByValue { }
             public static class ByReference extends CheckFieldAlignment
                 implements Structure.ByReference { }
-        
+
             public byte int8Field;
             public short int16Field;
             public int int32Field;
             public long int64Field;
             public float floatField;
             public double doubleField;
-            
+
+            @Override
             public List getFieldOrder() {
                 return Arrays.asList(new String[] { "int8Field", "int16Field", "int32Field", "int64Field", "floatField", "doubleField" });
             }
@@ -89,7 +90,7 @@ public class ArgumentsMarshalTest extends TestCase {
         int testStructureByReferenceArrayInitialization(CheckFieldAlignment.ByReference[] p, int len);
         void modifyStructureArray(CheckFieldAlignment[] p, int length);
         void modifyStructureByReferenceArray(CheckFieldAlignment.ByReference[] p, int length);
-        
+
         int fillInt8Buffer(byte[] buf, int len, byte value);
         int fillInt16Buffer(short[] buf, int len, short value);
         int fillInt32Buffer(int[] buf, int len, int value);
@@ -97,12 +98,13 @@ public class ArgumentsMarshalTest extends TestCase {
         int fillFloatBuffer(float[] buf, int len, float value);
         int fillDoubleBuffer(double[] buf, int len, double value);
 
-        // Nonexistent functions 
+        // Nonexistent functions
         boolean returnBooleanArgument(Object arg);
 
         // Structure
         class MinTestStructure extends Structure {
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -112,6 +114,7 @@ public class ArgumentsMarshalTest extends TestCase {
         class VariableSizedStructure extends Structure {
             public int length;
             public byte[] buffer;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "length", "buffer" });
             }
@@ -127,6 +130,7 @@ public class ArgumentsMarshalTest extends TestCase {
                 int callback(int arg1, int arg2);
             }
             public TestCallback cb;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "cb" });
             }
@@ -135,14 +139,16 @@ public class ArgumentsMarshalTest extends TestCase {
     }
 
     TestLibrary lib;
+    @Override
     protected void setUp() {
-        lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.loadLibrary("testlib", TestLibrary.class);
     }
-    
+
+    @Override
     protected void tearDown() {
         lib = null;
     }
-    
+
     public void testJavaObjectArgument() {
         Object o = this;
         try {
@@ -159,24 +165,24 @@ public class ArgumentsMarshalTest extends TestCase {
     }
 
     public void testBooleanArgument() {
-        assertTrue("True argument should be returned", 
+        assertTrue("True argument should be returned",
                    lib.returnBooleanArgument(true));
-        assertFalse("False argument should be returned", 
+        assertFalse("False argument should be returned",
                     lib.returnBooleanArgument(false));
     }
 
     public void testInt8Argument() {
         byte b = 0;
-        assertEquals("Wrong value returned", 
+        assertEquals("Wrong value returned",
                      b, lib.returnInt8Argument(b));
         b = 127;
-        assertEquals("Wrong value returned", 
+        assertEquals("Wrong value returned",
                      b, lib.returnInt8Argument(b));
         b = -128;
-        assertEquals("Wrong value returned", 
+        assertEquals("Wrong value returned",
                      b, lib.returnInt8Argument(b));
     }
-    
+
     public void testWideCharArgument() {
         char c = 0;
         assertEquals("Wrong value returned",
@@ -191,64 +197,64 @@ public class ArgumentsMarshalTest extends TestCase {
 
     public void testInt16Argument() {
         short v = 0;
-        assertEquals("Wrong value returned", 
+        assertEquals("Wrong value returned",
                      v, lib.returnInt16Argument(v));
         v = 32767;
-        assertEquals("Wrong value returned", 
+        assertEquals("Wrong value returned",
                      v, lib.returnInt16Argument(v));
         v = -32768;
-        assertEquals("Wrong value returned", 
+        assertEquals("Wrong value returned",
                      v, lib.returnInt16Argument(v));
     }
 
     public void testIntArgument() {
         int value = 0;
-        assertEquals("Should return 32-bit argument", 
+        assertEquals("Should return 32-bit argument",
                      value, lib.returnInt32Argument(value));
         value = 1;
-        assertEquals("Should return 32-bit argument", 
+        assertEquals("Should return 32-bit argument",
                      value, lib.returnInt32Argument(value));
         value = 0x7FFFFFFF;
-        assertEquals("Should return 32-bit argument", 
+        assertEquals("Should return 32-bit argument",
                      value, lib.returnInt32Argument(value));
         value = 0x80000000;
-        assertEquals("Should return 32-bit argument", 
+        assertEquals("Should return 32-bit argument",
                      value, lib.returnInt32Argument(value));
     }
 
     public void testLongArgument() {
         long value = 0L;
-        assertEquals("Should return 64-bit argument", 
+        assertEquals("Should return 64-bit argument",
                      value, lib.returnInt64Argument(value));
         value = 1L;
-        assertEquals("Should return 64-bit argument", 
+        assertEquals("Should return 64-bit argument",
                      value, lib.returnInt64Argument(value));
         value = 0x7FFFFFFFL;
-        assertEquals("Should return 64-bit argument", 
+        assertEquals("Should return 64-bit argument",
                      value, lib.returnInt64Argument(value));
         value = 0x80000000L;
-        assertEquals("Should return 64-bit argument", 
+        assertEquals("Should return 64-bit argument",
                      value, lib.returnInt64Argument(value));
         value = 0x7FFFFFFF00000000L;
-        assertEquals("Should return 64-bit argument", 
+        assertEquals("Should return 64-bit argument",
                      value, lib.returnInt64Argument(value));
         value = 0x8000000000000000L;
-        assertEquals("Should return 64-bit argument", 
+        assertEquals("Should return 64-bit argument",
                      value, lib.returnInt64Argument(value));
     }
 
     public void testNativeLongArgument() {
         NativeLong value = new NativeLong(0);
-        assertEquals("Should return 0", 
+        assertEquals("Should return 0",
                      value, lib.returnLongArgument(value));
         value = new NativeLong(1);
-        assertEquals("Should return 1", 
+        assertEquals("Should return 1",
                      value, lib.returnLongArgument(value));
         value = new NativeLong(0x7FFFFFFF);
-        assertEquals("Should return 0x7FFFFFFF", 
+        assertEquals("Should return 0x7FFFFFFF",
                      value, lib.returnLongArgument(value));
         value = new NativeLong(0x80000000);
-        assertEquals("Should return 0x80000000", 
+        assertEquals("Should return 0x80000000",
                      value, lib.returnLongArgument(value));
     }
 
@@ -272,19 +278,21 @@ public class ArgumentsMarshalTest extends TestCase {
         public Custom(int value) {
             this.value = value;
         }
+        @Override
         public Object fromNative(Object nativeValue, FromNativeContext context) {
             return new Custom(((Integer)nativeValue).intValue());
         }
+        @Override
         public Class nativeType() {
             return Integer.class;
         }
+        @Override
         public Object toNative() {
             return new Integer(value);
         }
     }
     protected NativeMappedLibrary loadNativeMappedLibrary() {
-        return (NativeMappedLibrary)
-            Native.loadLibrary("testlib", NativeMappedLibrary.class);
+        return Native.loadLibrary("testlib", NativeMappedLibrary.class);
     }
     public void testNativeMappedArgument() {
         NativeMappedLibrary lib = loadNativeMappedLibrary();
@@ -302,13 +310,13 @@ public class ArgumentsMarshalTest extends TestCase {
             assertEquals("Argument not mapped", MAGIC64, lib.returnInt64Argument(size));
         }
     }
-    
+
     public void testPointerArgumentReturn() {
         assertEquals("Expect null pointer",
                      null, lib.returnPointerArgument(null));
         Structure s = new TestLibrary.CheckFieldAlignment();
         assertEquals("Expect structure pointer",
-                     s.getPointer(), 
+                     s.getPointer(),
                      lib.returnPointerArgument(s.getPointer()));
     }
 
@@ -323,9 +331,9 @@ public class ArgumentsMarshalTest extends TestCase {
         assertEquals("Expect null pointer", null, lib.returnWStringArgument(null));
         assertEquals("Expect string magic", WMAGIC.toString(), lib.returnWStringArgument(WMAGIC).toString());
     }
-    
+
     public void testInt64ArgumentAlignment() {
-        long value = lib.checkInt64ArgumentAlignment(0x10101010, 0x1111111111111111L, 
+        long value = lib.checkInt64ArgumentAlignment(0x10101010, 0x1111111111111111L,
                                                      0x01010101, 0x2222222222222222L);
         assertEquals("Improper handling of interspersed int32/int64",
                      0x3333333344444444L, value);
@@ -340,7 +348,7 @@ public class ArgumentsMarshalTest extends TestCase {
     public void testStructurePointerArgument() {
         TestLibrary.CheckFieldAlignment struct = new TestLibrary.CheckFieldAlignment();
         assertEquals("Native address of structure should be returned",
-                     struct.getPointer(), 
+                     struct.getPointer(),
                      lib.testStructurePointerArgument(struct));
         // ensure that even if the argument is ByValue, it's passed as ptr
         struct = new TestLibrary.CheckFieldAlignment.ByValue();
@@ -355,12 +363,12 @@ public class ArgumentsMarshalTest extends TestCase {
     }
 
     public void testStructureByValueArgument() {
-        TestLibrary.CheckFieldAlignment.ByValue struct = 
+        TestLibrary.CheckFieldAlignment.ByValue struct =
             new TestLibrary.CheckFieldAlignment.ByValue();
         assertEquals("Wrong alignment in " + struct.toString(true),
                      "0", Integer.toHexString(lib.testStructureByValueArgument(struct)));
     }
-    
+
     public void testStructureByValueTypeInfo() {
         class TestStructure extends Structure implements Structure.ByValue {
             public byte b;
@@ -372,6 +380,7 @@ public class ArgumentsMarshalTest extends TestCase {
             public double d;
             public Pointer[] parray = new Pointer[2];
             public byte[] barray = new byte[2];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "b", "c", "s", "i", "j", "f", "d", "parray", "barray" });
             }
@@ -381,23 +390,23 @@ public class ArgumentsMarshalTest extends TestCase {
         s.size();
     }
 
-    
+
     public void testWriteStructureArrayArgumentMemory() {
         final int LENGTH = 10;
         TestLibrary.CheckFieldAlignment block = new TestLibrary.CheckFieldAlignment();
-        TestLibrary.CheckFieldAlignment[] array = 
+        TestLibrary.CheckFieldAlignment[] array =
             (TestLibrary.CheckFieldAlignment[])block.toArray(LENGTH);
         for (int i=0;i < array.length;i++) {
             array[i].int32Field = i;
         }
         assertEquals("Structure array memory not properly initialized",
                      -1, lib.testStructureArrayInitialization(array, array.length));
-        
+
     }
-    
+
     public void testUninitializedStructureArrayArgument() {
         final int LENGTH = 10;
-        TestLibrary.CheckFieldAlignment[] block = 
+        TestLibrary.CheckFieldAlignment[] block =
             new TestLibrary.CheckFieldAlignment[LENGTH];
         lib.modifyStructureArray(block, block.length);
         for (int i=0;i < block.length;i++) {
@@ -426,7 +435,7 @@ public class ArgumentsMarshalTest extends TestCase {
         catch(IllegalArgumentException e) {
         }
     }
-    
+
     public void testRejectIncompatibleStructureArrayArgument() {
         TestLibrary.CheckFieldAlignment s1 = new TestLibrary.CheckFieldAlignment.ByReference();
         TestLibrary.CheckFieldAlignment[] autoArray = (TestLibrary.CheckFieldAlignment[])s1.toArray(3);
@@ -489,43 +498,43 @@ public class ArgumentsMarshalTest extends TestCase {
     public void testByteArrayArgument() {
         byte[] buf = new byte[1024];
         final byte MAGIC = (byte)0xED;
-        assertEquals("Wrong return value", buf.length, 
+        assertEquals("Wrong return value", buf.length,
                      lib.fillInt8Buffer(buf, buf.length, MAGIC));
         for (int i=0;i < buf.length;i++) {
             assertEquals("Bad value at index " + i, MAGIC, buf[i]);
         }
     }
-    
+
     public void testShortArrayArgument() {
         short[] buf = new short[1024];
         final short MAGIC = (short)0xABED;
-        assertEquals("Wrong return value", buf.length, 
+        assertEquals("Wrong return value", buf.length,
                      lib.fillInt16Buffer(buf, buf.length, MAGIC));
         for (int i=0;i < buf.length;i++) {
             assertEquals("Bad value at index " + i, MAGIC, buf[i]);
         }
     }
-    
+
     public void testIntArrayArgument() {
         int[] buf = new int[1024];
         final int MAGIC = 0xABEDCF23;
-        assertEquals("Wrong return value", buf.length, 
+        assertEquals("Wrong return value", buf.length,
                      lib.fillInt32Buffer(buf, buf.length, MAGIC));
         for (int i=0;i < buf.length;i++) {
             assertEquals("Bad value at index " + i, MAGIC, buf[i]);
         }
     }
-    
-    public void testLongArrayArgument() { 
+
+    public void testLongArrayArgument() {
         long[] buf = new long[1024];
         final long MAGIC = 0x1234567887654321L;
-        assertEquals("Wrong return value", buf.length, 
+        assertEquals("Wrong return value", buf.length,
                      lib.fillInt64Buffer(buf, buf.length, MAGIC));
         for (int i=0;i < buf.length;i++) {
             assertEquals("Bad value at index " + i, MAGIC, buf[i]);
         }
     }
-    
+
     public void testUnsupportedJavaObjectArgument() {
         try {
             lib.returnBooleanArgument(this);
@@ -534,23 +543,23 @@ public class ArgumentsMarshalTest extends TestCase {
         catch(IllegalArgumentException e) {
         }
     }
-    
+
     public void testStringArrayArgument() {
         String[] args = { "one"+UNICODE, "two"+UNICODE, "three"+UNICODE };
         assertEquals("Wrong value returned", args[0], lib.returnStringArrayElement(args, 0));
-        assertNull("Native String array should be null terminated", 
+        assertNull("Native String array should be null terminated",
                    lib.returnStringArrayElement(args, args.length));
     }
-    
+
     public void testWideStringArrayArgument() {
         WString[] args = { new WString("one"+UNICODE), new WString("two"+UNICODE), new WString("three"+UNICODE) };
         assertEquals("Wrong value returned", args[0], lib.returnWideStringArrayElement(args, 0));
         assertNull("Native WString array should be null terminated",
                    lib.returnWideStringArrayElement(args, args.length));
     }
-    
+
     public void testPointerArrayArgument() {
-        Pointer[] args = { 
+        Pointer[] args = {
             new NativeString(getName()).getPointer(),
             null,
             new NativeString(getName()+"2").getPointer(),
@@ -581,7 +590,7 @@ public class ArgumentsMarshalTest extends TestCase {
     };
 
     public void testStructureByReferenceArrayArgument() {
-        CheckFieldAlignment.ByReference[] args = { 
+        CheckFieldAlignment.ByReference[] args = {
             new CheckFieldAlignment.ByReference(),
             null,
             new CheckFieldAlignment.ByReference(),
@@ -599,7 +608,7 @@ public class ArgumentsMarshalTest extends TestCase {
                      Arrays.asList(new String[] { "two", "three", "one" }),
                      Arrays.asList(args));
     }
-    
+
     public void testReadFunctionPointerAsCallback() {
         TestLibrary.CbStruct s = new TestLibrary.CbStruct();
         assertNull("Function pointer field should be null", s.cb);
@@ -640,5 +649,5 @@ public class ArgumentsMarshalTest extends TestCase {
     public static void main(java.lang.String[] argList) {
         junit.textui.TestRunner.run(ArgumentsMarshalTest.class);
     }
-    
+
 }

--- a/test/com/sun/jna/BufferArgumentsMarshalTest.java
+++ b/test/com/sun/jna/BufferArgumentsMarshalTest.java
@@ -8,7 +8,7 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -19,10 +19,6 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
-import java.util.Arrays;
-
-import com.sun.jna.ArgumentsMarshalTest.TestLibrary.CheckFieldAlignment;
-
 import junit.framework.TestCase;
 
 /** Exercise a range of native methods.
@@ -33,7 +29,7 @@ import junit.framework.TestCase;
 public class BufferArgumentsMarshalTest extends TestCase {
 
     public static interface TestLibrary extends Library {
-        
+
         // ByteBuffer alternative definitions
         int fillInt8Buffer(ByteBuffer buf, int len, byte value);
         int fillInt16Buffer(ByteBuffer buf, int len, short value);
@@ -41,7 +37,7 @@ public class BufferArgumentsMarshalTest extends TestCase {
         int fillInt64Buffer(ByteBuffer buf, int len, long value);
         int fillFloatBuffer(ByteBuffer buf, int len, float value);
         int fillDoubleBuffer(ByteBuffer buf, int len, double value);
-        
+
         // {Short|Int|Long|,Float|Double}Buffer alternative definitions
         int fillInt16Buffer(ShortBuffer buf, int len, short value);
         int fillInt32Buffer(IntBuffer buf, int len, int value);
@@ -51,14 +47,16 @@ public class BufferArgumentsMarshalTest extends TestCase {
     }
 
     TestLibrary lib;
+    @Override
     protected void setUp() {
-        lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.loadLibrary("testlib", TestLibrary.class);
     }
-    
+
+    @Override
     protected void tearDown() {
         lib = null;
     }
-    
+
     public void testByteBufferArgument() {
         ByteBuffer buf  = ByteBuffer.allocate(1024).order(ByteOrder.nativeOrder());
         final byte MAGIC = (byte)0xED;
@@ -91,7 +89,7 @@ public class BufferArgumentsMarshalTest extends TestCase {
             assertEquals("Bad value at index " + i, MAGIC, buf.get(i));
         }
     }
-    
+
     public void testDirectByteBufferArgument() {
         ByteBuffer buf  = ByteBuffer.allocateDirect(1024).order(ByteOrder.nativeOrder());
         final byte MAGIC = (byte)0xED;
@@ -106,7 +104,7 @@ public class BufferArgumentsMarshalTest extends TestCase {
                          i < 512 ? MAGIC : 0, buf.get(i));
         }
     }
-    
+
     public void testDirectShortBufferArgument() {
         ByteBuffer buf  = ByteBuffer.allocateDirect(1024*2).order(ByteOrder.nativeOrder());
         ShortBuffer shortBuf = buf.asShortBuffer();
@@ -116,7 +114,7 @@ public class BufferArgumentsMarshalTest extends TestCase {
             assertEquals("Bad value at index " + i, MAGIC, shortBuf.get(i));
         }
     }
-    
+
     public void testDirectIntBufferArgument() {
         ByteBuffer buf  = ByteBuffer.allocateDirect(1024*4).order(ByteOrder.nativeOrder());
         IntBuffer intBuf = buf.asIntBuffer();
@@ -126,7 +124,7 @@ public class BufferArgumentsMarshalTest extends TestCase {
             assertEquals("Bad value at index " + i, MAGIC, intBuf.get(i));
         }
     }
-    
+
     public void testDirectLongBufferArgument() {
         ByteBuffer buf  = ByteBuffer.allocateDirect(1024*8).order(ByteOrder.nativeOrder());
         LongBuffer longBuf = buf.asLongBuffer();
@@ -136,7 +134,7 @@ public class BufferArgumentsMarshalTest extends TestCase {
             assertEquals("Bad value at index " + i, MAGIC, longBuf.get(i));
         }
     }
-    
+
     public void testWrappedByteArrayArgument() {
         byte[] array = new byte[1024];
         ByteBuffer buf = ByteBuffer.wrap(array, 512, 512);
@@ -197,9 +195,9 @@ public class BufferArgumentsMarshalTest extends TestCase {
                          i < 512 ? 0 : MAGIC, array[i]);
         }
     }
-    
+
     public static void main(java.lang.String[] argList) {
         junit.textui.TestRunner.run(BufferArgumentsMarshalTest.class);
     }
-    
+
 }

--- a/test/com/sun/jna/ByReferenceArgumentsTest.java
+++ b/test/com/sun/jna/ByReferenceArgumentsTest.java
@@ -8,7 +8,7 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -41,10 +41,12 @@ public class ByReferenceArgumentsTest extends TestCase {
     }
 
     TestLibrary lib;
+    @Override
     protected void setUp() {
-        lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.loadLibrary("testlib", TestLibrary.class);
     }
-    
+
+    @Override
     protected void tearDown() {
         lib = null;
     }
@@ -93,9 +95,9 @@ public class ByReferenceArgumentsTest extends TestCase {
         lib.setPointerByReferenceNull(pref);
         assertNull("Default pointer should be NULL after call", pref.getValue());
     }
-    
+
     public static void main(java.lang.String[] argList) {
         junit.textui.TestRunner.run(ByReferenceArgumentsTest.class);
     }
-    
+
 }

--- a/test/com/sun/jna/DirectArgumentsMarshalTest.java
+++ b/test/com/sun/jna/DirectArgumentsMarshalTest.java
@@ -8,18 +8,9 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
-
-import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
-import java.nio.DoubleBuffer;
-import java.nio.IntBuffer;
-import java.nio.LongBuffer;
-import java.nio.ShortBuffer;
-
-import com.sun.jna.ArgumentsMarshalTest.TestLibrary.CheckFieldAlignment.ByReference;
 
 /** Exercise a range of native methods.
  *
@@ -29,55 +20,92 @@ public class DirectArgumentsMarshalTest extends ArgumentsMarshalTest {
 
     public static class DirectTestLibrary implements TestLibrary {
         /** Dummy.  Automatically fail when passed an object. */
+        @Override
         public String returnStringArgument(Object arg) {throw new IllegalArgumentException(arg.getClass().getName()); }
+        @Override
         public native boolean returnBooleanArgument(boolean arg);
+        @Override
         public native byte returnInt8Argument(byte arg);
+        @Override
         public native char returnWideCharArgument(char arg);
+        @Override
         public native short returnInt16Argument(short arg);
+        @Override
         public native int returnInt32Argument(int i);
+        @Override
         public native long returnInt64Argument(long l);
+        @Override
         public native NativeLong returnLongArgument(NativeLong l);
+        @Override
         public native float returnFloatArgument(float f);
+        @Override
         public native double returnDoubleArgument(double d);
+        @Override
         public native String returnStringArgument(String s);
+        @Override
         public native WString returnWStringArgument(WString s);
+        @Override
         public native Pointer returnPointerArgument(Pointer p);
+        @Override
         public String returnStringArrayElement(String[] args, int which) {throw new UnsupportedOperationException();}
+        @Override
         public WString returnWideStringArrayElement(WString[] args, int which) {throw new UnsupportedOperationException();}
+        @Override
         public Pointer returnPointerArrayElement(Pointer[] args, int which) {throw new UnsupportedOperationException();}
+        @Override
         public TestPointerType returnPointerArrayElement(TestPointerType[] args, int which) {throw new UnsupportedOperationException();}
+        @Override
         public CheckFieldAlignment returnPointerArrayElement(CheckFieldAlignment.ByReference[] args, int which) {throw new UnsupportedOperationException();}
+        @Override
         public int returnRotatedArgumentCount(String[] args) {throw new UnsupportedOperationException();}
 
+        @Override
         public native long checkInt64ArgumentAlignment(int i, long j, int i2, long j2);
+        @Override
         public native double checkDoubleArgumentAlignment(float i, double j, float i2, double j2);
+        @Override
         public native Pointer testStructurePointerArgument(CheckFieldAlignment p);
+        @Override
         public native int testStructureByValueArgument(CheckFieldAlignment.ByValue p);
+        @Override
         public int testStructureArrayInitialization(CheckFieldAlignment[] p, int len) {
             throw new UnsupportedOperationException();
         }
+        @Override
         public int testStructureByReferenceArrayInitialization(CheckFieldAlignment.ByReference[] p, int len) {
             throw new UnsupportedOperationException();
         }
+        @Override
         public void modifyStructureArray(CheckFieldAlignment[] p, int length) {
-            throw new UnsupportedOperationException(); 
+            throw new UnsupportedOperationException();
         }
+        @Override
         public void modifyStructureByReferenceArray(CheckFieldAlignment.ByReference[] p, int length) {
-            throw new UnsupportedOperationException(); 
+            throw new UnsupportedOperationException();
         }
-            
+
+        @Override
         public native int fillInt8Buffer(byte[] buf, int len, byte value);
+        @Override
         public native int fillInt16Buffer(short[] buf, int len, short value);
+        @Override
         public native int fillInt32Buffer(int[] buf, int len, int value);
+        @Override
         public native int fillInt64Buffer(long[] buf, int len, long value);
+        @Override
         public native int fillFloatBuffer(float[] buf, int len, float value);
+        @Override
         public native int fillDoubleBuffer(double[] buf, int len, double value);
 
         // dummy to avoid causing Native.register to fail
+        @Override
         public boolean returnBooleanArgument(Object arg) {throw new IllegalArgumentException();}
 
+        @Override
         public native Pointer testStructurePointerArgument(MinTestStructure s);
+        @Override
         public native String returnStringFromVariableSizedStructure(VariableSizedStructure s);
+        @Override
         public native void setCallbackInStruct(CbStruct s);
 
         static {
@@ -86,24 +114,30 @@ public class DirectArgumentsMarshalTest extends ArgumentsMarshalTest {
     }
 
     /* Override original. */
+    @Override
     protected void setUp() {
         lib = new DirectTestLibrary();
     }
-    
+
     public static class DirectNativeMappedLibrary implements NativeMappedLibrary {
+        @Override
         public native int returnInt32Argument(Custom arg);
+        @Override
         public native int returnInt32Argument(size_t arg);
+        @Override
         public native long returnInt64Argument(size_t arg);
         static {
             Native.register("testlib");
         }
     }
+    @Override
     protected NativeMappedLibrary loadNativeMappedLibrary() {
         return new DirectNativeMappedLibrary();
     }
 
     // This test crashes on w32 IBM J9 unless -Xint is used
     // (jvmwi3260-20080415_18762)
+    @Override
     public void testWideCharArgument() {
         if (Platform.isWindows()
             && "IBM".equals(System.getProperty("java.vm.vendor"))) {
@@ -113,6 +147,7 @@ public class DirectArgumentsMarshalTest extends ArgumentsMarshalTest {
     }
     // This test crashes on w32 IBM J9 unless -Xint is used
     // (jvmwi3260-20080415_18762)
+    @Override
     public void testWStringArgumentReturn() {
         if (Platform.isWindows()
             && "IBM".equals(System.getProperty("java.vm.vendor"))) {
@@ -122,21 +157,33 @@ public class DirectArgumentsMarshalTest extends ArgumentsMarshalTest {
     }
 
     // Override tests not yet supported in direct mode
+    @Override
     public void testStringArrayArgument() { }
+    @Override
     public void testWriteStructureArrayArgumentMemory() { }
+    @Override
     public void testUninitializedStructureArrayArgument() { }
+    @Override
     public void testRejectNoncontiguousStructureArrayArgument() { }
+    @Override
     public void testRejectIncompatibleStructureArrayArgument() { }
+    @Override
     public void testWideStringArrayArgument() { }
+    @Override
     public void testPointerArrayArgument() { }
+    @Override
     public void testNativeMappedArrayArgument() { }
+    @Override
     public void testStructureByReferenceArrayArgument() { }
+    @Override
     public void testWriteStructureByReferenceArrayArgumentMemory() { }
+    @Override
     public void testReadStructureByReferenceArrayArgumentMemory() { }
+    @Override
     public void testModifiedCharArrayArgument() { }
 
     public static void main(java.lang.String[] argList) {
         junit.textui.TestRunner.run(DirectArgumentsMarshalTest.class);
     }
-    
+
 }

--- a/test/com/sun/jna/JNALoadTest.java
+++ b/test/com/sun/jna/JNALoadTest.java
@@ -1,14 +1,14 @@
 /* Copyright (c) 2007-2009 Timothy Wall, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -26,11 +26,11 @@ import junit.framework.TestCase;
  * that no JNI classes are directly referenced in these tests.
  */
 public class JNALoadTest extends TestCase implements Paths, GCWaits {
-    
+
     private class TestLoader extends URLClassLoader {
         public TestLoader(boolean fromJar) throws MalformedURLException {
             super(new URL[] {
-                    Platform.isWindowsCE() 
+                    Platform.isWindowsCE()
                     ? new File("/Storage Card/" + (fromJar ? "jna.jar" : "test.jar")).toURI().toURL()
                     : new File(BUILDDIR + (fromJar ? "/jna.jar" : "/classes")).toURI().toURL(),
                   }, new CloverLoader());
@@ -41,12 +41,14 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
                 assertLibraryExists();
             }
         }
-        protected Class findClass(String name) throws ClassNotFoundException {
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
             String boot = System.getProperty("jna.boot.library.path");
             if (boot != null) {
                 System.setProperty("jna.boot.library.path", "");
             }
-            Class cls = super.findClass(name);
+            Class<?> cls = super.findClass(name);
             if (boot != null) {
                 System.setProperty("jna.boot.library.path", boot);
             }
@@ -60,7 +62,7 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
             throw new Error("Expected JNA jar file at " + jar + " is missing");
         }
     }
-    
+
     protected void assertLibraryExists() {
         String osPrefix = Platform.getNativeLibraryResourcePrefix();
         String name = System.mapLibraryName("jnidispatch").replace(".dylib", ".jnilib");
@@ -73,7 +75,7 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
     public void testAvoidJarUnpacking() throws Exception {
         System.setProperty("jna.nounpack", "true");
         try {
-            Class cls = Class.forName("com.sun.jna.Native", true, new TestLoader(true));
+            Class<?> cls = Class.forName("com.sun.jna.Native", true, new TestLoader(true));
 
             fail("Class com.sun.jna.Native should not be loadable if jna.nounpack=true: "
                  + cls.getClassLoader());
@@ -88,7 +90,7 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
     public void testAvoidResourcePathLoading() throws Exception {
         System.setProperty("jna.noclasspath", "true");
         try {
-            Class cls = Class.forName("com.sun.jna.Native", true, new TestLoader(false));
+            Class<?> cls = Class.forName("com.sun.jna.Native", true, new TestLoader(false));
 
             fail("Class com.sun.jna.Native should not be loadable if jna.noclasspath=true: "
                  + cls.getClassLoader());
@@ -102,7 +104,7 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
 
     public void testLoadAndUnloadFromJar() throws Exception {
         ClassLoader loader = new TestLoader(true);
-        Class cls = Class.forName("com.sun.jna.Native", true, loader);
+        Class<?> cls = Class.forName("com.sun.jna.Native", true, loader);
         assertEquals("Wrong class loader", loader, cls.getClassLoader());
         assertTrue("System property jna.loaded not set", Boolean.getBoolean("jna.loaded"));
 
@@ -158,7 +160,7 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
     // GC Fails under OpenJDK(linux/ppc)
     public void testLoadAndUnloadFromResourcePath() throws Exception {
         ClassLoader loader = new TestLoader(false);
-        Class cls = Class.forName("com.sun.jna.Native", true, loader);
+        Class<?> cls = Class.forName("com.sun.jna.Native", true, loader);
         assertEquals("Wrong class loader", loader, cls.getClassLoader());
         assertTrue("System property jna.loaded not set", Boolean.getBoolean("jna.loaded"));
 
@@ -209,9 +211,18 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
         }
     }
 
-    // Fails on Sun JVM windows (32 and 64-bit) (JVM bug)
-    // Works with IBM J9 (jdk6) windows
     public void testLoadFromUnicodePath() throws Exception {
+        if (Platform.isWindows()) {
+            String vendor = System.getProperty("java.vendor");
+            if (vendor != null) {
+                vendor = vendor.toLowerCase();
+                if (vendor.contains("oracle") || vendor.contains("sun")) {
+                    System.out.println("Skip " + getName() + " - Fails on Sun JVM windows (32 and 64-bit) (JVM bug), Works with IBM J9 (jdk6) windows");
+                    return;
+                }
+            }
+        }
+
         final String UNICODE = getName() + "-\u0444\u043b\u0441\u0432\u0443";
         File tmpdir = new File(System.getProperty("java.io.tmpdir"));
         File unicodeDir = new File(tmpdir, UNICODE);
@@ -221,7 +232,7 @@ public class JNALoadTest extends TestCase implements Paths, GCWaits {
             System.setProperty("jnidispatch.preserve", "true");
             System.setProperty("jna.tmpdir", unicodeDir.getAbsolutePath());
             ClassLoader loader = new TestLoader(true);
-            Class cls = Class.forName("com.sun.jna.Native", true, loader);
+            Class<?> cls = Class.forName("com.sun.jna.Native", true, loader);
             assertEquals("Wrong class loader", loader, cls.getClassLoader());
             assertTrue("System property jna.loaded not set", Boolean.getBoolean("jna.loaded"));
 

--- a/test/com/sun/jna/LastErrorTest.java
+++ b/test/com/sun/jna/LastErrorTest.java
@@ -1,14 +1,14 @@
 /* Copyright (c) 2009 Timothy Wall, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -22,9 +22,10 @@ import junit.framework.TestCase;
 
 //@SuppressWarnings("unused")
 public class LastErrorTest extends TestCase {
-    
+
     private static final Map OPTIONS = new HashMap() {{
         put(Library.OPTION_FUNCTION_MAPPER, new FunctionMapper() {
+            @Override
             public String getFunctionName(NativeLibrary library, Method m) {
                 if (m.getName().equals("noThrowLastError")
                     || m.getName().equals("throwLastError")) {
@@ -42,8 +43,11 @@ public class LastErrorTest extends TestCase {
     }
 
     public static class DirectTestLibrary implements TestLibrary {
+        @Override
         public native void setLastError(int code);
+        @Override
         public native void noThrowLastError(int code);
+        @Override
         public native void throwLastError(int code) throws LastErrorException;
         static {
             Native.register(NativeLibrary.getInstance("testlib", OPTIONS));
@@ -51,13 +55,14 @@ public class LastErrorTest extends TestCase {
     }
 
     public void testLastErrorPerThreadStorage() throws Exception {
-        final TestLibrary lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        final TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
         final int NTHREADS = 100;
         final int[] errors = new int[NTHREADS];
         Set<Thread> threads = new HashSet<Thread>();
         for (int i=0;i < NTHREADS;i++) {
             final int idx = i;
-            Thread t = new Thread() { public void run() {
+            Thread t = new Thread() { @Override
+            public void run() {
                 lib.setLastError(-idx-1);
                 errors[idx] = Native.getLastError();
             }};
@@ -80,7 +85,7 @@ public class LastErrorTest extends TestCase {
 
     private final int ERROR = Platform.isWindows() ? 1 : -1;
     public void testThrowLastError() {
-        TestLibrary lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class, OPTIONS);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, OPTIONS);
 
         lib.noThrowLastError(ERROR);
         assertEquals("Last error not preserved", ERROR, Native.getLastError());

--- a/test/com/sun/jna/LibraryLoadTest.java
+++ b/test/com/sun/jna/LibraryLoadTest.java
@@ -1,14 +1,14 @@
 /* Copyright (c) 2007-20013 Timothy Wall, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -27,7 +27,7 @@ import java.util.Collections;
 import junit.framework.TestCase;
 
 public class LibraryLoadTest extends TestCase implements Paths {
-    
+
     private class TestLoader extends URLClassLoader {
         public TestLoader(File path) throws MalformedURLException {
             super(new URL[] { path.toURI().toURL(), },
@@ -38,7 +38,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
     public void testLoadJNALibrary() {
         assertTrue("Pointer size should never be zero", Pointer.SIZE > 0);
     }
-    
+
     public void testLoadJAWT() {
         if (!Platform.HAS_AWT || !Platform.HAS_JAWT) return;
 
@@ -48,7 +48,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
         // AWT is unavailable
         AWT.loadJAWT(getName());
     }
-    
+
     public void testLoadAWTAfterJNA() {
         if (!Platform.HAS_AWT) return;
 
@@ -58,7 +58,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
             Toolkit.getDefaultToolkit();
         }
     }
-    
+
     public void testExtractFromResourcePath() throws Exception {
         // doesn't actually load the resource
         assertNotNull(Native.extractFromResourcePath("testlib-path", new TestLoader(new File(TESTPATH))));
@@ -115,19 +115,19 @@ public class LibraryLoadTest extends TestCase implements Paths {
     private Object load() {
         return Native.loadLibrary(Platform.C_LIBRARY_NAME, CLibrary.class);
     }
-    
+
     public void testLoadProcess() {
         Native.loadLibrary(CLibrary.class);
     }
-    
+
     public void testLoadProcessWithOptions() {
         Native.loadLibrary(CLibrary.class, Collections.EMPTY_MAP);
     }
-    
+
     public void testLoadCLibrary() {
         load();
     }
-    
+
     private void copy(File src, File dst) throws Exception {
         FileInputStream is = new FileInputStream(src);
         FileOutputStream os = new FileOutputStream(dst);
@@ -140,7 +140,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
         }
         finally {
             try { is.close(); } catch(IOException e) { }
-            try { os.close(); } catch(IOException e) { } 
+            try { os.close(); } catch(IOException e) { }
         }
     }
 
@@ -163,7 +163,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
             fail("Library '" + newLibName + "' at " + dst + " could not be loaded: " + e);
         }
     }
-    
+
     public void testLoadLibraryWithLongName() throws Exception {
         File tmpdir = Native.getTempDir();
         String libName = NativeLibrary.mapSharedLibraryName("testlib");
@@ -202,7 +202,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
             }
         }
     }
-    
+
     public void testLoadFrameworkLibraryAbsolute() {
         if (Platform.isMac()) {
             final String PATH = "/System/Library/Frameworks/CoreServices";
@@ -255,7 +255,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
     // dependent libraries in the same directory as the original
     public void testLoadDependentLibraryWithAlteredSearchPath() {
         try {
-            TestLib2 lib = (TestLib2)Native.loadLibrary("testlib2", TestLib2.class);
+            TestLib2 lib = Native.loadLibrary("testlib2", TestLib2.class);
             lib.dependentReturnFalse();
         }
         catch(UnsatisfiedLinkError e) {
@@ -271,11 +271,11 @@ public class LibraryLoadTest extends TestCase implements Paths {
     public void testLoadProperCLibraryVersion() {
         if (Platform.isWindows()) return;
 
-        CLibrary lib = (CLibrary)Native.loadLibrary("c", CLibrary.class);
+        CLibrary lib = Native.loadLibrary("c", CLibrary.class);
         assertNotNull("Couldn't get current user",
                       lib.getpwuid(lib.geteuid()));
     }
-    
+
     private static class AWT {
         public static void loadJAWT(String name) {
             Frame f = new Frame(name);

--- a/test/com/sun/jna/NativeLibraryTest.java
+++ b/test/com/sun/jna/NativeLibraryTest.java
@@ -1,14 +1,14 @@
 /* Copyright (c) 2007 Timothy Wall, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -27,7 +27,7 @@ import com.sun.jna.win32.W32APIOptions;
 import junit.framework.TestCase;
 
 public class NativeLibraryTest extends TestCase {
-    
+
     public static interface TestLibrary extends Library {
         int callCount();
     }
@@ -65,7 +65,7 @@ public class NativeLibraryTest extends TestCase {
         long start = System.currentTimeMillis();
         while (ref.get() != null) {
             Thread.sleep(10);
-            if (System.currentTimeMillis() - start > 5000) 
+            if (System.currentTimeMillis() - start > 5000)
                 break;
         }
         assertNull("Library not GC'd", ref.get());
@@ -77,41 +77,41 @@ public class NativeLibraryTest extends TestCase {
         // occasionally get the same library handle back on subsequent dlopen
         Thread.sleep(2);
 
-        TestLibrary lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
         assertEquals("Library should be newly loaded after explicit dispose of all native libraries",
                      1, lib.callCount());
         if (lib.callCount() <= 1) {
             fail("Library should not be reloaded without dispose");
         }
     }
-    
+
     public void testUseSingleLibraryInstance() {
-        TestLibrary lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
         int count = lib.callCount();
-        TestLibrary lib2 = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib2 = Native.loadLibrary("testlib", TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Interfaces should share a library instance",
                      count + 1, count2);
     }
 
     public void testAliasLibraryFilename() {
-        TestLibrary lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
         int count = lib.callCount();
         NativeLibrary nl = NativeLibrary.getInstance("testlib");
-        TestLibrary lib2 = (TestLibrary)Native.loadLibrary(nl.getFile().getName(), TestLibrary.class);
+        TestLibrary lib2 = Native.loadLibrary(nl.getFile().getName(), TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Simple filename load not aliased", count + 1, count2);
     }
-    
+
     public void testAliasLibraryFullPath() {
-        TestLibrary lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
         int count = lib.callCount();
         NativeLibrary nl = NativeLibrary.getInstance("testlib");
-        TestLibrary lib2 = (TestLibrary)Native.loadLibrary(nl.getFile().getAbsolutePath(), TestLibrary.class);
+        TestLibrary lib2 = Native.loadLibrary(nl.getFile().getAbsolutePath(), TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Full pathname load not aliased", count + 1, count2);
     }
-    
+
     public void testAliasSimpleLibraryName() throws Exception {
         NativeLibrary nl = NativeLibrary.getInstance("testlib");
         File file = nl.getFile();
@@ -121,12 +121,12 @@ public class NativeLibraryTest extends TestCase {
         long start = System.currentTimeMillis();
         while (ref.get() != null) {
             Thread.sleep(10);
-            if (System.currentTimeMillis() - start > 5000) 
+            if (System.currentTimeMillis() - start > 5000)
                 fail("Timed out waiting for library to be GC'd");
         }
-        TestLibrary lib = (TestLibrary)Native.loadLibrary(file.getAbsolutePath(), TestLibrary.class);
+        TestLibrary lib = Native.loadLibrary(file.getAbsolutePath(), TestLibrary.class);
         int count = lib.callCount();
-        TestLibrary lib2 = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib2 = Native.loadLibrary("testlib", TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Simple library name not aliased", count + 1, count2);
     }
@@ -160,29 +160,29 @@ public class NativeLibraryTest extends TestCase {
         System.gc();
         long start = System.currentTimeMillis();
         while (ref.get() != null && System.currentTimeMillis() - start < 2000) {
-            Thread.sleep(10);            
+            Thread.sleep(10);
         }
         assertNotNull("Library GC'd when it should not be", ref.get());
         f.invokeInt(new Object[0]);
         f = null;
         System.gc();
         while (ref.get() != null && System.currentTimeMillis() - start < 5000) {
-            Thread.sleep(10);            
+            Thread.sleep(10);
         }
         assertNull("Library not GC'd", ref.get());
     }
-    
+
     public void testLookupGlobalVariable() {
         NativeLibrary lib = NativeLibrary.getInstance("testlib");
         Pointer global = lib.getGlobalVariableAddress("test_global");
         assertNotNull("Test variable not found", global);
         final int MAGIC = 0x12345678;
         assertEquals("Wrong value for library global variable", MAGIC, global.getInt(0));
-        
+
         global.setInt(0, MAGIC+1);
         assertEquals("Library global variable not updated", MAGIC+1, global.getInt(0));
     }
-    
+
     public void testMatchUnversionedToVersioned() throws Exception {
     	File lib0 = File.createTempFile("lib", ".so.0");
     	File dir = lib0.getParentFile();
@@ -200,7 +200,7 @@ public class NativeLibraryTest extends TestCase {
                      lib1_1.getCanonicalPath(),
                      NativeLibrary.matchLibrary(name, path));
     }
-    
+
     public void testAvoidFalseMatch() throws Exception {
         File lib0 = File.createTempFile("lib", ".so.1");
     	File dir = lib0.getParentFile();
@@ -230,7 +230,7 @@ public class NativeLibraryTest extends TestCase {
     		assertEquals("Badly parsed version", EXPECTED[i], NativeLibrary.parseVersion(VERSIONS[i]), 0.0000001);
     	}
     }
-    
+
     // XFAIL on android
     public void testGetProcess() {
         if (Platform.isAndroid()) {
@@ -277,10 +277,10 @@ public class NativeLibraryTest extends TestCase {
         if (!Platform.isWindows()) {
             return;
         }
-        NativeLibrary kernel32 = (NativeLibrary)NativeLibrary.getInstance("kernel32", W32APIOptions.DEFAULT_OPTIONS);
+        NativeLibrary kernel32 = NativeLibrary.getInstance("kernel32", W32APIOptions.DEFAULT_OPTIONS);
         Function get = kernel32.getFunction("GetLastError");
         Function set = kernel32.getFunction("SetLastError");
-        assertEquals("SetLastError should not be customized", Function.class, set.getClass()); 
+        assertEquals("SetLastError should not be customized", Function.class, set.getClass());
         assertTrue("GetLastError should be a Function", Function.class.isAssignableFrom(get.getClass()));
         assertTrue("GetLastError should be a customized Function", get.getClass() != Function.class);
         final int EXPECTED = 42;
@@ -303,6 +303,7 @@ public class NativeLibraryTest extends TestCase {
 
     // returns unloadable "shared library" on any input
     private class DisfunctClassLoader extends ClassLoader {
+        @Override
         public URL getResource(String name) {
             try {
                 return new URL("jar", "", name);
@@ -312,6 +313,7 @@ public class NativeLibraryTest extends TestCase {
             }
         }
 
+        @Override
         public InputStream getResourceAsStream(String name) {
             return new ByteArrayInputStream(new byte[0]);
         }

--- a/test/com/sun/jna/NativeTest.java
+++ b/test/com/sun/jna/NativeTest.java
@@ -1,18 +1,19 @@
 /* Copyright (c) 2007-2013 Timothy Wall, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,9 +25,37 @@ import junit.framework.TestCase;
 
 //@SuppressWarnings("unused")
 public class NativeTest extends TestCase {
-    
+
     private static final String UNICODE = "[\u0444]";
 
+    public void testLoadLibraryMethods() throws Exception {
+        Class<?>[][] params = {
+                { Class.class },
+                { Class.class, Map.class },
+                { String.class, Class.class },
+                { String.class, Class.class, Map.class }
+        };
+
+        StringBuilder signature = new StringBuilder(Long.SIZE);
+        for (Class<?>[] paramTypes : params) {
+            signature.setLength(0);
+            signature.append('(');
+            for (Class<?> p : paramTypes) {
+                signature.append(Native.getSignature(p));
+            }
+            signature.append(')');
+
+            try {
+                Method m = Native.class.getMethod("loadLibrary", paramTypes);
+                Class<?> returnType = m.getReturnType();
+                signature.append(Native.getSignature(returnType));
+                assertSame("Mismatched return type for signature=" + signature, Object.class, returnType);
+//                System.out.println("===>" + m.getName() + ": " + signature);
+            } catch(NoSuchMethodError err) {
+                fail("No method for signature=" + signature);
+            }
+        }
+    }
     public void testVersion() {
         String[] INPUTS = { "1.0", "1.0.1", "2.1.3" };
         float[] EXPECTED = { 1.0f, 1.0f, 2.1f };
@@ -55,9 +84,9 @@ public class NativeTest extends TestCase {
         // Keep stuff within the extended ASCII range so we work with more
         // limited native encodings
         String UNICODE = "Un \u00e9l\u00e9ment gr\u00e2ce \u00e0 l'index";
-        
+
         if (!UNICODE.equals(new String(UNICODE.getBytes()))) {
-            // If the extended characters aren't encodable in the default 
+            // If the extended characters aren't encodable in the default
             // encoding, punt and use straight ASCII
             UNICODE = "";
             for (char ch=1;ch < 128;ch++) {
@@ -65,23 +94,23 @@ public class NativeTest extends TestCase {
             }
         }
         final String UNICODEZ = UNICODE + "\0more stuff";
-        
+
         byte[] customEncoded = Native.getBytes(UNICODE, ENCODING);
         byte[] expected = UNICODE.getBytes(ENCODING);
         for (int i=0;i < Math.min(customEncoded.length, expected.length);i++) {
-            assertEquals("Improperly encoded (" + ENCODING + ") from Java at " + i, 
+            assertEquals("Improperly encoded (" + ENCODING + ") from Java at " + i,
                          expected[i], customEncoded[i]);
         }
-        assertEquals("Wrong number of encoded characters (" + ENCODING + ")", 
+        assertEquals("Wrong number of encoded characters (" + ENCODING + ")",
                      expected.length, customEncoded.length);
         String result = Native.toString(customEncoded, ENCODING);
-        assertEquals("Improperly decoded from native bytes (" + ENCODING + ")", 
+        assertEquals("Improperly decoded from native bytes (" + ENCODING + ")",
                      UNICODE, result);
-        
+
         assertEquals("Should truncate bytes at NUL terminator",
                      UNICODE, Native.toString(UNICODEZ.getBytes(ENCODING), ENCODING));
     }
-    
+
     public void testToStringList() {
         List<String> expected = Arrays.asList(getClass().getPackage().getName(), getClass().getSimpleName(), "testToStringList");
         StringBuilder sb = new StringBuilder();
@@ -89,7 +118,7 @@ public class NativeTest extends TestCase {
             sb.append(value).append('\0');
         }
         sb.append('\0');
-        
+
         List<String> actual = Native.toStringList(sb.toString().toCharArray());
         assertEquals("Mismatched result size", expected.size(), actual.size());
         for (int index = 0; index < expected.size(); index++) {
@@ -105,17 +134,17 @@ public class NativeTest extends TestCase {
         byte[] utf8 = Native.getBytes(UNICODE);
         byte[] expected = UNICODE.getBytes(Native.DEFAULT_ENCODING);
         for (int i=0;i < Math.min(utf8.length, expected.length);i++) {
-            assertEquals("Improperly encoded at " + i, 
+            assertEquals("Improperly encoded at " + i,
                          expected[i], utf8[i]);
         }
         assertEquals("Wrong number of encoded characters", expected.length, utf8.length);
         String result = Native.toString(utf8);
         assertEquals("Improperly decoded", UNICODE, result);
-        
+
         assertEquals("Should truncate bytes at NUL terminator",
                      UNICODE, Native.toString(UNICODEZ.getBytes(Native.DEFAULT_ENCODING)));
     }
-    
+
     public void testCustomizeDefaultStringEncoding() {
         Properties oldprops = (Properties)System.getProperties().clone();
         final String ENCODING = System.getProperty("file.encoding");
@@ -137,14 +166,16 @@ public class NativeTest extends TestCase {
     public void testSynchronizedAccess() throws Exception {
         final boolean[] lockHeld = { false };
         final NativeLibrary nlib = NativeLibrary.getInstance("testlib", TestLib.class.getClassLoader());
-        final TestLib lib = (TestLib)Native.loadLibrary("testlib", TestLib.class);
-        final TestLib synchlib = (TestLib)Native.synchronizedLibrary(lib); 
+        final TestLib lib = Native.loadLibrary("testlib", TestLib.class);
+        final TestLib synchlib = (TestLib)Native.synchronizedLibrary(lib);
         final TestLib.VoidCallback cb = new TestLib.VoidCallback() {
+            @Override
             public void callback() {
                 lockHeld[0] = Thread.holdsLock(nlib);
             }
         };
         Thread t0 = new Thread() {
+            @Override
             public void run() {
                 lib.callVoidCallback(cb);
             }
@@ -155,6 +186,7 @@ public class NativeTest extends TestCase {
                    lockHeld[0]);
 
         Thread t1 = new Thread() {
+            @Override
             public void run() {
                 synchlib.callVoidCallback(cb);
             }
@@ -169,12 +201,13 @@ public class NativeTest extends TestCase {
         static class InnerTestClass extends Structure {
             interface TestCallback extends Callback { }
             static class InnerSubclass extends InnerTestClass implements Structure.ByReference { }
-            protected List getFieldOrder() { 
+            @Override
+            protected List getFieldOrder() {
                 return Collections.EMPTY_LIST;
             }
         }
     }
-    
+
     public void testFindInterfaceClass() throws Exception {
         Class interfaceClass = TestInterface.class;
         Class cls = TestInterface.InnerTestClass.class;
@@ -198,26 +231,25 @@ public class NativeTest extends TestCase {
             put(OPTION_STRUCTURE_ALIGNMENT, new Integer(TEST_ALIGNMENT));
             put(OPTION_STRING_ENCODING, TEST_ENCODING);
         }};
-        TestInterfaceWithInstance ARBITRARY = (TestInterfaceWithInstance) 
-            Native.loadLibrary("testlib", TestInterfaceWithInstance.class, TEST_OPTS);
+        TestInterfaceWithInstance ARBITRARY = Native.loadLibrary("testlib", TestInterfaceWithInstance.class, TEST_OPTS);
         abstract class TestStructure extends Structure {}
     }
     public void testOptionsInferenceFromInstanceField() {
         Class[] classes = { TestInterfaceWithInstance.class, TestInterfaceWithInstance.TestStructure.class };
         String[] desc = { "interface", "structure from interface" };
         for (int i=0;i < classes.length;i++) {
-            assertEquals("Wrong type mapper found for " + desc[i], 
+            assertEquals("Wrong type mapper found for " + desc[i],
                          TestInterfaceWithInstance.TEST_MAPPER,
                          Native.getTypeMapper(classes[i]));
-            assertEquals("Wrong alignment found for " + desc[i], 
+            assertEquals("Wrong alignment found for " + desc[i],
                          TestInterfaceWithInstance.TEST_ALIGNMENT,
                          Native.getStructureAlignment(classes[i]));
-            assertEquals("Wrong string encoding found for " + desc[i], 
+            assertEquals("Wrong string encoding found for " + desc[i],
                          TestInterfaceWithInstance.TEST_ENCODING,
                          Native.getStringEncoding(classes[i]));
         }
     }
-    
+
     public interface TestInterfaceWithOptions extends Library {
         int TEST_ALIGNMENT = Structure.ALIGN_NONE;
         TypeMapper TEST_MAPPER = new DefaultTypeMapper();
@@ -232,13 +264,13 @@ public class NativeTest extends TestCase {
     public void testOptionsInferenceFromOptionsField() {
         Class[] classes = { TestInterfaceWithOptions.class, TestInterfaceWithOptions.TestStructure.class };
         for (int i=0;i < classes.length;i++) {
-            assertEquals("Wrong type mapper found", 
+            assertEquals("Wrong type mapper found",
                          TestInterfaceWithOptions.TEST_MAPPER,
                          Native.getTypeMapper(classes[i]));
-            assertEquals("Wrong alignment found", 
+            assertEquals("Wrong alignment found",
                          TestInterfaceWithOptions.TEST_ALIGNMENT,
                          Native.getStructureAlignment(classes[i]));
-            assertEquals("Wrong encoding found", 
+            assertEquals("Wrong encoding found",
                          TestInterfaceWithOptions.TEST_ENCODING,
                          Native.getStringEncoding(classes[i]));
         }
@@ -250,10 +282,10 @@ public class NativeTest extends TestCase {
         abstract class TestStructure extends Structure { }
     }
     public void testOptionsInferenceFromTypeMapperField() {
-        assertEquals("Wrong type mapper found for interface which provides TYPE_MAPPER", 
+        assertEquals("Wrong type mapper found for interface which provides TYPE_MAPPER",
                      TestInterfaceWithTypeMapper.TEST_MAPPER,
                      Native.getTypeMapper(TestInterfaceWithTypeMapper.class));
-        assertEquals("Wrong type mapper found for structure from interface which provides TYPE_MAPPER", 
+        assertEquals("Wrong type mapper found for structure from interface which provides TYPE_MAPPER",
                      TestInterfaceWithTypeMapper.TEST_MAPPER,
                      Native.getTypeMapper(TestInterfaceWithTypeMapper.TestStructure.class));
     }
@@ -263,10 +295,10 @@ public class NativeTest extends TestCase {
         abstract class TestStructure extends Structure { }
     }
     public void testOptionsInferenceFromAlignmentField() {
-        assertEquals("Wrong alignment found for interface which provides STRUCTURE_ALIGNMENT", 
+        assertEquals("Wrong alignment found for interface which provides STRUCTURE_ALIGNMENT",
                      Structure.ALIGN_NONE,
                      Native.getStructureAlignment(TestInterfaceWithAlignment.class));
-        assertEquals("Wrong alignment found for structure from interface which provides STRUCTURE_ALIGNMENT", 
+        assertEquals("Wrong alignment found for structure from interface which provides STRUCTURE_ALIGNMENT",
                      Structure.ALIGN_NONE,
                      Native.getStructureAlignment(TestInterfaceWithAlignment.TestStructure.class));
     }
@@ -276,10 +308,10 @@ public class NativeTest extends TestCase {
         abstract class TestStructure extends Structure { }
     }
     public void testOptionsInferenceFromEncodingField() {
-        assertEquals("Wrong encoding found for interface which provides STRING_ENCODING", 
+        assertEquals("Wrong encoding found for interface which provides STRING_ENCODING",
                      TestInterfaceWithEncoding.STRING_ENCODING,
                      Native.getStringEncoding(TestInterfaceWithEncoding.class));
-        assertEquals("Wrong encoding found for structure from interface which provides STRING_ENCODING", 
+        assertEquals("Wrong encoding found for structure from interface which provides STRING_ENCODING",
                      TestInterfaceWithEncoding.STRING_ENCODING,
                      Native.getStringEncoding(TestInterfaceWithEncoding.TestStructure.class));
     }
@@ -289,13 +321,14 @@ public class NativeTest extends TestCase {
         TypeMapper TYPE_MAPPER = new DefaultTypeMapper();
         class TypeMappedStructure extends Structure {
             public String stringField;
+            @Override
             protected List getFieldOrder() { return Arrays.asList("stringField"); }
         }
     }
     public interface OptionsSubclass extends OptionsBase, Library {
         TypeMapper _MAPPER = new DefaultTypeMapper();
         Map _OPTIONS = new HashMap() { { put(Library.OPTION_TYPE_MAPPER, _MAPPER); } };
-        OptionsSubclass INSTANCE = (OptionsSubclass)Native.loadLibrary("testlib", OptionsSubclass.class, _OPTIONS);
+        OptionsSubclass INSTANCE = Native.loadLibrary("testlib", OptionsSubclass.class, _OPTIONS);
     }
     public void testStructureOptionsInference() {
         Structure s = new OptionsBase.TypeMappedStructure();
@@ -422,18 +455,18 @@ public class NativeTest extends TestCase {
                     "com.sun.jna.NativeLibraryTest",
                     "com.sun.jna.PointerTest",
                     "com.sun.jna.MemoryTest",
-                    "com.sun.jna.LibraryLoadTest", 
+                    "com.sun.jna.LibraryLoadTest",
                     "com.sun.jna.ArgumentsMarshalTest",
                     "com.sun.jna.ReturnTypesTest",
-                    "com.sun.jna.TypeMapperTest", 
+                    "com.sun.jna.TypeMapperTest",
                     "com.sun.jna.ByReferenceArgumentsTest",
-                    "com.sun.jna.LastErrorTest", 
+                    "com.sun.jna.LastErrorTest",
                     "com.sun.jna.StructureTest",// 1 wce failure (RO fields)
                     "com.sun.jna.StructureByValueTest",
                     "com.sun.jna.UnionTest",
-                    "com.sun.jna.IntegerTypeTest", 
+                    "com.sun.jna.IntegerTypeTest",
                     "com.sun.jna.VMCrashProtectionTest",
-                    "com.sun.jna.CallbacksTest", 
+                    "com.sun.jna.CallbacksTest",
                     "com.sun.jna.JNAUnloadTest",
                     "com.sun.jna.DirectTest",
                     "com.sun.jna.DirectArgumentsMarshalTest",

--- a/test/com/sun/jna/PerformanceTest.java
+++ b/test/com/sun/jna/PerformanceTest.java
@@ -13,16 +13,13 @@
 package com.sun.jna;
 
 import junit.framework.*;
-import com.sun.jna.*;
-import com.sun.jna.ptr.PointerByReference;
-import java.lang.ref.*;
 import java.io.File;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Map;
 import java.util.HashMap;
-import java.lang.reflect.Method; 
+import java.lang.reflect.Method;
 
 import com.sun.jna.DirectTest.TestInterface;
 import com.sun.jna.DirectTest.TestLibrary;
@@ -40,7 +37,7 @@ public class PerformanceTest extends TestCase implements Paths {
             }
             System.load(path);
         }
-        
+
         private static native double cos(double x);
         private static native int getpid();
     }
@@ -52,7 +49,7 @@ public class PerformanceTest extends TestCase implements Paths {
     static class MathLibrary {
 
         public static native double cos(double x);
-        
+
         static {
             Native.register(Platform.MATH_LIBRARY_NAME);
         }
@@ -81,7 +78,7 @@ public class PerformanceTest extends TestCase implements Paths {
         public static native int strlen(Pointer p);
         public static native int strlen(byte[] b);
         public static native int strlen(Buffer b);
-        
+
         static {
             Native.register(Platform.C_LIBRARY_NAME);
         }
@@ -120,8 +117,7 @@ public class PerformanceTest extends TestCase implements Paths {
         Pointer pb = Native.getDirectBufferPointer(b);
 
         String mname = Platform.MATH_LIBRARY_NAME;
-        MathInterface mlib = (MathInterface)
-            Native.loadLibrary(mname, MathInterface.class);
+        MathInterface mlib = Native.loadLibrary(mname, MathInterface.class);
         Function f = NativeLibrary.getInstance(mname).getFunction("cos");
 
         ///////////////////////////////////////////
@@ -204,17 +200,17 @@ public class PerformanceTest extends TestCase implements Paths {
         Map options = new HashMap();
         if (Platform.isWindows()) {
             options.put(Library.OPTION_FUNCTION_MAPPER, new FunctionMapper() {
+                @Override
                 public String getFunctionName(NativeLibrary library, Method method) {
                     String name = method.getName();
-                    if ("getpid".equals(name)) { 
+                    if ("getpid".equals(name)) {
                         name = "_getpid";
                     }
                     return name;
                 }
             });
         }
-        CInterface clib = (CInterface)
-            Native.loadLibrary(cname, CInterface.class, options);
+        CInterface clib = Native.loadLibrary(cname, CInterface.class, options);
 
         ///////////////////////////////////////////
         // getpid
@@ -473,9 +469,10 @@ public class PerformanceTest extends TestCase implements Paths {
 
         ///////////////////////////////////////////
         // Callbacks
-        TestInterface tlib = (TestInterface)Native.loadLibrary("testlib", TestInterface.class);
+        TestInterface tlib = Native.loadLibrary("testlib", TestInterface.class);
         start = System.currentTimeMillis();
         TestInterface.Int32Callback cb = new TestInterface.Int32Callback() {
+            @Override
             public int invoke(int arg1, int arg2) {
                 return arg1 + arg2;
             }
@@ -492,6 +489,7 @@ public class PerformanceTest extends TestCase implements Paths {
 
         start = System.currentTimeMillis();
         TestInterface.NativeLongCallback nlcb = new TestInterface.NativeLongCallback() {
+            @Override
             public NativeLong invoke(NativeLong arg1, NativeLong arg2) {
                 return new NativeLong(arg1.longValue() + arg2.longValue());
             }

--- a/test/com/sun/jna/StructureByValueTest.java
+++ b/test/com/sun/jna/StructureByValueTest.java
@@ -27,6 +27,7 @@ public class StructureByValueTest extends TestCase {
     public static class TestNativeMappedInStructure extends Structure {
         public static class ByValue extends TestNativeMappedInStructure implements Structure.ByValue { }
         public NativeLong field;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field" });
         }
@@ -45,10 +46,12 @@ public class StructureByValueTest extends TestCase {
 
     TestLibrary lib;
 
+    @Override
     protected void setUp() {
-        lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.loadLibrary("testlib", TestLibrary.class);
     }
 
+    @Override
     protected void tearDown() {
         lib = null;
     }
@@ -56,30 +59,35 @@ public class StructureByValueTest extends TestCase {
     public static abstract class ByValueStruct extends Structure implements Structure.ByValue { }
     public static class ByValue8 extends ByValueStruct {
         public byte data;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "data" });
         }
     }
     public static class ByValue16 extends ByValueStruct {
         public short data;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "data" });
         }
     }
     public static class ByValue32 extends ByValueStruct {
         public int data;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "data" });
         }
     }
     public static class ByValue64 extends ByValueStruct {
         public long data;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "data" });
         }
     }
     public static class ByValue128 extends ByValueStruct {
         public long data, data1;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "data", "data1" });
         }

--- a/test/com/sun/jna/StructureTest.java
+++ b/test/com/sun/jna/StructureTest.java
@@ -16,8 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
 import junit.framework.TestCase;
 
 import com.sun.jna.Structure.StructureSet;
@@ -40,6 +38,7 @@ public class StructureTest extends TestCase {
     public void testSimpleSize() throws Exception {
         class TestStructure extends Structure {
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -51,6 +50,7 @@ public class StructureTest extends TestCase {
     public void testInitializeFromPointer() {
         class TestStructureX extends Structure {
             public int field1, field2;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field1", "field2" });
             }
@@ -73,6 +73,7 @@ public class StructureTest extends TestCase {
     public void testInitializeWithTypeMapper() {
         class TestStructure extends Structure {
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -91,6 +92,7 @@ public class StructureTest extends TestCase {
         public int f1;
         public int f2;
         public int f3;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "f0", "f1", "f2", "f3" });
         }
@@ -102,6 +104,7 @@ public class StructureTest extends TestCase {
             public TestStructure() { }
             public TestStructure(Pointer p) { super(p); }
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -118,6 +121,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public TestStructure(Pointer p) { super(p); }
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -154,6 +158,7 @@ public class StructureTest extends TestCase {
             public long l;
             public float f;
             public double d;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "b", "s", "i", "l", "f", "d" });
             }
@@ -173,6 +178,7 @@ public class StructureTest extends TestCase {
             public long l;
             public float f;
             public double d;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "b", "s", "i", "l", "f", "d" });
             }
@@ -184,6 +190,7 @@ public class StructureTest extends TestCase {
 
     public static abstract class FilledStructure extends Structure {
         private boolean initialized;
+        @Override
         protected void ensureAllocated() {
             super.ensureAllocated();
             if (!initialized) {
@@ -198,6 +205,7 @@ public class StructureTest extends TestCase {
     public static class TestStructure0 extends FilledStructure {
         public byte field0 = 0x01;
         public short field1 = 0x0202;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field0", "field1" });
         }
@@ -205,6 +213,7 @@ public class StructureTest extends TestCase {
     public static class TestStructure1 extends FilledStructure {
         public byte field0 = 0x01;
         public int field1 = 0x02020202;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field0", "field1" });
         }
@@ -212,6 +221,7 @@ public class StructureTest extends TestCase {
     public static class TestStructure2 extends FilledStructure {
         public short field0 = 0x0101;
         public int field1 = 0x02020202;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field0", "field1" });
         }
@@ -220,6 +230,7 @@ public class StructureTest extends TestCase {
         public int field0 = 0x01010101;
         public short field1 = 0x0202;
         public int field2 = 0x03030303;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field0", "field1", "field2" });
         }
@@ -229,6 +240,7 @@ public class StructureTest extends TestCase {
         public long field1 = 0x0202020202020202L;
         public int field2 = 0x03030303;
         public long field3 = 0x0404040404040404L;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field0", "field1", "field2", "field3" });
         }
@@ -236,6 +248,7 @@ public class StructureTest extends TestCase {
     public static class TestStructure5 extends FilledStructure {
         public long field0 = 0x0101010101010101L;
         public byte field1 = 0x02;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field0", "field1" });
         }
@@ -245,7 +258,7 @@ public class StructureTest extends TestCase {
     }
     private void testStructureSize(int index) {
         try {
-            SizeTest lib = (SizeTest)Native.loadLibrary("testlib", SizeTest.class);
+            SizeTest lib = Native.loadLibrary("testlib", SizeTest.class);
             Class cls = Class.forName(getClass().getName() + "$TestStructure" + index);
             Structure s = Structure.newInstance(cls);
             assertEquals("Incorrect size for structure " + index + "=>" + s.toString(true), lib.getStructureSize(index), s.size());
@@ -279,7 +292,7 @@ public class StructureTest extends TestCase {
     }
 
     private void testAlignStruct(int index) {
-        AlignmentTest lib = (AlignmentTest)Native.loadLibrary("testlib", AlignmentTest.class);
+        AlignmentTest lib = Native.loadLibrary("testlib", AlignmentTest.class);
         try {
             IntByReference offset = new IntByReference();
             LongByReference value = new LongByReference();
@@ -316,6 +329,7 @@ public class StructureTest extends TestCase {
 
     public void testStructureWithNoFields() {
         class TestStructure extends Structure {
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] {});
             }
@@ -331,6 +345,7 @@ public class StructureTest extends TestCase {
     public void testStructureWithOnlyNonPublicMemberFields() {
         class TestStructure extends Structure {
             int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] {"field"});
             }
@@ -357,10 +372,12 @@ public class StructureTest extends TestCase {
         public PublicTestStructure() { }
         public PublicTestStructure(Pointer p) { super(p); read(); }
         public static int allocations = 0;
+        @Override
         protected void allocateMemory(int size) {
             super.allocateMemory(size);
             ++allocations;
         }
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "x", "y" });
         }
@@ -369,6 +386,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public PublicTestStructure s1, s2;
             public int after;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "s1", "s2", "after" });
             }
@@ -398,6 +416,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public PublicTestStructure.ByValue s1, s2;
             public int after;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "s1", "s2", "after" });
             }
@@ -433,6 +452,7 @@ public class StructureTest extends TestCase {
             public long s_long;
             public TestUnion s_union;
             public int s_int;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "s_long", "s_union", "s_int" });
             }
@@ -445,6 +465,7 @@ public class StructureTest extends TestCase {
     public static class NonAllocatingTestStructure extends PublicTestStructure {
         public NonAllocatingTestStructure() { }
         public NonAllocatingTestStructure(Pointer p) { super(p); read(); }
+        @Override
         protected void allocateMemory(int size) {
             throw new Error("Memory unexpectedly allocated");
         }
@@ -458,6 +479,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public NonAllocatingTestStructure s1;
             public TestStructure() { }
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "s1" });
             }
@@ -469,6 +491,7 @@ public class StructureTest extends TestCase {
     public void testPrimitiveArrayField() {
         class TestStructure extends Structure {
             public byte[] buffer = new byte[1024];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "buffer" });
             }
@@ -490,6 +513,7 @@ public class StructureTest extends TestCase {
             // initialized array elements
             public PublicTestStructure[] inner2 = (PublicTestStructure[])
                 new PublicTestStructure().toArray(2);
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "inner", "inner2" });
             }
@@ -532,6 +556,7 @@ public class StructureTest extends TestCase {
     public static class ToArrayTestStructure extends Structure {
         public PublicTestStructure[] inner =
             (PublicTestStructure[])new PublicTestStructure().toArray(2);
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "inner" });
         }
@@ -550,6 +575,7 @@ public class StructureTest extends TestCase {
     public void testUninitializedNestedArrayFails() {
         class TestStructure extends Structure {
             public Pointer[] buffer;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "buffer" });
             }
@@ -585,6 +611,7 @@ public class StructureTest extends TestCase {
             public float[] fa = new float[3];
             public double[] da = new double[3];
             public PublicTestStructure nested;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "z", "b", "c", "s", "i", "l", "f", "d", "ba", "ca", "sa", "ia", "la", "fa", "da", "nested" });
             }
@@ -645,6 +672,7 @@ public class StructureTest extends TestCase {
     public void testNativeLongSize() throws Exception {
         class TestStructure extends Structure {
             public NativeLong l;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "l" });
             }
@@ -657,6 +685,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public int i;
             public NativeLong l;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "i", "l" });
             }
@@ -680,6 +709,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public int i;
             public NativeLong l;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "i", "l" });
             }
@@ -704,6 +734,7 @@ public class StructureTest extends TestCase {
     public void testMemoryField() {
         class MemoryFieldStructure extends Structure {
             public Memory m;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "m" });
             }
@@ -714,6 +745,7 @@ public class StructureTest extends TestCase {
     public void testDisallowFunctionPointerAsField() {
         class BadFieldStructure extends Structure {
             public Function cb;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "cb" });
             }
@@ -728,6 +760,7 @@ public class StructureTest extends TestCase {
 
     public static class BadFieldStructure extends Structure {
         public Object badField;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "badField" });
         }
@@ -735,6 +768,7 @@ public class StructureTest extends TestCase {
     public void testUnsupportedField() {
         class BadNestedStructure extends Structure {
             public BadFieldStructure badStruct = new BadFieldStructure();
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "badStruct" });
             }
@@ -782,6 +816,7 @@ public class StructureTest extends TestCase {
             (PublicTestStructure.ByReference[])s.toArray(2);
         class TestStructure extends Structure {
             public PublicTestStructure.ByReference ref;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "ref" });
             }
@@ -808,6 +843,7 @@ public class StructureTest extends TestCase {
 
     static class CbStruct extends Structure {
         public Callback cb;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "cb" });
         }
@@ -830,6 +866,7 @@ public class StructureTest extends TestCase {
     public void testUninitializedArrayField() {
         class UninitializedArrayFieldStructure extends Structure {
             public byte[] array;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "array" });
             }
@@ -845,6 +882,7 @@ public class StructureTest extends TestCase {
 
     public static class StructureWithArrayOfStructureField extends Structure {
         public Structure[] array;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "array" });
         }
@@ -865,6 +903,7 @@ public class StructureTest extends TestCase {
         class ArrayOfPointerStructure extends Structure {
             final static int SIZE = 10;
             public Pointer[] array = new Pointer[SIZE];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "array" });
             }
@@ -883,6 +922,7 @@ public class StructureTest extends TestCase {
         class VolatileStructure extends Structure {
             public volatile int counter;
             public int value;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "counter", "value" });
             }
@@ -906,6 +946,7 @@ public class StructureTest extends TestCase {
     public static class StructureWithPointers extends Structure {
         public PublicTestStructure.ByReference s1;
         public PublicTestStructure.ByReference s2;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "s1", "s2" });
         }
@@ -951,6 +992,7 @@ public class StructureTest extends TestCase {
             public TestPointer p2 = new TestPointer() {
                 { setPointer(new Memory(256)); }
             };
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "p", "p2" });
             }
@@ -970,6 +1012,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public String s;
             public WString ws;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "s", "ws" });
             }
@@ -995,6 +1038,7 @@ public class StructureTest extends TestCase {
     public static class StructureFromPointer extends Structure {
         public String s;
         public WString ws;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "s", "ws" });
         }
@@ -1009,6 +1053,7 @@ public class StructureTest extends TestCase {
     public void testInitializeStructureFieldWithStrings() {
         class ContainingStructure extends Structure {
             public StructureFromPointer inner;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "inner" });
             }
@@ -1058,6 +1103,7 @@ public class StructureTest extends TestCase {
     public void testStructureByReferenceArrayField() {
         class TestStructure extends Structure {
             public PublicTestStructure.ByReference[] array = new PublicTestStructure.ByReference[2];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "array" });
             }
@@ -1088,6 +1134,7 @@ public class StructureTest extends TestCase {
     public void testAutoReadWriteStructureByReferenceArrayField() {
         class TestStructure extends Structure {
             public PublicTestStructure.ByReference field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -1111,12 +1158,14 @@ public class StructureTest extends TestCase {
     static class NestedTypeInfoStructure extends Structure {
         public static class Inner extends Structure {
             public int dummy;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "dummy" });
             }
         }
         public Inner inner;
         public int dummy;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "inner", "dummy" });
         }
@@ -1135,6 +1184,7 @@ public class StructureTest extends TestCase {
         public short alignment;
         public short type;
         public Pointer elements;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "size", "alignment", "type", "elements" });
         }
@@ -1170,6 +1220,7 @@ public class StructureTest extends TestCase {
     public void testInnerArrayTypeInfo() {
         class TestStructure extends Structure {
             public int[] inner = new int[5];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "inner" });
             }
@@ -1195,6 +1246,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public int intField;
             public PublicTestStructure inner;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "intField", "inner" });
             }
@@ -1226,6 +1278,7 @@ public class StructureTest extends TestCase {
     public void testNativeMappedWrite() {
     	class TestStructure extends Structure {
             public ByteByReference ref;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "ref" });
             }
@@ -1243,6 +1296,7 @@ public class StructureTest extends TestCase {
     public void testNativeMappedRead() {
     	class TestStructure extends Structure {
             public ByteByReference ref;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "ref" });
             }
@@ -1263,6 +1317,7 @@ public class StructureTest extends TestCase {
 
     public static class ROStructure extends Structure {
         public final int field;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "field" });
         }
@@ -1313,6 +1368,7 @@ public class StructureTest extends TestCase {
         final int SIZE = 24;
         class TestStructure extends Structure {
             public NativeLong[] longs = new NativeLong[SIZE];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "longs" });
             }
@@ -1349,6 +1405,7 @@ public class StructureTest extends TestCase {
             { setAlignType(ALIGN_NONE); }
             public NativeLong nl = INITIAL;
             public NativeLong uninitialized;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "nl", "uninitialized" });
             }
@@ -1372,6 +1429,7 @@ public class StructureTest extends TestCase {
     public void testThrowErrorOnMissingFieldOrderOnDerivedStructure() {
         class TestStructure extends Structure {
             public int f1, f2;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "f1", "f2" });
             }
@@ -1390,6 +1448,7 @@ public class StructureTest extends TestCase {
     public void testThrowErrorOnIncorrectFieldOrderNameMismatch() {
         class TestStructure extends Structure {
             public int f1, f2;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "F1", "F2" });
             }
@@ -1405,6 +1464,7 @@ public class StructureTest extends TestCase {
     public void testThrowErrorOnIncorrectFieldOrderCount() {
         class TestStructure extends Structure {
             public int f1, f2;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "f1", "f2", "f3" });
             }
@@ -1419,12 +1479,14 @@ public class StructureTest extends TestCase {
 
     class XTestStructure extends Structure {
 	public int first = 1;
-	protected List getFieldOrder() {
+	@Override
+    protected List getFieldOrder() {
 	    return Arrays.asList(new String[] { "first" }); }
     }
     class XTestStructureSub extends XTestStructure {
 	public int second = 2;
-	protected List getFieldOrder() {
+	@Override
+    protected List getFieldOrder() {
 	    List list = new ArrayList(super.getFieldOrder());
 	    list.addAll(Arrays.asList(new String[] { "second" }));
 	    return list;
@@ -1447,6 +1509,7 @@ public class StructureTest extends TestCase {
             public int one = 1;
             public int three = 3;
             public int two = 2;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(ORDER);
             }
@@ -1454,6 +1517,7 @@ public class StructureTest extends TestCase {
         class DerivedTestStructure extends TestStructure {
             public int five = 5;
             public int four = 4;
+            @Override
             protected List getFieldOrder() {
                 List list = new ArrayList(super.getFieldOrder());
                 list.addAll(Arrays.asList(new String[] { "four", "five" }));
@@ -1493,12 +1557,15 @@ public class StructureTest extends TestCase {
         final DefaultTypeMapper mapper = new DefaultTypeMapper() {
             {
                 addTypeConverter(TestField.class, new TypeConverter() {
+                    @Override
                     public Object fromNative(Object value, FromNativeContext context) {
                         return new TestField();
                     }
+                    @Override
                     public Class nativeType() {
                         return String.class;
                     }
+                    @Override
                     public Object toNative(Object value, ToNativeContext ctx) {
                         return value == null ? null : value.toString();
                     }
@@ -1510,6 +1577,7 @@ public class StructureTest extends TestCase {
             public TestStructure() {
                 super(mapper);
             }
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -1522,6 +1590,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public Boolean zfield;
             public Integer field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "zfield", "field" });
             }
@@ -1537,6 +1606,7 @@ public class StructureTest extends TestCase {
             public int first;
             public int[] second = new int[4];
             public Pointer[] third = new Pointer[4];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "first", "second", "third" });
             }
@@ -1545,6 +1615,7 @@ public class StructureTest extends TestCase {
             public int first;
             public int[] second = new int[4];
             public Pointer[] third = new Pointer[4];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "first", "second", "third" });
             }
@@ -1571,6 +1642,7 @@ public class StructureTest extends TestCase {
     public void testStructureHashCodeMatchesWhenEqual() {
         class TestStructure extends Structure {
             public int first;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "first" });
             }
@@ -1594,6 +1666,7 @@ public class StructureTest extends TestCase {
             public TestStructureByRef() { }
             public int unique;
             public TestStructureByRef s;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "unique", "s" });
             }
@@ -1627,6 +1700,7 @@ public class StructureTest extends TestCase {
         public CyclicTestStructure(Pointer p) { super(p); }
         public CyclicTestStructure() { }
         public CyclicTestStructure.ByReference next;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "next" });
         }
@@ -1653,12 +1727,14 @@ public class StructureTest extends TestCase {
     public void testAvoidMemoryAllocationInPointerCTOR() {
         class TestStructure extends Structure {
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
             public TestStructure(Pointer p) {
                 super(p);
             }
+            @Override
             protected Memory autoAllocate(int size) {
                 fail("Memory should not be auto-allocated");
                 return null;
@@ -1672,6 +1748,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public int intField;
             public byte[] arrayField = new byte[256];
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "intField", "arrayField" });
             }
@@ -1711,6 +1788,7 @@ public class StructureTest extends TestCase {
         public int value1;
         public ByReference[] array = new ByReference[13];
         public int value2;
+        @Override
         protected List getFieldOrder() {
             return Arrays.asList(new String[] { "value1", "array", "value2" });
         }
@@ -1738,6 +1816,7 @@ public class StructureTest extends TestCase {
     public void testEquals() {
         class TestStructure extends Structure {
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -1755,6 +1834,7 @@ public class StructureTest extends TestCase {
     public void testStructureLayoutCacheing() {
         class TestStructure extends Structure {
             public int field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -1768,6 +1848,7 @@ public class StructureTest extends TestCase {
     public void testStructureLayoutVariableNoCache() {
         class TestStructure extends Structure {
             public byte[] variable;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "variable" });
             }
@@ -1787,10 +1868,13 @@ public class StructureTest extends TestCase {
         class TestTypeMapper extends DefaultTypeMapper {
             {
                 TypeConverter tc = new TypeConverter() {
+                    @Override
                     public Class nativeType() { return int.class; }
+                    @Override
                     public Object fromNative(Object nativeValue, FromNativeContext c) {
                         return new Boolean(nativeValue.equals(new Integer(0)));
                     }
+                    @Override
                     public Object toNative(Object value, ToNativeContext c) {
                         return new Integer(Boolean.TRUE.equals(value) ? -1 : 0);
                     }
@@ -1802,6 +1886,7 @@ public class StructureTest extends TestCase {
         final TestTypeMapper m = new TestTypeMapper();
         class TestStructure extends Structure {
             public boolean field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -1823,6 +1908,7 @@ public class StructureTest extends TestCase {
         class TestStructure extends Structure {
             public byte first;
             public int second;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "first", "second" });
             }
@@ -1848,13 +1934,16 @@ public class StructureTest extends TestCase {
 
     public void testFFITypeCalculationWithTypeMappedFields() {
         final TypeMapper mapper = new TypeMapper() {
+            @Override
             public FromNativeConverter getFromNativeConverter(Class cls) {
                 if (Boolean.class.equals(cls)
                     || boolean.class.equals(cls)) {
                     return new FromNativeConverter() {
+                        @Override
                         public Class nativeType() {
                             return byte.class;
                         }
+                        @Override
                         public Object fromNative(Object nativeValue, FromNativeContext context) {
                             return nativeValue.equals(new Byte((byte)0))
                                 ? Boolean.FALSE : Boolean.TRUE;
@@ -1863,13 +1952,16 @@ public class StructureTest extends TestCase {
                 }
                 return null;
             }
+            @Override
             public ToNativeConverter getToNativeConverter(Class javaType) {
                 if (Boolean.class.equals(javaType)
                     || boolean.class.equals(javaType)) {
                     return new ToNativeConverter() {
+                        @Override
                         public Object toNative(Object value, ToNativeContext context) {
                             return new Byte(Boolean.TRUE.equals(value) ? (byte)1 : (byte)0);
                         }
+                        @Override
                         public Class nativeType() {
                             return byte.class;
                         }
@@ -1886,6 +1978,7 @@ public class StructureTest extends TestCase {
             public TestStructure() {
                 super(mapper);
             }
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "b", "s", "p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7" });
             }
@@ -1901,6 +1994,7 @@ public class StructureTest extends TestCase {
     public void testDefaultStringEncoding() {
         class TestStructure extends Structure {
             public String field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -1914,6 +2008,7 @@ public class StructureTest extends TestCase {
     public void testStringFieldEncoding() throws Exception {
         class TestStructure extends Structure {
             public String field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
@@ -1939,18 +2034,19 @@ public class StructureTest extends TestCase {
         s.read();
         assertEquals("String not decoded properly on read", VALUE, s.field);
     }
-    
+
     public void testThreadLocalSetReleasesReferences() {
     	class TestStructure extends Structure {
             public String field;
+            @Override
             protected List getFieldOrder() {
                 return Arrays.asList(new String[] { "field" });
             }
         }
-    	
+
     	TestStructure ts1 = new TestStructure();
     	TestStructure ts2 = new TestStructure();
-    	
+
     	StructureSet structureSet = (StructureSet) Structure.busy();
     	structureSet.add(ts1);
     	structureSet.add(ts2);

--- a/test/com/sun/jna/TypeMapperTest.java
+++ b/test/com/sun/jna/TypeMapperTest.java
@@ -46,8 +46,7 @@ public class TypeMapperTest extends TestCase {
             }
         });
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
-        TestLibrary lib = (TestLibrary) 
-            Native.loadLibrary("testlib", TestLibrary.class, options);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, options);
         assertEquals("Failed to convert Boolean argument to Int", MAGIC,
                      lib.returnInt32Argument(true));
     }
@@ -64,8 +63,7 @@ public class TypeMapperTest extends TestCase {
         Map options = new HashMap();
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
         final int MAGIC = 0x7BEDCF23;
-        TestLibrary lib = (TestLibrary) 
-            Native.loadLibrary("testlib", TestLibrary.class, options);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, options);
         assertEquals("Failed to convert String argument to Int", MAGIC,
                      lib.returnInt32Argument(Integer.toHexString(MAGIC)));
     }
@@ -82,8 +80,7 @@ public class TypeMapperTest extends TestCase {
         Map options = new HashMap();
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
         final String MAGIC = "magic" + UNICODE;
-        TestLibrary lib = (TestLibrary) 
-            Native.loadLibrary("testlib", TestLibrary.class, options);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, options);
         assertEquals("Failed to convert String argument to WString", new WString(MAGIC),
                      lib.returnWStringArgument(MAGIC));
     }
@@ -101,8 +98,7 @@ public class TypeMapperTest extends TestCase {
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
         
         final int MAGIC = 0x7BEDCF23;
-        TestLibrary lib = (TestLibrary) 
-            Native.loadLibrary("testlib", TestLibrary.class, options);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, options);
         assertEquals("Failed to convert String argument to Int", MAGIC,
                      lib.returnInt32Argument(Integer.toHexString(MAGIC)));
     }
@@ -120,8 +116,7 @@ public class TypeMapperTest extends TestCase {
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
         
         final int MAGIC = 0x7BEDCF23;
-        TestLibrary lib = (TestLibrary) 
-            Native.loadLibrary("testlib", TestLibrary.class, options);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, options);
         assertEquals("Failed to convert Double argument to Int", MAGIC,
                      lib.returnInt32Argument(new Double(MAGIC)));
     }
@@ -141,8 +136,7 @@ public class TypeMapperTest extends TestCase {
         });
         Map options = new HashMap();
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
-        TestLibrary lib = (TestLibrary)
-            Native.loadLibrary("testlib", TestLibrary.class, options);
+        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, options);
         assertEquals("Failed to convert WString result to String", MAGIC,
                      lib.returnWStringArgument(new WString(MAGIC)));
     }
@@ -171,8 +165,7 @@ public class TypeMapperTest extends TestCase {
             }
         });
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
-        BooleanTestLibrary lib = (BooleanTestLibrary) 
-            Native.loadLibrary("testlib", BooleanTestLibrary.class, options);
+        BooleanTestLibrary lib = Native.loadLibrary("testlib", BooleanTestLibrary.class, options);
         assertEquals("Failed to convert integer return to boolean TRUE", true,
                      lib.returnInt32Argument(true));
         assertEquals("Failed to convert integer return to boolean FALSE", false,
@@ -205,8 +198,7 @@ public class TypeMapperTest extends TestCase {
         mapper.addTypeConverter(Boolean.class, converter);
         Map options = new HashMap();
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
-		StructureTestLibrary lib = (StructureTestLibrary)
-            Native.loadLibrary("testlib", StructureTestLibrary.class, options);
+		StructureTestLibrary lib = Native.loadLibrary("testlib", StructureTestLibrary.class, options);
         StructureTestLibrary.TestStructure s = new StructureTestLibrary.TestStructure(mapper);
         assertEquals("Wrong native size", 4, s.size());
         
@@ -251,8 +243,7 @@ public class TypeMapperTest extends TestCase {
         mapper.addTypeConverter(Enumeration.class, converter);
         Map options = new HashMap();
         options.put(Library.OPTION_TYPE_MAPPER, mapper);
-        EnumerationTestLibrary lib = (EnumerationTestLibrary)
-            Native.loadLibrary("testlib", EnumerationTestLibrary.class, options);
+        EnumerationTestLibrary lib = Native.loadLibrary("testlib", EnumerationTestLibrary.class, options);
         assertEquals("Enumeration improperly converted", Enumeration.STATUS_1, lib.returnInt32Argument(Enumeration.STATUS_1));
     }
     

--- a/test/com/sun/jna/VarArgsTest.java
+++ b/test/com/sun/jna/VarArgsTest.java
@@ -8,7 +8,7 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna;
 
@@ -24,8 +24,9 @@ public class VarArgsTest extends TestCase {
     public static interface TestLibrary extends Library {
         public static class TestStructure extends Structure {
             public int magic = 0;
+            @Override
             protected List getFieldOrder() {
-                return Arrays.asList(new String[] { "magic" }); 
+                return Arrays.asList(new String[] { "magic" });
             }
         }
         public int addInt32VarArgs(String fmt, Number... args);
@@ -33,12 +34,14 @@ public class VarArgsTest extends TestCase {
         public void modifyStructureVarArgs(String fmt, Object arg1, Object... args);
     }
     TestLibrary lib;
+    @Override
     protected void setUp() {
-        lib = (TestLibrary)Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.loadLibrary("testlib", TestLibrary.class);
     }
+    @Override
     protected void tearDown() {
         lib = null;
-    }   
+    }
     public void testIntVarArgs() {
         int arg1 = 1;
         int arg2 = 2;
@@ -62,24 +65,24 @@ public class VarArgsTest extends TestCase {
         assertEquals("Did not return correct string", args[0],
                      lib.returnStringVarArgs("", args));
     }
-    
+
     public void testAppendNullToVarargs() {
         Number[] args = new Number[] { new Integer(1) };
         assertEquals("No trailing NULL was appended to varargs list",
                      1, lib.addInt32VarArgs("dd", args));
     }
-    
+
     public void testModifyStructureInVarargs() {
         TestStructure arg1 = new TestStructure();
         TestStructure[] varargs = new TestStructure[] { new TestStructure() };
         lib.modifyStructureVarArgs("ss", arg1, varargs[0]);
         assertEquals("Structure memory not read in fixed arg w/varargs",
-                     MAGIC32, arg1.magic); 
+                     MAGIC32, arg1.magic);
         assertEquals("Structure memory not read in varargs",
-                     MAGIC32, varargs[0].magic); 
-                     
+                     MAGIC32, varargs[0].magic);
+
     }
-    
+
     public static void main(String[] args) {
         junit.textui.TestRunner.run(VarArgsTest.class);
     }

--- a/test/com/sun/jna/WebStartTest.java
+++ b/test/com/sun/jna/WebStartTest.java
@@ -290,8 +290,7 @@ public class WebStartTest extends TestCase implements Paths {
             }
             // NOTE: win64 only includes javaws in the system path
             if (Platform.isWindows()) {
-                FolderInfo info = (FolderInfo)
-                    Native.loadLibrary("shell32", FolderInfo.class);
+                FolderInfo info = Native.loadLibrary("shell32", FolderInfo.class);
                 char[] buf = new char[FolderInfo.MAX_PATH];
                 //int result =
                         info.SHGetFolderPathW(null, FolderInfo.CSIDL_WINDOWS, null, 0, buf);
@@ -321,8 +320,7 @@ public class WebStartTest extends TestCase implements Paths {
             vendor = vendor.substring(0, vendor.indexOf(" "));
         }
         if (Platform.isWindows()) {
-            FolderInfo info = (FolderInfo)
-                Native.loadLibrary("shell32", FolderInfo.class);
+            FolderInfo info = Native.loadLibrary("shell32", FolderInfo.class);
             char[] buf = new char[FolderInfo.MAX_PATH];
             info.SHGetFolderPathW(null, FolderInfo.CSIDL_APPDATA,
                                   null, 0, buf);

--- a/test/com/sun/jna/win32/W32StdCallTest.java
+++ b/test/com/sun/jna/win32/W32StdCallTest.java
@@ -8,7 +8,7 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna.win32;
 
@@ -34,8 +34,9 @@ public class W32StdCallTest extends TestCase {
     public static interface TestLibrary extends StdCallLibrary {
         public static class Inner extends Structure {
             public double value;
+            @Override
             protected List getFieldOrder() {
-                return Arrays.asList(new String[] { "value" }); 
+                return Arrays.asList(new String[] { "value" });
             }
         }
         public static class TestStructure extends Structure {
@@ -45,8 +46,9 @@ public class W32StdCallTest extends TestCase {
             public int i;
             public long j;
             public Inner inner;
+            @Override
             protected List getFieldOrder() {
-                return Arrays.asList(new String[] { "c", "s", "i", "j", "inner" }); 
+                return Arrays.asList(new String[] { "c", "s", "i", "j", "inner" });
             }
         }
         int returnInt32ArgumentStdCall(int arg);
@@ -68,20 +70,23 @@ public class W32StdCallTest extends TestCase {
                                         double arg8, NativeLong arg9,
                                         NativeLong arg10, NativeLong arg11);
     }
-    
+
     public static void main(java.lang.String[] argList) {
         junit.textui.TestRunner.run(W32StdCallTest.class);
     }
 
     private TestLibrary testlib;
-    
+
+    @Override
     protected void setUp() {
-        testlib = (TestLibrary)
-            Native.loadLibrary("testlib", TestLibrary.class, new HashMap() {
-                { put(Library.OPTION_FUNCTION_MAPPER, StdCallLibrary.FUNCTION_MAPPER); }
-            });
+        testlib = Native.loadLibrary("testlib", TestLibrary.class, new HashMap() {
+						{
+						    put(Library.OPTION_FUNCTION_MAPPER, StdCallLibrary.FUNCTION_MAPPER);
+					    }
+                    });
     }
-    
+
+    @Override
     protected void tearDown() {
         testlib = null;
     }
@@ -113,22 +118,23 @@ public class W32StdCallTest extends TestCase {
                          name, lib.getFunction(name, StdCallLibrary.STDCALL_CONVENTION).getName());
         }
     }
-    
+
     public void testStdCallReturnInt32Argument() {
         final int MAGIC = 0x12345678;
         assertEquals("Expect zero return", 0, testlib.returnInt32ArgumentStdCall(0));
         assertEquals("Expect magic return", MAGIC, testlib.returnInt32ArgumentStdCall(MAGIC));
     }
-    
+
     public void testStdCallReturnStructureByValueArgument() {
         TestLibrary.TestStructure.ByValue s = new TestLibrary.TestStructure.ByValue();
         assertTrue("Wrong struct value", s.dataEquals(testlib.returnStructureByValueArgumentStdCall(s)));
     }
-    
+
     public void testStdCallCallback() {
         final int MAGIC = 0x11111111;
         final boolean[] called = { false };
         TestLibrary.Int32Callback cb = new TestLibrary.Int32Callback() {
+            @Override
             public int callback(int arg, int arg2) {
                 called[0] = true;
                 return arg + arg2;
@@ -140,9 +146,9 @@ public class W32StdCallTest extends TestCase {
         if (value == -1) {
             fail("stdcall callback did not restore the stack pointer");
         }
-        assertEquals("Wrong stdcall callback value", Integer.toHexString(EXPECTED), 
+        assertEquals("Wrong stdcall callback value", Integer.toHexString(EXPECTED),
                      Integer.toHexString(value));
-        
+
         value = testlib.callInt32StdCallCallback(cb, -1, -2);
         if (value == -1) {
             fail("stdcall callback did not restore the stack pointer");
@@ -153,6 +159,7 @@ public class W32StdCallTest extends TestCase {
     public void testStdCallCallbackStackAlignment() {
         final boolean[] called = { false };
         TestLibrary.ManyArgsStdCallCallback cb = new TestLibrary.ManyArgsStdCallCallback() {
+            @Override
             public void callback(NativeLong arg1, int arg2, double arg3,
                                  String arg4, String arg5,
                                  double arg6, NativeLong arg7,

--- a/test/com/sun/jna/wince/CoreDLLTest.java
+++ b/test/com/sun/jna/wince/CoreDLLTest.java
@@ -25,6 +25,8 @@ public class CoreDLLTest extends TestCase {
     }
 
     public interface CoreDLL extends StdCallLibrary {
+        CoreDLL INSTANCE = Native.loadLibrary("coredll", CoreDLL.class, W32APIOptions.UNICODE_OPTIONS);
+
         public static class SECURITY_ATTRIBUTES extends Structure {
             public int dwLength;
             public Pointer lpSecurityDescriptor;
@@ -88,8 +90,7 @@ public class CoreDLLTest extends TestCase {
                 return Arrays.asList(new String[] { "hProcess", "hThread", "dwProcessId", "dwThreadId" });
             }
         }
-        CoreDLL INSTANCE = (CoreDLL)Native.loadLibrary("coredll", CoreDLL.class,
-                                                       W32APIOptions.UNICODE_OPTIONS);
+
         boolean CreateProcess(String lpApplicationName, String lpCommandLine,
                               SECURITY_ATTRIBUTES lpProcessAttributes,
                               SECURITY_ATTRIBUTES lpThreadAttributes,


### PR DESCRIPTION
Take 2 - this time I feel more confident in the result since I have run the _ant clean_ and then _ant_ including full build of the native code + running the _jUnit_ tests (all passed). Like I said, if it fails again for the same reason, then let's roll back the changes.