### PR TITLE
Fixed issue #604: Kernel32#GetLastError() always returns ERROR_SUCCESS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@ Bug Fixes
 * [#578](https://github.com/java-native-access/jna/pull/578): Fix COM CallbackHandlers, allow usage of VARIANTs directly in c.s.j.p.w.COM.util.ProxyObject and fix native memory leak in c.s.j.p.w.COM.util.ProxyObject - [@matthiasblaesing](https://github.com/matthiasblaesing)
 * [#601](https://github.com/java-native-access/jna/pull/601): Remove COMThread and COM initialization from objects and require callers to initialize COM themselves. Asserts are added to guard correct usage. - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#602] https://github.com/java-native-access/jna/pull/602): Make sure SID related memory is properly released once no longer required [@lgoldstein](https://github.com/lgoldstein).
+* [#610](https://github.com/java-native-access/jna/pull/610): Fixed issue #604: Kernel32#GetLastError() always returns ERROR_SUCCESS [@lgoldstein](https://github.com/lgoldstein).
 
 Release 4.2.1
 =============

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -109,7 +109,12 @@ public class NativeLibrary {
             synchronized(functions) {
                 Function f = new Function(this, "GetLastError", Function.ALT_CONVENTION, encoding) {
                         @Override
-                        Object invoke(Object[] args, Class<?> returnType, boolean b) {
+                        Object invoke(Object[] args, Class<?> returnType, boolean b, int fixedArgs) {
+                            return Integer.valueOf(Native.getLastError());
+                        }
+
+                        @Override
+                        Object invoke(Method invokingMethod, Class<?>[] paramTypes, Class<?> returnType, Object[] inArgs, Map<String, ?> options) {
                             return Integer.valueOf(Native.getLastError());
                         }
                     };


### PR DESCRIPTION
Corrected required overrides in the "short-circuit" code