### PR TITLE
Improve binding of TypeLib bindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ Bug Fixes
 * [#566](https://github.com/java-native-access/jna/pull/566): Fix return type of Native#loadLibrary to match unconstrained generic [@lgoldstein](https://github.com/lgoldstein)
 * [#584](https://github.com/java-native-access/jna/pull/584): Promote float varargs to double - [@marco2357](https://github.com/marco2357).
 * [#588](https://github.com/java-native-access/jna/pull/588): Fix varargs calls on arm - [@twall](https://github.com/twall).
+* [#593](https://github.com/java-native-access/jna/pull/593): Improve binding of TypeLib bindings - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.2.1
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/ITypeLib.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/ITypeLib.java
@@ -12,6 +12,7 @@
  */
 package com.sun.jna.platform.win32.COM;
 
+import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.OaIdl.MEMBERID;
 import com.sun.jna.platform.win32.OaIdl.TLIBATTR;
@@ -69,9 +70,9 @@ public interface ITypeLib extends IUnknown {
 
     public HRESULT FindName(
     /* [annotation][out][in] */
-    BSTRByReference szNameBuf,
+    LPOLESTR szNameBuf,
     /* [in] */ULONG lHashVal,
-    /* [length_is][size_is][out] */PointerByReference ppTInfo,
+    /* [length_is][size_is][out] */Pointer[] ppTInfo,
     /* [length_is][size_is][out] */MEMBERID[] rgMemId,
     /* [out][in] */USHORTByReference pcFound);
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLib.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLib.java
@@ -188,8 +188,7 @@ public class TypeLib extends Unknown implements ITypeLib {
      * @return the hresult
      */
     public HRESULT IsName(
-    /* [annotation][out][in] */
-    LPOLESTR szNameBuf,
+    /* [annotation][out][in] */ LPOLESTR szNameBuf,
     /* [in] */ULONG lHashVal,
     /* [out] */BOOLByReference pfName) {
 
@@ -214,10 +213,9 @@ public class TypeLib extends Unknown implements ITypeLib {
      * @return the hresult
      */
     public HRESULT FindName(
-    /* [annotation][out][in] */
-    BSTRByReference szNameBuf,
+    /* [annotation][out][in] */ LPOLESTR szNameBuf,
     /* [in] */ULONG lHashVal,
-    /* [length_is][size_is][out] */PointerByReference ppTInfo,
+    /* [length_is][size_is][out] */Pointer[] ppTInfo,
     /* [length_is][size_is][out] */MEMBERID[] rgMemId,
     /* [out][in] */USHORTByReference pcFound) {
 
@@ -233,7 +231,7 @@ public class TypeLib extends Unknown implements ITypeLib {
      *            the t lib attr
      */
     public void ReleaseTLibAttr(/* [in] */TLIBATTR pTLibAttr) {
-        this._invokeNativeObject(12, new Object[] { this.getPointer() },
-                HRESULT.class);
+        this._invokeNativeObject(12, new Object[] { this.getPointer(), 
+            pTLibAttr.getPointer() },  HRESULT.class);
     }
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
@@ -12,6 +12,7 @@
  */
 package com.sun.jna.platform.win32.COM;
 
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.CLSID;
@@ -21,6 +22,7 @@ import com.sun.jna.platform.win32.OaIdl.TLIBATTR;
 import com.sun.jna.platform.win32.OaIdl.TYPEKIND;
 import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.OleAuto;
+import com.sun.jna.platform.win32.WTypes;
 import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.platform.win32.WTypes.LPOLESTR;
 import com.sun.jna.platform.win32.WinDef.BOOLByReference;
@@ -364,32 +366,29 @@ public class TypeLibUtil {
      * @param name
      *            the name
      * @param hashVal
-     *            the hash val
-     * @param found
-     *            the found
+     *            the hash val or 0 if unknown
+     * @param maxResult
+     *            maximum number of items to search
      * @return the find name
      */
-    public FindName FindName(String name, int hashVal, short found) {
-        /* [annotation][out][in] */
-        BSTRByReference szNameBuf = new BSTRByReference(
-                OleAuto.INSTANCE.SysAllocString(name));
-        /* [in] */ULONG lHashVal = new ULONG(hashVal);
-        /* [out][in] */USHORTByReference pcFound = new USHORTByReference(found);
+    public FindName FindName(String name, int hashVal, short maxResult) {
+        Pointer p = Ole32.INSTANCE.CoTaskMemAlloc((name.length() + 1L) * Native.WCHAR_SIZE);
+        WTypes.LPOLESTR olestr = new WTypes.LPOLESTR(p);
+        olestr.setValue(name);
 
-        HRESULT hr = this.typelib.FindName(szNameBuf, lHashVal, null, null,
+        ULONG lHashVal = new ULONG(hashVal);
+        USHORTByReference pcFound = new USHORTByReference(maxResult);
+
+        Pointer[] ppTInfo = new Pointer[maxResult];
+        MEMBERID[] rgMemId = new MEMBERID[maxResult];
+        HRESULT hr = this.typelib.FindName(olestr, lHashVal, ppTInfo, rgMemId,
                 pcFound);
         COMUtils.checkRC(hr);
 
-        found = pcFound.getValue().shortValue();
-        /* [length_is][size_is][out] */PointerByReference ppTInfo = new PointerByReference();
-        /* [length_is][size_is][out] */MEMBERID[] rgMemId = new MEMBERID[found];
-        hr = this.typelib.FindName(szNameBuf, lHashVal, ppTInfo, rgMemId,
-                pcFound);
-        COMUtils.checkRC(hr);
-
-        FindName findName = new FindName(szNameBuf.getString(), ppTInfo,
-                rgMemId, found);
-        OLEAUTO.SysFreeString(szNameBuf.getValue());
+        FindName findName = new FindName(olestr.getValue(), ppTInfo,
+                rgMemId, pcFound.getValue().shortValue());
+        
+        Ole32.INSTANCE.CoTaskMemFree(p);
 
         return findName;
     }
@@ -405,7 +404,7 @@ public class TypeLibUtil {
         private String nameBuf;
 
         /** The p t info. */
-        private PointerByReference pTInfo;
+        private Pointer[] pTInfo;
 
         /** The rg mem id. */
         private MEMBERID[] rgMemId;
@@ -423,12 +422,14 @@ public class TypeLibUtil {
  *            the rg mem id
          * @param pcFound
          */
-        public FindName(String nameBuf, PointerByReference pTInfo, MEMBERID[] rgMemId,
+        FindName(String nameBuf, Pointer[] pTInfo, MEMBERID[] rgMemId,
                         short pcFound) {
             this.nameBuf = nameBuf;
-            this.pTInfo = pTInfo;
-            this.rgMemId = rgMemId;
+            this.pTInfo = new Pointer[pcFound];
+            this.rgMemId = new MEMBERID[pcFound];
             this.pcFound = pcFound;
+            System.arraycopy(pTInfo, 0, this.pTInfo, 0, pcFound);
+            System.arraycopy(rgMemId, 0, this.rgMemId, 0, pcFound);
         }
 
         /**
@@ -446,12 +447,10 @@ public class TypeLibUtil {
          * @return the t info
          */
         public ITypeInfo[] getTInfo() {
-
-            Pointer pVals = pTInfo.getValue();
             ITypeInfo[] values=new ITypeInfo[pcFound];
             for(int i=0;i<pcFound;i++)
             {
-                values[i]=new TypeInfo(pVals.getPointer(i*Pointer.SIZE));
+                values[i]=new TypeInfo(pTInfo[i]);
             }
             return values;
         }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
@@ -196,7 +196,7 @@ public interface WTypes {
     }
 
     public static class LPOLESTR extends PointerType {
-        public static class ByReference extends BSTR implements
+        public static class ByReference extends LPOLESTR implements
                 Structure.ByReference {
         }
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ITypeLibTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ITypeLibTest.java
@@ -12,16 +12,22 @@
  */
 package com.sun.jna.platform.win32.COM;
 
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import junit.framework.TestCase;
 
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.CLSID;
+import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.OaIdl;
 import com.sun.jna.platform.win32.OaIdl.MEMBERID;
 import com.sun.jna.platform.win32.OaIdl.TYPEKIND;
 import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.OleAuto;
-import com.sun.jna.platform.win32.WTypes.BSTRByReference;
+import com.sun.jna.platform.win32.WTypes;
+import com.sun.jna.platform.win32.WTypes.BSTR;
+import com.sun.jna.platform.win32.WinDef;
 import com.sun.jna.platform.win32.WinDef.LCID;
 import com.sun.jna.platform.win32.WinDef.UINT;
 import com.sun.jna.platform.win32.WinDef.ULONG;
@@ -33,7 +39,12 @@ import com.sun.jna.ptr.PointerByReference;
  * @author dblock[at]dblock[dot]org
  */
 public class ITypeLibTest extends TestCase {
-
+    // Microsoft Shell Controls And Automation
+    private static final String SHELL_CLSID = "{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}";
+    // Version 1.0
+    private static final int SHELL_MAJOR = 1;
+    private static final int SHELL_MINOR = 0;
+    
     public static void main(String[] args) {
         junit.textui.TestRunner.run(ITypeLibTest.class);
     }
@@ -42,22 +53,19 @@ public class ITypeLibTest extends TestCase {
     }
 
     private ITypeLib loadShellTypeLib() {
-        // Microsoft Shell Controls And Automation
         CLSID.ByReference clsid = new CLSID.ByReference();
         // get CLSID from string
-        HRESULT hr = Ole32.INSTANCE.CLSIDFromString(new WString(
-                                                                "{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}"), clsid);
-        COMUtils.checkRC(hr);
-        assertEquals(0, hr.intValue());
+        HRESULT hr = Ole32.INSTANCE.CLSIDFromString(new WString(SHELL_CLSID), clsid);
+        assertTrue(COMUtils.SUCCEEDED(hr));
 
         // get user default lcid
         LCID lcid = Kernel32.INSTANCE.GetUserDefaultLCID();
-        // create a IUnknown pointer
+
         PointerByReference pShellTypeLib = new PointerByReference();
         // load typelib
-        hr = OleAuto.INSTANCE.LoadRegTypeLib(clsid, 1, 0, lcid, pShellTypeLib);
-        COMUtils.checkRC(hr);
-        assertEquals(0, hr.intValue());
+        hr = OleAuto.INSTANCE.LoadRegTypeLib(clsid, SHELL_MAJOR, SHELL_MINOR, lcid, pShellTypeLib);
+        
+        assertTrue(COMUtils.SUCCEEDED(hr));
 
         return new TypeLib(pShellTypeLib.getValue());
     }
@@ -65,7 +73,7 @@ public class ITypeLibTest extends TestCase {
     public void testGetTypeInfoCount() {
         ITypeLib shellTypeLib = loadShellTypeLib();
         UINT typeInfoCount = shellTypeLib.GetTypeInfoCount();
-        //System.out.println("GetTypeInfoCount: " + typeInfoCount);
+        assertEquals(38, typeInfoCount.intValue());
     }
 
     public void testGetTypeInfo() {
@@ -74,8 +82,8 @@ public class ITypeLibTest extends TestCase {
         PointerByReference ppTInfo = new PointerByReference();
         HRESULT hr = shellTypeLib.GetTypeInfo(new UINT(0), ppTInfo);
         
-        COMUtils.checkRC(hr);
-        assertEquals(0, hr.intValue());
+        assertTrue(COMUtils.SUCCEEDED(hr));
+        
         //System.out.println("ITypeInfo: " + ppTInfo.toString());
     }
 
@@ -85,55 +93,119 @@ public class ITypeLibTest extends TestCase {
         TYPEKIND.ByReference pTKind = new TYPEKIND.ByReference();
         HRESULT hr = shellTypeLib.GetTypeInfoType(new UINT(0), pTKind);
 
-        COMUtils.checkRC(hr);
-        assertEquals(0, hr.intValue());
+        assertTrue(COMUtils.SUCCEEDED(hr));
+        
         //System.out.println("TYPEKIND: " + pTKind);
     }
 
     public void testGetTypeInfoOfGuid() {
-        // ITypeLib shellTypeLib = loadShellTypeLib();
-        //
-        // GUID shellGuid = new GUID("{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}");
-        // TypeInfo.ByReference pTInfo = new TypeInfo.ByReference();
-        // HRESULT hr = shellTypeLib.GetTypeInfoOfGuid(shellGuid, pTInfo);
-        //
-        // COMUtils.checkRC(hr);
-        // assertEquals(0, hr.intValue());
-        // System.out.println("ITypeInfo: " + pTInfo.toString());
+         ITypeLib shellTypeLib = loadShellTypeLib();
+        
+         // GUID for dispinterface IFolderViewOC
+         GUID iFolderViewOC = new GUID("{9BA05970-F6A8-11CF-A442-00A0C90A8F39}");
+         PointerByReference pbr = new PointerByReference();
+         HRESULT hr = shellTypeLib.GetTypeInfoOfGuid(iFolderViewOC, pbr);
+        
+         assertTrue(COMUtils.SUCCEEDED(hr));
     }
 
-    public void testGetLibAttr() {
-        // ITypeLib shellTypeLib = loadShellTypeLib();
-        //
-        // TLIBATTR.ByReference ppTLibAttr = new TLIBATTR.ByReference();
-        // HRESULT hr = shellTypeLib.GetLibAttr(ppTLibAttr);
-        //
-        // COMUtils.checkRC(hr);
-        // assertEquals(0, hr.intValue());
-        // System.out.println("ppTLibAttr: " + ppTLibAttr.toString());
+    public void testLibAttr() {
+         ITypeLib shellTypeLib = loadShellTypeLib();
+        
+         PointerByReference pbr = new PointerByReference();
+         HRESULT hr = shellTypeLib.GetLibAttr(pbr);
+         
+         assertTrue(COMUtils.SUCCEEDED(hr));
+         
+         OaIdl.TLIBATTR tlibAttr = new OaIdl.TLIBATTR(pbr.getValue());
+        
+         assertEquals(SHELL_CLSID, tlibAttr.guid.toGuidString());
+         assertEquals(SHELL_MAJOR, tlibAttr.wMajorVerNum.intValue());
+         assertEquals(SHELL_MINOR, tlibAttr.wMinorVerNum.intValue());
+         
+         shellTypeLib.ReleaseTLibAttr(tlibAttr);
     }
 
     public void testGetTypeComp() {
-        // ITypeLib shellTypeLib = loadShellTypeLib();
-        //
-        // TypeComp.ByReference pTComp = new TypeComp.ByReference();
-        // HRESULT hr = shellTypeLib.GetTypeComp(pTComp);
-        //
-        // COMUtils.checkRC(hr);
-        // assertEquals(0, hr.intValue());
-        // System.out.println("pTComp: " + pTComp.toString());
+        ITypeLib shellTypeLib = loadShellTypeLib();
+
+        PointerByReference pbr = new PointerByReference();
+        HRESULT hr = shellTypeLib.GetTypeComp(pbr);
+
+        // Only check that call works
+        assertTrue(COMUtils.SUCCEEDED(hr));
     }
 
+    public void testIsName() {
+        ITypeLib shellTypeLib = loadShellTypeLib();
+
+        String memberValue = "Folder";
+        Pointer p = Ole32.INSTANCE.CoTaskMemAlloc((memberValue.length() + 1L) * Native.WCHAR_SIZE);
+        WTypes.LPOLESTR olestr = new WTypes.LPOLESTR(p);
+        olestr.setValue(memberValue);
+        
+        WinDef.BOOLByReference boolByRef = new WinDef.BOOLByReference();
+        
+        HRESULT hr = shellTypeLib.IsName(olestr, new ULONG(0), boolByRef);
+        assertTrue(COMUtils.SUCCEEDED(hr));
+        
+        // Folder is a member
+        assertTrue(boolByRef.getValue().booleanValue());
+        
+        Ole32.INSTANCE.CoTaskMemFree(p);
+    }
+    
     public void testFindName() {
         ITypeLib shellTypeLib = loadShellTypeLib();
-        BSTRByReference szNameBuf = new BSTRByReference(OleAuto.INSTANCE.SysAllocString("Application"));
+        
+        // The found member is Count, search done with lowercase value to test
+        // correct behaviour (search is case insensitive)
+        String memberValue = "count";
+        String memberValueOk = "Count";
+        Pointer p = Ole32.INSTANCE.CoTaskMemAlloc((memberValue.length() + 1L) * Native.WCHAR_SIZE);
+        WTypes.LPOLESTR olestr = new WTypes.LPOLESTR(p);
+        olestr.setValue(memberValue);
+        
+        short maxResults = 100;
+        
         ULONG lHashVal = new ULONG(0);
-        USHORTByReference pcFound = new USHORTByReference((short)20);
-        PointerByReference ppTInfo = new PointerByReference();
-        MEMBERID[] rgMemId = new MEMBERID[20];
-        HRESULT hr = shellTypeLib.FindName(szNameBuf, lHashVal, ppTInfo, rgMemId, pcFound);
-
-        COMUtils.checkRC(hr);
-        //System.out.println("szNameBuf: " + szNameBuf);
+        USHORTByReference pcFound = new USHORTByReference(maxResults);
+        Pointer[] pointers = new Pointer[maxResults];
+        MEMBERID[] rgMemId = new MEMBERID[maxResults];
+        
+        HRESULT hr = shellTypeLib.FindName(olestr, lHashVal, pointers, rgMemId, pcFound);
+        assertTrue(COMUtils.SUCCEEDED(hr));
+                
+        // If a reader can come up with more tests it would be appretiated,
+        // the documentation is unclear what more can be expected
+        
+        // 2 matches come from manual tests
+        assertTrue(pcFound.getValue().intValue() == 2);
+        // Check that function return corrected member name (Count) - see uppercase C
+        assertEquals(memberValueOk, olestr.getValue());
+        
+        // There have to be as many pointers as reported by pcFound
+        assertNotNull(pointers[0]);
+        assertNotNull(pointers[1]);
+        assertNull(pointers[2]); // Might be flaky, contract only defined positions 0 -> (pcFound - 1)
+        
+        // Test access to second value
+        TypeInfo secondTypeInfo = new TypeInfo(pointers[1]);
+        
+        PointerByReference pbr = new PointerByReference();
+        hr = secondTypeInfo.GetTypeAttr(pbr);
+        assertTrue(COMUtils.SUCCEEDED(hr));
+        OaIdl.TYPEATTR pTypeAttr = new OaIdl.TYPEATTR(pbr.getValue());
+        
+        // Either interface FolderItemVerbs ({1F8352C0-50B0-11CF-960C-0080C7F4EE85})
+        // or FolderItems ({744129E0-CBE5-11CE-8350-444553540000})
+        String typeGUID = pTypeAttr.guid.toGuidString();
+        
+        assertTrue(typeGUID.equals("{1F8352C0-50B0-11CF-960C-0080C7F4EE85}") ||
+                typeGUID.equals("{744129E0-CBE5-11CE-8350-444553540000}"));
+                
+        secondTypeInfo.ReleaseTypeAttr(pTypeAttr);
+        
+        Ole32.INSTANCE.CoTaskMemFree(olestr.getPointer());
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/TypeLibUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/TypeLibUtilTest.java
@@ -15,9 +15,14 @@ package com.sun.jna.platform.win32.COM;
 import junit.framework.TestCase;
 
 import com.sun.jna.platform.win32.COM.TypeInfoUtil.TypeInfoDoc;
+import com.sun.jna.platform.win32.COM.TypeLibUtil.FindName;
+import com.sun.jna.platform.win32.COM.TypeLibUtil.IsName;
+import com.sun.jna.platform.win32.OaIdl;
 import com.sun.jna.platform.win32.OaIdl.FUNCDESC;
 import com.sun.jna.platform.win32.OaIdl.MEMBERID;
 import com.sun.jna.platform.win32.OaIdl.TYPEATTR;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+import com.sun.jna.ptr.PointerByReference;
 
 /**
  * @author dblock[at]dblock[dot]org
@@ -70,31 +75,52 @@ public class TypeLibUtilTest extends TestCase {
             typeInfoUtil.ReleaseTypeAttr(typeAttr);
         }
     }
-    
-    public void testBug() {
-        TypeLibUtil shellTypeLib = loadShellTypeLib();
-        int typeInfoCount = shellTypeLib.getTypeInfoCount();
-        
-        ITypeInfo typeInfo = shellTypeLib.getTypeInfo(4);
-        TypeInfoUtil typeInfoUtil = new TypeInfoUtil(typeInfo);
-        
-        TYPEATTR typeAttr = typeInfoUtil.getTypeAttr();
-        int cFuncs = typeAttr.cFuncs.intValue();
-    
-        for (int y = 0; y < cFuncs; y++) {
-            // Get the function description
-            FUNCDESC funcDesc = typeInfoUtil.getFuncDesc(y);
-            // Get the member ID
-            MEMBERID memberID = funcDesc.memid;
-            // Get the name of the method
-            TypeInfoDoc typeInfoDoc2 = typeInfoUtil.getDocumentation(memberID);
-            String methodName = typeInfoDoc2.getName();
-            
-            assertNotNull(methodName);
 
-            typeInfoUtil.ReleaseFuncDesc(funcDesc);
-        }
+    public void testFindName() {
+        // Test is modelled after ITypeLibTest#testFindName
+        TypeLibUtil shellTypeLib = loadShellTypeLib();
         
-        typeInfoUtil.ReleaseTypeAttr(typeAttr);
+        String memberValue = "count";
+        String memberValueOk = "Count";
+        
+        FindName result = shellTypeLib.FindName(memberValue, 0, (short) 100);
+        
+        // 2 matches come from manual tests
+        assertEquals(2, result.getFound());
+        // Check that function return corrected member name (Count) - see uppercase C
+        assertEquals(memberValueOk, result.getNameBuf());
+        
+        // There have to be as many pointers as reported by pcFound
+        ITypeInfo[] typelib = result.getTInfo();
+        assertEquals(2, typelib.length);
+        assertNotNull(typelib[0]);
+        assertNotNull(typelib[1]);
+        
+        PointerByReference pbr = new PointerByReference();
+        HRESULT hr = typelib[1].GetTypeAttr(pbr);
+        assertTrue(COMUtils.SUCCEEDED(hr));
+        OaIdl.TYPEATTR pTypeAttr = new OaIdl.TYPEATTR(pbr.getValue());
+        
+        // Either interface FolderItemVerbs ({1F8352C0-50B0-11CF-960C-0080C7F4EE85})
+        // or FolderItems ({744129E0-CBE5-11CE-8350-444553540000})
+        String typeGUID = pTypeAttr.guid.toGuidString();
+        
+        assertTrue(typeGUID.equals("{1F8352C0-50B0-11CF-960C-0080C7F4EE85}") ||
+                typeGUID.equals("{744129E0-CBE5-11CE-8350-444553540000}"));
+                
+        typelib[1].ReleaseTypeAttr(pTypeAttr);
     }
+    
+    public void testIsName() {
+        // Test is modelled after ITypeLibTest#testFindName
+        TypeLibUtil shellTypeLib = loadShellTypeLib();
+        
+        String memberValue = "count";
+        String memberValueOk = "Count";
+        
+        IsName isNameResult = shellTypeLib.IsName(memberValue, 0);
+        
+        assertEquals(memberValueOk, isNameResult.getNameBuf());
+        assertTrue(isNameResult.isName());
+    }    
 }


### PR DESCRIPTION
- fix wrong function signature in ITypeLib/TypeLib for FindName/IsName
  and adjust callers
- TypeLib#ReleaseLibAttr did not pass parameter to native method
- LPOLESTR.ByReference is derived from wrong type (BSTR instead of LPOLESTR)
- Fix/Add unittests