### PR TITLE
making CallbackReference accessible (public)

### DIFF
--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -36,7 +36,7 @@ import com.sun.jna.win32.DLLCallback;
  * and a Java {@link Callback} closure.
  */
 
-class CallbackReference extends WeakReference<Callback> {
+public class CallbackReference extends WeakReference<Callback> {
 
     static final Map<Callback, CallbackReference> callbackMap = new WeakHashMap<Callback, CallbackReference>();
     static final Map<Callback, CallbackReference> directCallbackMap = new WeakHashMap<Callback, CallbackReference>();


### PR DESCRIPTION
CallbackReference has some useful methods:
- public static Callback getCallback(Class<?> type, Pointer p) { ... }
- public static Pointer getFunctionPointer(Callback cb) { ... }

But they can't be used because the class is not public. This little patch makes the class public.