### PR TITLE
OaIdl.INVOKEKIND can't be instantiated (fixes failing TypeLibUtilTest)

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
@@ -1075,6 +1075,8 @@ public interface OaIdl {
                 Structure.ByReference {
         };
 
+        public static final List<String> FIELDS = createFieldsOrder("value");
+        
         // / <i>native declaration : line 30</i>
         public static final INVOKEKIND INVOKE_FUNC = new INVOKEKIND(1);
         // / <i>native declaration : line 31</i>
@@ -1084,7 +1086,6 @@ public interface OaIdl {
         // / <i>native declaration : line 33</i>
         public static final INVOKEKIND INVOKE_PROPERTYPUTREF = new INVOKEKIND(8);
 
-        public static final List<String> FIELDS = createFieldsOrder("value");
         public int value;
 
         public INVOKEKIND() {


### PR DESCRIPTION
The initialization order of the static fields in OaIdl.INVOKEKIND is broken. When INVOKEKIND is initialized the static fields also hold instances of INVOKEKIND. The constructors are called before the necessary definition of FIELDS is available. This results in the stacktrace:

**java.lang.ExceptionInInitializerError
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at java.lang.Class.newInstance(Class.java:442)
	at com.sun.jna.Structure.newInstance(Structure.java:1807)**
	at com.sun.jna.Structure.newInstance(Structure.java:1793)
	at com.sun.jna.Structure.size(Structure.java:1062)
	at com.sun.jna.Native.getNativeSize(Native.java:1208)
	at com.sun.jna.Structure.getNativeSize(Structure.java:2114)
	at com.sun.jna.Structure.getNativeSize(Structure.java:2104)
	at com.sun.jna.Structure.validateField(Structure.java:1138)
	at com.sun.jna.Structure.validateFields(Structure.java:1151)
	at com.sun.jna.Structure.<init>(Structure.java:178)
	at com.sun.jna.Structure.<init>(Structure.java:171)
	at com.sun.jna.Structure.<init>(Structure.java:167)
	at com.sun.jna.platform.win32.OaIdl$FUNCDESC.<init>(OaIdl.java:815)
	at com.sun.jna.platform.win32.COM.TypeInfoUtil.getFuncDesc(TypeInfoUtil.java:102)
	at com.sun.jna.platform.win32.COM.TypeLibUtilTest.testBug(TypeLibUtilTest.java:86)
**Caused by: java.lang.NullPointerException
	at com.sun.jna.Structure.getFields(Structure.java:996)**
	at com.sun.jna.Structure.deriveLayout(Structure.java:116