### PR TITLE
Make sure superclass 'finalize' method is always called

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Features
 * [#573](https://github.com/java-native-access/jna/pull/573): Added `EnumProcessModules`, `GetModuleInformation`, and `GetProcessImageFileName` to `com.sun.jna.platform.win32.Psapi` and added `ExtractIconEx` to `com.sun.jna.platform.win32.Shell32` - [@mlfreeman2](https://github.com/mlfreeman2).
 * [#574](https://github.com/java-native-access/jna/pull/574): Using static final un-modifiable List of field names for structure(s) [@lgoldstein](https://github.com/lgoldstein)
 * [#577](https://github.com/java-native-access/jna/pull/577): Apply generic definitions wherever applicable [@lgoldstein](https://github.com/lgoldstein)
+* [#581](https://github.com/java-native-access/jna/pull/581): Make sure superclass 'finalize' method is always called [@lgoldstein](https://github.com/lgoldstein)
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/FileMonitor.java
+++ b/contrib/platform/src/com/sun/jna/platform/FileMonitor.java
@@ -8,7 +8,7 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna.platform;
 
@@ -47,7 +47,7 @@ public abstract class FileMonitor {
     public interface FileListener {
         public void fileChanged(FileEvent e);
     }
-    
+
 	public class FileEvent extends EventObject {
         private final File file;
         private final int type;
@@ -58,14 +58,15 @@ public abstract class FileMonitor {
         }
         public File getFile() { return file; }
         public int getType() { return type; }
+        @Override
         public String toString() {
             return "FileEvent: " + file + ":" + type;
         }
     }
-    
+
     private final Map<File, Integer> watched = new HashMap<File, Integer>();
     private List<FileListener> listeners = new ArrayList<FileListener>();
-    
+
     protected abstract void watch(File file, int mask, boolean recursive) throws IOException ;
     protected abstract void unwatch(File file);
     public abstract void dispose();
@@ -73,11 +74,11 @@ public abstract class FileMonitor {
     public void addWatch(File dir) throws IOException {
         addWatch(dir, FILE_ANY);
     }
-    
+
     public void addWatch(File dir, int mask) throws IOException {
         addWatch(dir, mask, dir.isDirectory());
     }
-    
+
     public void addWatch(File dir, int mask, boolean recursive) throws IOException {
         watched.put(dir, Integer.valueOf(mask));
         watch(dir, mask, recursive);
@@ -88,33 +89,38 @@ public abstract class FileMonitor {
             unwatch(file);
         }
     }
-    
+
     protected void notify(FileEvent e) {
     	for (FileListener listener : listeners) {
     		listener.fileChanged(e);
     	}
     }
-    
+
     public synchronized void addFileListener(FileListener listener) {
         List<FileListener> list = new ArrayList<FileListener>(listeners);
         list.add(listener);
         listeners = list;
     }
-    
+
     public synchronized void removeFileListener(FileListener x) {
         List<FileListener> list = new ArrayList<FileListener>(listeners);
         list.remove(x);
         listeners = list;
     }
-    
-    protected void finalize() {
-    	for (File watchedFile : watched.keySet()) {
-    		removeWatch(watchedFile);
-    	}
-    	
-        dispose();
+
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+        	for (File watchedFile : watched.keySet()) {
+        		removeWatch(watchedFile);
+        	}
+
+            dispose();
+        } finally {
+            super.finalize();
+        }
     }
-    
+
     /** Canonical lazy loading of a singleton. */
     private static class Holder {
         public static final FileMonitor INSTANCE;
@@ -128,7 +134,7 @@ public abstract class FileMonitor {
             }
         }
     }
-    
+
     public static FileMonitor getInstance() {
         return Holder.INSTANCE;
     }

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ComThread.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ComThread.java
@@ -32,11 +32,11 @@ public class ComThread {
 	boolean requiresInitialisation;
 	long timeoutMilliseconds;
 	UncaughtExceptionHandler uncaughtExceptionHandler;
-	
+
 	public ComThread(final String threadName, long timeoutMilliseconds, UncaughtExceptionHandler uncaughtExceptionHandler) {
 		this(threadName, timeoutMilliseconds, uncaughtExceptionHandler, Ole32.COINIT_MULTITHREADED);
 	}
-	
+
 	public ComThread(final String threadName, long timeoutMilliseconds, UncaughtExceptionHandler uncaughtExceptionHandler, final int coinitialiseExFlag) {
 		this.requiresInitialisation = true;
 		this.timeoutMilliseconds = timeoutMilliseconds;
@@ -67,7 +67,7 @@ public class ComThread {
 				}
 				Thread thread = new Thread(r, threadName);
 				//make sure this is a daemon thread, or it will stop JVM existing
-				// if program does not call terminate(); 
+				// if program does not call terminate();
 				thread.setDaemon(true);
 
 				thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
@@ -86,7 +86,7 @@ public class ComThread {
 
 	/**
 	 * Stop the COM Thread.
-	 * 
+	 *
 	 * @param timeoutMilliseconds
 	 *            number of milliseconds to wait for a clean shutdown before a
 	 *            forced shutdown is attempted
@@ -114,9 +114,13 @@ public class ComThread {
 
 	@Override
 	protected void finalize() throws Throwable {
-		if (!executor.isShutdown()) {
-			this.terminate(100);
-		}
+	    try {
+    		if (!executor.isShutdown()) {
+    			this.terminate(100);
+    		}
+	    } finally {
+	        super.finalize();
+	    }
 	}
 
 	public <T> T execute(Callable<T> task) throws TimeoutException, InterruptedException, ExecutionException {

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
@@ -137,7 +137,11 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 
 	@Override
 	protected void finalize() throws Throwable {
-		this.dispose(1);
+	    try {
+	        this.dispose(1);
+        } finally {
+            super.finalize();
+        }
 	}
 
 	public void dispose(int r) {

--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -365,8 +365,12 @@ class CallbackReference extends WeakReference<Callback> {
 
     /** Free native resources associated with this callback when GC'd. */
     @Override
-    protected void finalize() {
-        dispose();
+    protected void finalize() throws Throwable {
+        try {
+            dispose();
+        } finally {
+            super.finalize();
+        }
     }
 
     /** Free native resources associated with this callback. */

--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -171,8 +171,12 @@ public class Memory extends Pointer {
 
     /** Properly dispose of native memory when this object is GC'd. */
     @Override
-    protected void finalize() {
-        dispose();
+    protected void finalize() throws Throwable {
+        try {
+            dispose();
+        } finally {
+            super.finalize();
+        }
     }
 
     /** Free the native memory and set peer to zero */

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -176,8 +176,12 @@ public final class Native implements Version {
     /** Force a dispose when the Native class is GC'd. */
     private static final Object finalizer = new Object() {
         @Override
-        protected void finalize() {
-            dispose();
+        protected void finalize() throws Throwable {
+            try {
+                dispose();
+            } finally {
+                super.finalize();
+            }
         }
     };
 

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -602,8 +602,12 @@ public class NativeLibrary {
     }
     /** Close the library when it is no longer referenced. */
     @Override
-    protected void finalize() {
-        dispose();
+    protected void finalize() throws Throwable {
+        try {
+            dispose();
+        } finally {
+            super.finalize();
+        }
     }
 
     /** Close all open native libraries. */

--- a/test/com/sun/jna/MemoryTest.java
+++ b/test/com/sun/jna/MemoryTest.java
@@ -24,9 +24,12 @@ public class MemoryTest extends TestCase implements GCWaits {
         final boolean[] flag = { false };
         Memory core = new Memory(10) {
             @Override
-            protected void finalize() {
-                super.finalize();
-                flag[0] = true;
+            protected void finalize() throws Throwable{
+                try {
+                    flag[0] = true;
+                } finally {
+                    super.finalize();
+                }
             }
         };
         Pointer shared = core.share(0, 5);


### PR DESCRIPTION
While there is no immediate problem, it is a matter of good practice to always call the superclass _finalize_method - even if it is known to do nothing.