### PR TITLE
Allow calling COM methods/getters requirering hybrid calling (METHOD+PROPERTYGET convention)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ Features
 * [#569](https://github.com/java-native-access/jna/pull/569): Added `com.sun.jna.platform.win32.Winspool.PRINTER_INFO_2` support. Added GetPrinter and ClosePrinter functions in `com.sun.jna.platform.win32.Winspool` - [@IvanRF](https://github.com/IvanRF).
 * [#583](https://github.com/java-native-access/jna/pull/583): Added printer attributes and status - [@IvanRF](https://github.com/IvanRF).
 * [#589](https://github.com/java-native-access/jna/pull/589): Use MethodResultContext in direct mapping (as done in interface mapping) - [@marco2357](https://github.com/marco2357).
+* [#595](https://github.com/java-native-access/jna/pull/595): Allow calling COM methods/getters requiring hybrid calling (METHOD+PROPERTYGET) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
@@ -611,6 +611,36 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 			dp.cNamedArgs = new UINT(_argsLen);
 			dp.rgdispidNamedArgs = new DISPIDByReference(OaIdl.DISPID_PROPERTYPUT);
 		}
+                
+                // Apply "fix" according to
+                // https://www.delphitools.info/2013/04/30/gaining-visual-basic-ole-super-powers/
+                // https://msdn.microsoft.com/en-us/library/windows/desktop/ms221486(v=vs.85).aspx
+                //
+                // Summary: there are methods in the word typelibrary that require both
+                // PROPERTYGET _and_ METHOD to be set. With only one of these set the call
+                // fails.
+                //
+                // The article from delphitools argues, that automation compatible libraries
+                // need to be compatible with VisualBasic which does not distingish methods
+                // and property getters and will set both flags always.
+                //
+                // The MSDN article advises this behaviour: "[...] Some languages cannot 
+                // distinguish between retrieving a property and calling a method. In this 
+                //case, you should set the flags DISPATCH_PROPERTYGET and DISPATCH_METHOD.
+                // [...]"))
+                //
+                // This was found when trying to bind InchesToPoints from the _Application 
+                // dispatch interface of the MS Word 15 type library
+                //
+                // The signature according the ITypeLib Viewer (OLE/COM Object Viewer):
+                // [id(0x00000172), helpcontext(0x09700172)]
+                // single InchesToPoints([in] single Inches);
+                final int finalNType;
+                if(nType == OleAuto.DISPATCH_METHOD || nType == OleAuto.DISPATCH_PROPERTYGET) {
+                    finalNType = OleAuto.DISPATCH_METHOD | OleAuto.DISPATCH_PROPERTYGET;
+                } else {
+                    finalNType = nType;
+                }
 
 		// Build DISPPARAMS
 		if (_argsLen > 0) {
@@ -629,7 +659,7 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 				@Override
 				public HRESULT call() throws Exception {
 					return pDisp.Invoke(dispId, new REFIID(Guid.IID_NULL), LOCALE_SYSTEM_DEFAULT,
-							new WinDef.WORD(nType), dp, pvResult, pExcepInfo, puArgErr);
+							new WinDef.WORD(finalNType), dp, pvResult, pExcepInfo, puArgErr);
 				}
 			});
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IDispatchTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IDispatchTest.java
@@ -39,7 +39,7 @@ public class IDispatchTest extends TestCase {
         try {
             PointerByReference pDispatch = new PointerByReference();
 
-            // Get CLSID for Word.Application...
+            // Get CLSID for Shell.Application...
             CLSID.ByReference clsid = new CLSID.ByReference();
             HRESULT hr = Ole32.INSTANCE.CLSIDFromProgID("Shell.Application",
                     clsid);

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/RunningObjectTable_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/RunningObjectTable_Test.java
@@ -31,10 +31,10 @@ public class RunningObjectTable_Test {
 	@ComInterface(iid="{00020970-0000-0000-C000-000000000046}")
 	interface Application extends IUnknown {
 		@ComProperty
-		boolean getVisible();
+		Boolean getVisible();
 		
 		@ComProperty
-		void setVisible(boolean value);
+		void setVisible(Boolean value);
 		
 		@ComMethod
 		void Quit(boolean SaveChanges, Object OriginalFormat, Boolean RouteDocument);


### PR DESCRIPTION
It was found, that calling InchesToPoints method from word type library
failed. Research lead to 

https://www.delphitools.info/2013/04/30/gaining-visual-basic-ole-super-powers/
https://msdn.microsoft.com/en-us/library/windows/desktop/ms221486(v=vs.85).aspx

Summary: there are methods in the word typelibrary that require both
PROPERTYGET _and_ METHOD to be set. With only one of these set the call
fails.

The article from delphitools argues, that automation compatible libraries
need to be compatible with VisualBasic which does not distingish methods
and property getters and will set both flags always.

The MSDN article advises this behaviour: "[...] Some languages cannot 
distinguish between retrieving a property and calling a method. In this 
case, you should set the flags DISPATCH_PROPERTYGET and DISPATCH_METHOD.
[...]"

This further support the advised way from delphitools and was implemented.