### PR TITLE
Added standard Kernel32Util#closeHandle method that throws an exception if failed to close the handle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,9 +39,10 @@ Features
 * [#595](https://github.com/java-native-access/jna/pull/595): Allow calling COM methods/getters requiring hybrid calling (METHOD+PROPERTYGET) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#582](https://github.com/java-native-access/jna/pull/582): Mavenize the build process - Phase 1: building the native code via Maven [@lgoldstein](https://github.com/lgoldstein).
 * [#606](https://github.com/java-native-access/jna/pull/606): Added Kerne32Util method to facilitate checking that calls to LocalFree/GlobalFree are successful [@lgoldstein](https://github.com/lgoldstein).
-* [#612](https://github.com/java-native-access/jna/pull/612): Kernel32Util#freeLocal/GlobalMemory always throws Win32Exception if failed [@lgoldstein](https://github.com/lgoldstein).
+* [#612](https://github.com/java-native-access/jna/pull/612): 'Kernel32Util#freeLocal/GlobalMemory' always throws Win32Exception if failed [@lgoldstein](https://github.com/lgoldstein).
 * [#608](https://github.com/java-native-access/jna/pull/608): Mavenize the build process - change parent and native pom artifactId/name to differentiate in IDE and build tools. [@bhamail](https://github.com/bhamail)
 * [#613](https://github.com/java-native-access/jna/pull/613): Make Win32Exception extend LastErrorException [@lgoldstein](https://github.com/lgoldstein).
+* [#613](https://github.com/java-native-access/jna/pull/614): Added standard 'Kernel32Util#closeHandle' method that throws a Win32Exception if failed to close the handle [@lgoldstein](https://github.com/lgoldstein).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -735,14 +735,15 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
             int dwDesiredAccess, boolean bInheritHandle, int dwOptions);
 
     /**
-     * The CloseHandle function closes an open object handle.
+     * Closes an open object handle.
      *
      * @param hObject
      *            Handle to an open object. This parameter can be a pseudo
      *            handle or INVALID_HANDLE_VALUE.
      * @return If the function succeeds, the return value is nonzero. If the
      *         function fails, the return value is zero. To get extended error
-     *         information, call GetLastError.
+     *         information, call {@code GetLastError}.
+     * @see <A HREF="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx">CloseHandle</A>
      */
     boolean CloseHandle(HANDLE hObject);
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
@@ -1,28 +1,31 @@
 /* Copyright (c) 2010 Daniel Doubrovkine, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna.platform.win32;
+
+import static com.sun.jna.platform.win32.WinBase.FILE_DIR_DISALOWED;
+import static com.sun.jna.platform.win32.WinBase.FILE_ENCRYPTABLE;
+import static com.sun.jna.platform.win32.WinBase.FILE_IS_ENCRYPTED;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.util.Map;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
-
 import com.sun.jna.platform.win32.Advapi32Util.Account;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogIterator;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogRecord;
 import com.sun.jna.platform.win32.LMAccess.USER_INFO_1;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.platform.win32.WinNT.SECURITY_DESCRIPTOR_RELATIVE;
@@ -31,7 +34,7 @@ import com.sun.jna.platform.win32.WinNT.WELL_KNOWN_SID_TYPE;
 import com.sun.jna.platform.win32.WinReg.HKEY;
 import com.sun.jna.platform.win32.WinReg.HKEYByReference;
 
-import static com.sun.jna.platform.win32.WinBase.*;
+import junit.framework.TestCase;
 
 /**
  * @author dblock[at]dblock[dot]org
@@ -42,17 +45,17 @@ public class Advapi32UtilTest extends TestCase {
         junit.textui.TestRunner.run(Advapi32UtilTest.class);
         String currentUserName = Advapi32Util.getUserName();
         System.out.println("GetUserName: " + currentUserName);
-		
+
         for(Account group : Advapi32Util.getCurrentUserGroups()) {
             System.out.println(" " + group.fqn + " [" + group.sidString + "]");
         }
-		
+
         Account accountByName = Advapi32Util.getAccountByName(currentUserName);
         System.out.println("AccountByName: " + currentUserName);
         System.out.println(" Fqn: " + accountByName.fqn);
         System.out.println(" Domain: " + accountByName.domain);
         System.out.println(" Sid: " + accountByName.sidString);
-        
+
         Account accountBySid = Advapi32Util.getAccountBySid(new PSID(accountByName.sid));
         System.out.println("AccountBySid: " + accountByName.sidString);
         System.out.println(" Fqn: " + accountBySid.fqn);
@@ -75,13 +78,13 @@ public class Advapi32UtilTest extends TestCase {
         final boolean access = Advapi32Util.accessCheck(new File(System.getProperty("java.io.tmpdir")), Advapi32Util.AccessCheckPermission.EXECUTE);
         assertTrue(access);
     }
-    
+
     public void testGetUsername() {
         String username = Advapi32Util.getUserName();
         assertTrue(username.length() > 0);
     }
-	
-    public void testGetAccountBySid() {		
+
+    public void testGetAccountBySid() {
         String accountName = Advapi32Util.getUserName();
         Account currentUser = Advapi32Util.getAccountByName(accountName);
         Account account = Advapi32Util.getAccountBySid(new PSID(currentUser.sid));
@@ -89,23 +92,23 @@ public class Advapi32UtilTest extends TestCase {
         assertEquals(currentUser.fqn.toLowerCase(), account.fqn.toLowerCase());
         assertEquals(currentUser.name.toLowerCase(), account.name.toLowerCase());
         assertEquals(currentUser.domain.toLowerCase(), account.domain.toLowerCase());
-        assertEquals(currentUser.sidString, account.sidString);		
+        assertEquals(currentUser.sidString, account.sidString);
     }
 
-    public void testGetAccountByName() {		
+    public void testGetAccountByName() {
         String accountName = Advapi32Util.getUserName();
         Account account = Advapi32Util.getAccountByName(accountName);
         assertEquals(SID_NAME_USE.SidTypeUser, account.accountType);
     }
-	
+
     public void testGetAccountNameFromSid() {
-        assertEquals("Everyone", Advapi32Util.getAccountBySid("S-1-1-0").name);		
+        assertEquals("Everyone", Advapi32Util.getAccountBySid("S-1-1-0").name);
     }
 
     public void testGetAccountSidFromName() {
         assertEquals("S-1-1-0", Advapi32Util.getAccountByName("Everyone").sidString);
     }
-	
+
     public void testConvertSid() {
     	String sidString = "S-1-1-0"; // Everyone
     	byte[] sidBytes = Advapi32Util.convertStringSidToSid(sidString);
@@ -113,7 +116,7 @@ public class Advapi32UtilTest extends TestCase {
     	String convertedSidString = Advapi32Util.convertSidToStringSid(new PSID(sidBytes));
     	assertEquals(convertedSidString, sidString);
     }
-	
+
     public void testGetCurrentUserGroups() {
         Account[] groups = Advapi32Util.getCurrentUserGroups();
         assertTrue(groups.length > 0);
@@ -123,7 +126,7 @@ public class Advapi32UtilTest extends TestCase {
             assertTrue(group.sid.length > 0);
         }
     }
-	
+
     public void testGetUserGroups() {
     	USER_INFO_1 userInfo = new USER_INFO_1();
     	userInfo.usri1_name = "JNANetapi32TestUser";
@@ -137,7 +140,7 @@ public class Advapi32UtilTest extends TestCase {
             HANDLEByReference phUser = new HANDLEByReference();
             try {
                 assertTrue(Advapi32.INSTANCE.LogonUser(userInfo.usri1_name.toString(),
-                                                       null, userInfo.usri1_password.toString(), WinBase.LOGON32_LOGON_NETWORK, 
+                                                       null, userInfo.usri1_password.toString(), WinBase.LOGON32_LOGON_NETWORK,
                                                        WinBase.LOGON32_PROVIDER_DEFAULT, phUser));
                 Account[] groups = Advapi32Util.getTokenGroups(phUser.getValue());
                 assertTrue(groups.length > 0);
@@ -147,17 +150,18 @@ public class Advapi32UtilTest extends TestCase {
                     assertTrue(group.sid.length > 0);
                 }
             } finally {
-                if (phUser.getValue() != WinBase.INVALID_HANDLE_VALUE) {
-                    Kernel32.INSTANCE.CloseHandle(phUser.getValue());
-                }				
+                HANDLE hUser = phUser.getValue();
+                if (!WinBase.INVALID_HANDLE_VALUE.equals(hUser)) {
+                    Kernel32Util.closeHandle(hUser);
+                }
             }
         } finally {
             assertEquals("Error in NetUserDel",
                          LMErr.NERR_Success,
-                         Netapi32.INSTANCE.NetUserDel(null, userInfo.usri1_name.toString()));			
+                         Netapi32.INSTANCE.NetUserDel(null, userInfo.usri1_name.toString()));
         }
     }
-	
+
     public void testGetUserAccount() {
     	USER_INFO_1 userInfo = new USER_INFO_1();
     	userInfo.usri1_name = "JNANetapi32TestUser";
@@ -171,47 +175,47 @@ public class Advapi32UtilTest extends TestCase {
             HANDLEByReference phUser = new HANDLEByReference();
             try {
                 assertTrue(Advapi32.INSTANCE.LogonUser(userInfo.usri1_name.toString(),
-                                                       null, userInfo.usri1_password.toString(), WinBase.LOGON32_LOGON_NETWORK, 
+                                                       null, userInfo.usri1_password.toString(), WinBase.LOGON32_LOGON_NETWORK,
                                                        WinBase.LOGON32_PROVIDER_DEFAULT, phUser));
                 Advapi32Util.Account account = Advapi32Util.getTokenAccount(phUser.getValue());
                 assertTrue(account.name.length() > 0);
                 assertEquals(userInfo.usri1_name.toString(), account.name);
             } finally {
-                if (phUser.getValue() != WinBase.INVALID_HANDLE_VALUE) {
-                    Kernel32.INSTANCE.CloseHandle(phUser.getValue());
+                HANDLE hUser = phUser.getValue();
+                if (!WinBase.INVALID_HANDLE_VALUE.equals(hUser)) {
+                    Kernel32Util.closeHandle(hUser);
                 }
             }
         } finally {
-            assertEquals(LMErr.NERR_Success, Netapi32.INSTANCE.NetUserDel(
-                                                                          null, userInfo.usri1_name.toString()));			
+            assertEquals(LMErr.NERR_Success, Netapi32.INSTANCE.NetUserDel(null, userInfo.usri1_name.toString()));
         }
-    }	
-	
+    }
+
     public void testRegistryKeyExists() {
-        assertTrue(Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE, 
+        assertTrue(Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE,
                                                   ""));
-        assertTrue(Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE, 
+        assertTrue(Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE,
                                                   "Software\\Microsoft"));
-        assertFalse(Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE, 
+        assertFalse(Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE,
                                                    "KeyDoesNotExist\\SubKeyDoesNotExist"));
     }
-	
+
     public void testRegistryValueExists() {
-        assertFalse(Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, 
+        assertFalse(Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE,
                                                      "Software\\Microsoft", ""));
-        assertFalse(Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, 
+        assertFalse(Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE,
                                                      "Software\\Microsoft", "KeyDoesNotExist"));
-        assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, 
+        assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE,
                                                     "SYSTEM\\CurrentControlSet\\Control", "SystemBootDevice"));
-    }	
-	
+    }
+
     public void testRegistryCreateDeleteKey() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         assertTrue(Advapi32Util.registryKeyExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA"));
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         assertFalse(Advapi32Util.registryKeyExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA"));
     }
-	
+
     public void testRegistryCreateKeyDisposition() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
@@ -225,47 +229,47 @@ public class Advapi32UtilTest extends TestCase {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registrySetIntValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "IntValue", 42);
         assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "IntValue"));
-        Advapi32Util.registryDeleteValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "IntValue");		
+        Advapi32Util.registryDeleteValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "IntValue");
         assertFalse(Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "IntValue"));
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
-	
+
     public void testRegistrySetGetIntValue() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registrySetIntValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "IntValue", 42);
-        assertEquals(42, Advapi32Util.registryGetIntValue(WinReg.HKEY_CURRENT_USER, 
+        assertEquals(42, Advapi32Util.registryGetIntValue(WinReg.HKEY_CURRENT_USER,
                                                           "Software\\JNA", "IntValue"));
         assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "IntValue"));
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
-	
+
     public void testRegistrySetGetLongValue() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registrySetLongValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "LongValue", 1234L);
-        assertEquals(1234L, Advapi32Util.registryGetLongValue(WinReg.HKEY_CURRENT_USER, 
+        assertEquals(1234L, Advapi32Util.registryGetLongValue(WinReg.HKEY_CURRENT_USER,
                                                               "Software\\JNA", "LongValue"));
         assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "LongValue"));
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
-	
+
     public void testRegistrySetGetStringValue() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registrySetStringValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "StringValue", "Hello World");
-        assertEquals("Hello World", Advapi32Util.registryGetStringValue(WinReg.HKEY_CURRENT_USER, 
+        assertEquals("Hello World", Advapi32Util.registryGetStringValue(WinReg.HKEY_CURRENT_USER,
                                                                         "Software\\JNA", "StringValue"));
         assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "StringValue"));
-        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");		
+        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
 
     public void testRegistrySetGetExpandableStringValue() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registrySetExpandableStringValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "StringValue", "Temp is %TEMP%");
-        assertEquals("Temp is %TEMP%", Advapi32Util.registryGetExpandableStringValue(WinReg.HKEY_CURRENT_USER, 
+        assertEquals("Temp is %TEMP%", Advapi32Util.registryGetExpandableStringValue(WinReg.HKEY_CURRENT_USER,
                                                                                      "Software\\JNA", "StringValue"));
         assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "StringValue"));
-        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");		
+        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
-	
+
     public void testRegistrySetGetStringArray() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         String[] dataWritten = { "Hello", "World" };
@@ -288,14 +292,14 @@ public class Advapi32UtilTest extends TestCase {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registrySetBinaryValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "BinaryValue", data);
         byte[] read = Advapi32Util.registryGetBinaryValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "BinaryValue");
-        assertEquals(data.length, read.length);		
+        assertEquals(data.length, read.length);
         for(int i = 0; i < data.length; i++) {
             assertEquals(data[i], read[i]);
         }
         assertTrue(Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "BinaryValue"));
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
-	
+
     public void testRegistryGetKeys() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key1");
@@ -306,9 +310,9 @@ public class Advapi32UtilTest extends TestCase {
         assertEquals(subKeys[1], "Key2");
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key1");
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key2");
-        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");				
+        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
-	
+
     public void testRegistryGetCloseKey() {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key1");
@@ -323,14 +327,14 @@ public class Advapi32UtilTest extends TestCase {
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key2");
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
-	
+
     public void testRegistryGetValues() {
         String uu = new String("A" + "\\u00ea" + "\\u00f1" + "\\u00fc" + "C");
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
         Advapi32Util.registrySetIntValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "FourtyTwo" + uu, 42);
         Advapi32Util.registrySetStringValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "42" + uu, "FourtyTwo" + uu);
         Advapi32Util.registrySetExpandableStringValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "ExpandableString", "%TEMP%");
-        byte[] dataWritten = { 0xD, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF };		
+        byte[] dataWritten = { 0xD, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF };
         Advapi32Util.registrySetBinaryValue(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "DeadBeef", dataWritten);
         String[] stringsWritten = { "Hello", "World", "Hello World", uu };
         Advapi32Util.registrySetStringArray(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "StringArray", stringsWritten);
@@ -354,7 +358,7 @@ public class Advapi32UtilTest extends TestCase {
         }
         stringsRead = (String[]) values.get("EmptyStringArray");
         assertEquals(0, stringsRead.length);
-        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");						
+        Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
     }
 
     public void testRegistryGetEmptyValues() {
@@ -396,16 +400,16 @@ public class Advapi32UtilTest extends TestCase {
             }
         }
     }
-	
-    public void testIsWellKnownSid() {		
+
+    public void testIsWellKnownSid() {
         String everyoneString = "S-1-1-0";
-        assertTrue(Advapi32Util.isWellKnownSid(everyoneString, WELL_KNOWN_SID_TYPE.WinWorldSid));		
+        assertTrue(Advapi32Util.isWellKnownSid(everyoneString, WELL_KNOWN_SID_TYPE.WinWorldSid));
         assertFalse(Advapi32Util.isWellKnownSid(everyoneString, WELL_KNOWN_SID_TYPE.WinAccountAdministratorSid));
         byte[] everyoneBytes = Advapi32Util.convertStringSidToSid(everyoneString);
-        assertTrue(Advapi32Util.isWellKnownSid(everyoneBytes, WELL_KNOWN_SID_TYPE.WinWorldSid));		
+        assertTrue(Advapi32Util.isWellKnownSid(everyoneBytes, WELL_KNOWN_SID_TYPE.WinWorldSid));
         assertFalse(Advapi32Util.isWellKnownSid(everyoneBytes, WELL_KNOWN_SID_TYPE.WinAccountAdministratorSid));
     }
-	
+
     public void testEventLogIteratorForwards() {
         EventLogIterator iter = new EventLogIterator("Application");
         try {
@@ -418,18 +422,18 @@ public class Advapi32UtilTest extends TestCase {
                 assertNotNull(record.getType().name());
                 assertNotNull(record.getSource());
                 if (record.getRecord().DataLength.intValue() > 0) {
-                    assertEquals(record.getData().length, 
+                    assertEquals(record.getData().length,
                                  record.getRecord().DataLength.intValue());
                 } else {
                     assertNull(record.getData());
                 }
                 if (record.getRecord().NumStrings.intValue() > 0) {
-                    assertEquals(record.getStrings().length, 
+                    assertEquals(record.getStrings().length,
                                  record.getRecord().NumStrings.intValue());
                 } else {
                     assertNull(record.getStrings());
                 }
-				
+
                 if (max-- <= 0) {
                     break; // shorten test
                 }
@@ -444,9 +448,9 @@ public class Advapi32UtilTest extends TestCase {
             iter.close();
         }
     }
-	
+
     public void testEventLogIteratorBackwards() {
-        EventLogIterator iter = new EventLogIterator(null, 
+        EventLogIterator iter = new EventLogIterator(null,
                                                      "Application", WinNT.EVENTLOG_BACKWARDS_READ);
         try {
             int max = 100;
@@ -469,10 +473,10 @@ public class Advapi32UtilTest extends TestCase {
             iter.close();
         }
     }
-	
+
     public void testGetEnvironmentBlock() {
         String expected = "KEY=value\0"
-            + "KEY_EMPTY=\0" 
+            + "KEY_EMPTY=\0"
             + "KEY_NUMBER=2\0"
             + "\0";
 
@@ -481,28 +485,28 @@ public class Advapi32UtilTest extends TestCase {
         mockEnvironment.put("KEY", "value");
         mockEnvironment.put("KEY_EMPTY", "");
         mockEnvironment.put("KEY_NUMBER", "2");
-        mockEnvironment.put("KEY_NULL", null);		
+        mockEnvironment.put("KEY_NULL", null);
 
         String block = Advapi32Util.getEnvironmentBlock(mockEnvironment);
         assertEquals("Environment block must comprise key=value pairs separated by NUL characters", expected, block);
     }
-	
+
     public void testGetFileSecurityDescriptor() throws Exception {
-        File file = createTempFile();        
+        File file = createTempFile();
         SECURITY_DESCRIPTOR_RELATIVE sdr = Advapi32Util.getFileSecurityDescriptor(file, false);
         assertTrue(Advapi32.INSTANCE.IsValidSecurityDescriptor(sdr.getPointer()));
         file.delete();
     }
-    
+
     public void testSetFileSecurityDescriptor() throws Exception {
-        File file = createTempFile();        
-        SECURITY_DESCRIPTOR_RELATIVE sdr = Advapi32Util.getFileSecurityDescriptor(file, false);        
+        File file = createTempFile();
+        SECURITY_DESCRIPTOR_RELATIVE sdr = Advapi32Util.getFileSecurityDescriptor(file, false);
         Advapi32Util.setFileSecurityDescriptor(file, sdr, false, true, true, false, true, false);
         sdr = Advapi32Util.getFileSecurityDescriptor(file, false);
-        assertTrue(Advapi32.INSTANCE.IsValidSecurityDescriptor(sdr.getPointer()));        
+        assertTrue(Advapi32.INSTANCE.IsValidSecurityDescriptor(sdr.getPointer()));
         file.delete();
     }
-    
+
     public void testEncryptFile() throws Exception {
         File file = createTempFile();
         assertEquals(FILE_ENCRYPTABLE, Advapi32Util.fileEncryptionStatus(file));
@@ -521,7 +525,7 @@ public class Advapi32UtilTest extends TestCase {
     }
 
     public void testDisableEncryption() throws Exception {
-        File dir = new File(System.getProperty("java.io.tmpdir") + File.separator 
+        File dir = new File(System.getProperty("java.io.tmpdir") + File.separator
                 + System.nanoTime());
         dir.mkdir();
         assertEquals(FILE_ENCRYPTABLE, Advapi32Util.fileEncryptionStatus(dir));
@@ -534,29 +538,29 @@ public class Advapi32UtilTest extends TestCase {
         }
         dir.delete();
     }
-    
+
     public void testBackupEncryptedFile() throws Exception {
         // backup an encrypted file
         File srcFile = createTempFile();
         Advapi32Util.encryptFile(srcFile);
-        File dest = new File(System.getProperty("java.io.tmpdir") + File.separator 
+        File dest = new File(System.getProperty("java.io.tmpdir") + File.separator
                 + "backup" + System.nanoTime());
         dest.mkdir();
 
         Advapi32Util.backupEncryptedFile(srcFile, dest);
 
         // simple check to see if a backup file exist
-        File backupFile = new File(dest.getAbsolutePath() + File.separator + 
+        File backupFile = new File(dest.getAbsolutePath() + File.separator +
                 srcFile.getName());
         assertTrue(backupFile.exists());
         assertEquals(srcFile.length(), backupFile.length());
 
         // backup an encrypted directory
-        File srcDir = new File(System.getProperty("java.io.tmpdir") + File.separator 
+        File srcDir = new File(System.getProperty("java.io.tmpdir") + File.separator
                 + System.nanoTime());
         srcDir.mkdir();
         Advapi32Util.encryptFile(srcDir);
-        
+
         Advapi32Util.backupEncryptedFile(srcDir, dest);
 
         // Check to see if a backup directory exist
@@ -576,7 +580,7 @@ public class Advapi32UtilTest extends TestCase {
     }
 
     private File createTempFile() throws Exception{
-        String filePath = System.getProperty("java.io.tmpdir") + System.nanoTime() 
+        String filePath = System.getProperty("java.io.tmpdir") + System.nanoTime()
                 + ".text";
         File file = new File(filePath);
         file.createNewFile();

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
@@ -291,7 +291,7 @@ public class Kernel32UtilTest extends TestCase {
             String name = Kernel32Util.QueryFullProcessImageName(h, 0);
             assertTrue("Failed to query process image name, empty path returned", name.length() > 0);
         } finally {
-            assertTrue("CloseHandle", Kernel32.INSTANCE.CloseHandle(h));
+            Kernel32Util.closeHandle(h);
         }
     }
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/PsapiTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/PsapiTest.java
@@ -1,14 +1,14 @@
 /* Copyright (c) 2015 Andreas "PAX" L\u00FCck, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna.platform.win32;
 
@@ -31,7 +31,7 @@ import com.sun.jna.ptr.IntByReference;
 
 /**
  * Applies API tests on {@link Psapi}.
- * 
+ *
  * @author Andreas "PAX" L&uuml;ck, onkelpax-git[at]yahoo.de
  */
 public class PsapiTest {
@@ -99,7 +99,7 @@ public class PsapiTest {
 			w.dispose();
 		}
 	}
-	
+
 	@Test
     public void testEnumProcessModules() {
         HANDLE me = null;
@@ -108,7 +108,7 @@ public class PsapiTest {
         try {
             me = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_ALL_ACCESS, false, Kernel32.INSTANCE.GetCurrentProcessId());
             assertTrue("Handle to my process should not be null", me != null);
-            
+
             List<HMODULE> list = new LinkedList<HMODULE>();
 
             HMODULE[] lphModule = new HMODULE[100 * 4];
@@ -125,23 +125,23 @@ public class PsapiTest {
             assertTrue("List should have at least 1 item in it.", list.size() > 0);
         } catch (Win32Exception e) {
             we = e;
+            throw we;   // re-throw to invoke finally block
         } finally {
-            if (me != null) {
-                if (!Kernel32.INSTANCE.CloseHandle(me)) {
-                    Win32Exception e = new Win32Exception(Native.getLastError());
-                    if (we != null) {
-                        e.addSuppressed(we);
-                    }
+            try {
+                Kernel32Util.closeHandle(me);
+            } catch(Win32Exception e) {
+                if (we == null) {
                     we = e;
+                } else {
+                    we.addSuppressed(e);
                 }
             }
+            if (we != null) {
+                throw we;
+            }
         }
-        if (we != null) {
-            throw we;
-        }
-
     }
-	
+
 	@Test
     public void testGetModuleInformation() {
         HANDLE me = null;
@@ -150,7 +150,7 @@ public class PsapiTest {
         try {
             me = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_ALL_ACCESS, false, Kernel32.INSTANCE.GetCurrentProcessId());
             assertTrue("Handle to my process should not be null", me != null);
-            
+
             List<HMODULE> list = new LinkedList<HMODULE>();
 
             HMODULE[] lphModule = new HMODULE[100 * 4];
@@ -165,34 +165,34 @@ public class PsapiTest {
             }
 
             assertTrue("List should have at least 1 item in it.", list.size() > 0);
-            
+
             MODULEINFO lpmodinfo = new MODULEINFO();
-            
+
             if (!Psapi.INSTANCE.GetModuleInformation(me, list.get(0), lpmodinfo, lpmodinfo.size())) {
                 throw new Win32Exception(Native.getLastError());
             }
-            
+
             assertTrue("MODULEINFO.EntryPoint should not be null.", lpmodinfo.EntryPoint != null);
-            
+
         } catch (Win32Exception e) {
             we = e;
+            throw we;   // re-throw to invoke finally block
         } finally {
-            if (me != null) {
-                if (!Kernel32.INSTANCE.CloseHandle(me)) {
-                    Win32Exception e = new Win32Exception(Native.getLastError());
-                    if (we != null) {
-                        e.addSuppressed(we);
-                    }
+            try {
+                Kernel32Util.closeHandle(me);
+            } catch(Win32Exception e) {
+                if (we == null) {
                     we = e;
+                } else {
+                    we.addSuppressed(e);
                 }
             }
+            if (we != null) {
+                throw we;
+            }
         }
-        if (we != null) {
-            throw we;
-        }
-
     }
-	
+
 	@Test
     public void testGetProcessImageFileName() {
         HANDLE me = null;
@@ -201,27 +201,27 @@ public class PsapiTest {
         try {
             me = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_ALL_ACCESS, false, Kernel32.INSTANCE.GetCurrentProcessId());
             assertTrue("Handle to my process should not be null", me != null);
-            
+
             char[] buffer = new char[256];
             Psapi.INSTANCE.GetProcessImageFileName(me, buffer, 256);
             String path = new String(buffer);
             assertTrue("Image path should contain 'java' and '.exe'", path.contains("java") && path.contains(".exe"));
         } catch (Win32Exception e) {
             we = e;
+            throw we;   // re-throw to invoke finally block
         } finally {
-            if (me != null) {
-                if (!Kernel32.INSTANCE.CloseHandle(me)) {
-                    Win32Exception e = new Win32Exception(Native.getLastError());
-                    if (we != null) {
-                        e.addSuppressed(we);
-                    }
+            try {
+                Kernel32Util.closeHandle(me);
+            } catch(Win32Exception e) {
+                if (we == null) {
                     we = e;
+                } else {
+                    we.addSuppressed(e);
                 }
             }
+            if (we != null) {
+                throw we;
+            }
         }
-        if (we != null) {
-            throw we;
-        }
-
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Secur32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Secur32Test.java
@@ -1,18 +1,16 @@
 /* Copyright (c) 2010 Daniel Doubrovkine, All Rights Reserved
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.  
+ * Lesser General Public License for more details.
  */
 package com.sun.jna.platform.win32;
-
-import junit.framework.TestCase;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Sspi.CredHandle;
@@ -24,6 +22,8 @@ import com.sun.jna.platform.win32.Sspi.TimeStamp;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.ptr.IntByReference;
 
+import junit.framework.TestCase;
+
 /**
  * @author dblock[at]dblock[dot]org
  */
@@ -32,7 +32,7 @@ public class Secur32Test extends TestCase {
     public static void main(String[] args) {
         junit.textui.TestRunner.run(Secur32Test.class);
     }
-    
+
     public void testGetUserNameEx() {
     	IntByReference len = new IntByReference();
     	Secur32.INSTANCE.GetUserNameEx(
@@ -44,59 +44,59 @@ public class Secur32Test extends TestCase {
     	String username = Native.toString(buffer);
     	assertTrue(username.length() > 0);
     }
-    
+
     public void testAcquireCredentialsHandle() {
     	CredHandle phCredential = new CredHandle();
     	TimeStamp ptsExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null,
     			null, phCredential, ptsExpiry));
     	assertTrue(phCredential.dwLower != null);
     	assertTrue(phCredential.dwUpper != null);
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.FreeCredentialsHandle(
-    			phCredential));    	
+    			phCredential));
     }
-    
+
     public void testAcquireCredentialsHandleInvalidPackage() {
     	CredHandle phCredential = new CredHandle();
     	TimeStamp ptsExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_SECPKG_NOT_FOUND, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "PackageDoesntExist", Sspi.SECPKG_CRED_OUTBOUND, null, null, null, 
+    			null, "PackageDoesntExist", Sspi.SECPKG_CRED_OUTBOUND, null, null, null,
     			null, phCredential, ptsExpiry));
     }
-    
+
     public void testInitializeSecurityContext() {
     	CredHandle phCredential = new CredHandle();
     	TimeStamp ptsExpiry = new TimeStamp();
     	// acquire a credentials handle
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null,
     			null, phCredential, ptsExpiry));
     	// initialize security context
     	CtxtHandle phNewContext = new CtxtHandle();
     	SecBufferDesc pbToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, Sspi.MAX_TOKEN_SIZE);
     	IntByReference pfContextAttr = new IntByReference();
-    	int rc = Secur32.INSTANCE.InitializeSecurityContext(phCredential, null, 
-    			Advapi32Util.getUserName(), Sspi.ISC_REQ_CONNECTION, 0, 
-    			Sspi.SECURITY_NATIVE_DREP, null, 0, phNewContext, pbToken, 
-    			pfContextAttr, null);    	
+    	int rc = Secur32.INSTANCE.InitializeSecurityContext(phCredential, null,
+    			Advapi32Util.getUserName(), Sspi.ISC_REQ_CONNECTION, 0,
+    			Sspi.SECURITY_NATIVE_DREP, null, 0, phNewContext, pbToken,
+    			pfContextAttr, null);
     	assertTrue(rc == W32Errors.SEC_I_CONTINUE_NEEDED || rc == W32Errors.SEC_E_OK);
     	assertTrue(phNewContext.dwLower != null);
     	assertTrue(phNewContext.dwUpper != null);
     	assertTrue(pbToken.pBuffers[0].getBytes().length > 0);
-    	// release 
+    	// release
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.DeleteSecurityContext(
     			phNewContext));
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.FreeCredentialsHandle(
     			phCredential));
     }
-    
+
     public void testAcceptSecurityContext() {
     	// client ----------- acquire outbound credential handle
     	CredHandle phClientCredential = new CredHandle();
     	TimeStamp ptsClientExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null,
     			null, phClientCredential, ptsClientExpiry));
     	// client ----------- security context
     	CtxtHandle phClientContext = new CtxtHandle();
@@ -105,7 +105,7 @@ public class Secur32Test extends TestCase {
     	CredHandle phServerCredential = new CredHandle();
     	TimeStamp ptsServerExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_INBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_INBOUND, null, null, null,
     			null, phServerCredential, ptsServerExpiry));
     	// server ----------- security context
 		CtxtHandle phServerContext = new CtxtHandle();
@@ -119,37 +119,37 @@ public class Secur32Test extends TestCase {
         	SecBufferDesc pbClientToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, Sspi.MAX_TOKEN_SIZE);
         	if (clientRc == W32Errors.SEC_I_CONTINUE_NEEDED) {
 	        	// server token is empty the first time
-	        	SecBufferDesc pbServerTokenCopy = pbServerToken == null 
+	        	SecBufferDesc pbServerTokenCopy = pbServerToken == null
 	        		? null : new SecBufferDesc(Sspi.SECBUFFER_TOKEN, pbServerToken.getBytes());
 	        	clientRc = Secur32.INSTANCE.InitializeSecurityContext(
-	    				phClientCredential, 
-	    				phClientContext.isNull() ? null : phClientContext, 
-	        			Advapi32Util.getUserName(), 
-	        			Sspi.ISC_REQ_CONNECTION, 
-	        			0, 
-	        			Sspi.SECURITY_NATIVE_DREP, 
-	        			pbServerTokenCopy, 
-	        			0, 
-	        			phClientContext, 
-	        			pbClientToken, 
-	        			pfClientContextAttr, 
-	        			null);    		
+	    				phClientCredential,
+	    				phClientContext.isNull() ? null : phClientContext,
+	        			Advapi32Util.getUserName(),
+	        			Sspi.ISC_REQ_CONNECTION,
+	        			0,
+	        			Sspi.SECURITY_NATIVE_DREP,
+	        			pbServerTokenCopy,
+	        			0,
+	        			phClientContext,
+	        			pbClientToken,
+	        			pfClientContextAttr,
+	        			null);
 	    		assertTrue(clientRc == W32Errors.SEC_I_CONTINUE_NEEDED || clientRc == W32Errors.SEC_E_OK);
         	}
         	// server ----------- accept security context, produce a server token
     		if (serverRc == W32Errors.SEC_I_CONTINUE_NEEDED) {
 	    		pbServerToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, Sspi.MAX_TOKEN_SIZE);
 	    		SecBufferDesc pbClientTokenByValue = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, pbClientToken.getBytes());
-	    		serverRc = Secur32.INSTANCE.AcceptSecurityContext(phServerCredential, 
-	    				phServerContext.isNull() ? null : phServerContext, 
+	    		serverRc = Secur32.INSTANCE.AcceptSecurityContext(phServerCredential,
+	    				phServerContext.isNull() ? null : phServerContext,
 	    				pbClientTokenByValue,
-	    				Sspi.ISC_REQ_CONNECTION, 
-	    				Sspi.SECURITY_NATIVE_DREP, 
+	    				Sspi.ISC_REQ_CONNECTION,
+	    				Sspi.SECURITY_NATIVE_DREP,
 	    				phServerContext,
-	    				pbServerToken, 
-	    				pfServerContextAttr, 
-	    				ptsServerExpiry);    		
-	    		assertTrue(serverRc == W32Errors.SEC_I_CONTINUE_NEEDED || serverRc == W32Errors.SEC_E_OK);    		
+	    				pbServerToken,
+	    				pfServerContextAttr,
+	    				ptsServerExpiry);
+	    		assertTrue(serverRc == W32Errors.SEC_I_CONTINUE_NEEDED || serverRc == W32Errors.SEC_E_OK);
     		}
     	} while(serverRc != W32Errors.SEC_E_OK || clientRc != W32Errors.SEC_E_OK);
     	// release server context
@@ -163,13 +163,13 @@ public class Secur32Test extends TestCase {
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.FreeCredentialsHandle(
     			phClientCredential));
     }
-    
+
     public void testImpersonateRevertSecurityContext() {
     	// client ----------- acquire outbound credential handle
     	CredHandle phClientCredential = new CredHandle();
     	TimeStamp ptsClientExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null,
     			null, phClientCredential, ptsClientExpiry));
     	// client ----------- security context
     	CtxtHandle phClientContext = new CtxtHandle();
@@ -178,7 +178,7 @@ public class Secur32Test extends TestCase {
     	CredHandle phServerCredential = new CredHandle();
     	TimeStamp ptsServerExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_INBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_INBOUND, null, null, null,
     			null, phServerCredential, ptsServerExpiry));
     	// server ----------- security context
 		CtxtHandle phServerContext = new CtxtHandle();
@@ -192,37 +192,37 @@ public class Secur32Test extends TestCase {
         	SecBufferDesc pbClientToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, Sspi.MAX_TOKEN_SIZE);
         	if (clientRc == W32Errors.SEC_I_CONTINUE_NEEDED) {
 	        	// server token is empty the first time
-	        	SecBufferDesc pbServerTokenCopy = pbServerToken == null 
+	        	SecBufferDesc pbServerTokenCopy = pbServerToken == null
 	        		? null : new SecBufferDesc(Sspi.SECBUFFER_TOKEN, pbServerToken.getBytes());
 	        	clientRc = Secur32.INSTANCE.InitializeSecurityContext(
-	    				phClientCredential, 
-	    				phClientContext.isNull() ? null : phClientContext, 
-	        			Advapi32Util.getUserName(), 
-	        			Sspi.ISC_REQ_CONNECTION, 
-	        			0, 
-	        			Sspi.SECURITY_NATIVE_DREP, 
-	        			pbServerTokenCopy, 
-	        			0, 
-	        			phClientContext, 
-	        			pbClientToken, 
-	        			pfClientContextAttr, 
-	        			null);    		
+	    				phClientCredential,
+	    				phClientContext.isNull() ? null : phClientContext,
+	        			Advapi32Util.getUserName(),
+	        			Sspi.ISC_REQ_CONNECTION,
+	        			0,
+	        			Sspi.SECURITY_NATIVE_DREP,
+	        			pbServerTokenCopy,
+	        			0,
+	        			phClientContext,
+	        			pbClientToken,
+	        			pfClientContextAttr,
+	        			null);
 	    		assertTrue(clientRc == W32Errors.SEC_I_CONTINUE_NEEDED || clientRc == W32Errors.SEC_E_OK);
         	}
         	// server ----------- accept security context, produce a server token
     		if (serverRc == W32Errors.SEC_I_CONTINUE_NEEDED) {
 	    		pbServerToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, Sspi.MAX_TOKEN_SIZE);
 	    		SecBufferDesc pbClientTokenByValue = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, pbClientToken.getBytes());
-	    		serverRc = Secur32.INSTANCE.AcceptSecurityContext(phServerCredential, 
-	    				phServerContext.isNull() ? null : phServerContext, 
+	    		serverRc = Secur32.INSTANCE.AcceptSecurityContext(phServerCredential,
+	    				phServerContext.isNull() ? null : phServerContext,
 	    				pbClientTokenByValue,
-	    				Sspi.ISC_REQ_CONNECTION, 
-	    				Sspi.SECURITY_NATIVE_DREP, 
+	    				Sspi.ISC_REQ_CONNECTION,
+	    				Sspi.SECURITY_NATIVE_DREP,
 	    				phServerContext,
-	    				pbServerToken, 
-	    				pfServerContextAttr, 
-	    				ptsServerExpiry);    		
-	    		assertTrue(serverRc == W32Errors.SEC_I_CONTINUE_NEEDED || serverRc == W32Errors.SEC_E_OK);    		
+	    				pbServerToken,
+	    				pfServerContextAttr,
+	    				ptsServerExpiry);
+	    		assertTrue(serverRc == W32Errors.SEC_I_CONTINUE_NEEDED || serverRc == W32Errors.SEC_E_OK);
     		}
     	} while(serverRc != W32Errors.SEC_E_OK || clientRc != W32Errors.SEC_E_OK);
     	// impersonate
@@ -241,14 +241,14 @@ public class Secur32Test extends TestCase {
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.FreeCredentialsHandle(
     			phClientCredential));
     }
-    
+
     public void testEnumerateSecurityPackages() {
     	IntByReference pcPackages = new IntByReference();
     	PSecPkgInfo.ByReference pPackageInfo = new PSecPkgInfo.ByReference();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.EnumerateSecurityPackages(
     			pcPackages, pPackageInfo));
     	SecPkgInfo.ByReference[] packagesInfo = pPackageInfo.toArray(
-    			pcPackages.getValue());    	
+    			pcPackages.getValue());
     	for(SecPkgInfo.ByReference packageInfo : packagesInfo) {
     		assertTrue(packageInfo.Name.length() > 0);
     		assertTrue(packageInfo.Comment.length() >= 0);
@@ -256,13 +256,13 @@ public class Secur32Test extends TestCase {
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.FreeContextBuffer(
     			pPackageInfo.getPointer()));
     }
-    
+
     public void testQuerySecurityContextToken() {
     	// client ----------- acquire outbound credential handle
     	CredHandle phClientCredential = new CredHandle();
     	TimeStamp ptsClientExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND, null, null, null,
     			null, phClientCredential, ptsClientExpiry));
     	// client ----------- security context
     	CtxtHandle phClientContext = new CtxtHandle();
@@ -271,7 +271,7 @@ public class Secur32Test extends TestCase {
     	CredHandle phServerCredential = new CredHandle();
     	TimeStamp ptsServerExpiry = new TimeStamp();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.AcquireCredentialsHandle(
-    			null, "Negotiate", Sspi.SECPKG_CRED_INBOUND, null, null, null, 
+    			null, "Negotiate", Sspi.SECPKG_CRED_INBOUND, null, null, null,
     			null, phServerCredential, ptsServerExpiry));
     	// server ----------- security context
 		CtxtHandle phServerContext = new CtxtHandle();
@@ -286,40 +286,40 @@ public class Secur32Test extends TestCase {
     		if (clientRc == W32Errors.SEC_I_CONTINUE_NEEDED) {
 	        	// server token is empty the first time
 	    		clientRc = Secur32.INSTANCE.InitializeSecurityContext(
-	    				phClientCredential, 
-	    				phClientContext.isNull() ? null : phClientContext, 
-	        			Advapi32Util.getUserName(), 
-	        			Sspi.ISC_REQ_CONNECTION, 
-	        			0, 
-	        			Sspi.SECURITY_NATIVE_DREP, 
-	        			pbServerToken, 
-	        			0, 
-	        			phClientContext, 
-	        			pbClientToken, 
-	        			pfClientContextAttr, 
-	        			null);    		
-	    		assertTrue(clientRc == W32Errors.SEC_I_CONTINUE_NEEDED || clientRc == W32Errors.SEC_E_OK);    		
-    		}    		
+	    				phClientCredential,
+	    				phClientContext.isNull() ? null : phClientContext,
+	        			Advapi32Util.getUserName(),
+	        			Sspi.ISC_REQ_CONNECTION,
+	        			0,
+	        			Sspi.SECURITY_NATIVE_DREP,
+	        			pbServerToken,
+	        			0,
+	        			phClientContext,
+	        			pbClientToken,
+	        			pfClientContextAttr,
+	        			null);
+	    		assertTrue(clientRc == W32Errors.SEC_I_CONTINUE_NEEDED || clientRc == W32Errors.SEC_E_OK);
+    		}
         	// server ----------- accept security context, produce a server token
     		if (serverRc == W32Errors.SEC_I_CONTINUE_NEEDED) {
-	    		serverRc = Secur32.INSTANCE.AcceptSecurityContext(phServerCredential, 
-	    				phServerContext.isNull() ? null : phServerContext, 
-	    				pbClientToken, 
-	    				Sspi.ISC_REQ_CONNECTION, 
-	    				Sspi.SECURITY_NATIVE_DREP, 
+	    		serverRc = Secur32.INSTANCE.AcceptSecurityContext(phServerCredential,
+	    				phServerContext.isNull() ? null : phServerContext,
+	    				pbClientToken,
+	    				Sspi.ISC_REQ_CONNECTION,
+	    				Sspi.SECURITY_NATIVE_DREP,
 	    				phServerContext,
-	    				pbServerToken, 
-	    				pfServerContextAttr, 
+	    				pbServerToken,
+	    				pfServerContextAttr,
 	    				ptsServerExpiry);
 	    		assertTrue(serverRc == W32Errors.SEC_I_CONTINUE_NEEDED || serverRc == W32Errors.SEC_E_OK);
-    		}    		
-    	} while(serverRc != W32Errors.SEC_E_OK || clientRc != W32Errors.SEC_E_OK);    	
+    		}
+    	} while(serverRc != W32Errors.SEC_E_OK || clientRc != W32Errors.SEC_E_OK);
     	// query security context token
     	HANDLEByReference phContextToken = new HANDLEByReference();
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.QuerySecurityContextToken(
     			phServerContext, phContextToken));
     	// release security context token
-    	assertTrue(Kernel32.INSTANCE.CloseHandle(phContextToken.getValue()));
+    	Kernel32Util.closeHandleRef(phContextToken);
     	// release server context
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.DeleteSecurityContext(
     			phServerContext));
@@ -329,9 +329,9 @@ public class Secur32Test extends TestCase {
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.DeleteSecurityContext(
     			phClientContext));
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.FreeCredentialsHandle(
-    			phClientCredential));    	
+    			phClientCredential));
     }
-    
+
     public void testCreateEmptyToken() {
         SecBufferDesc token = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, Sspi.MAX_TOKEN_SIZE);
         assertEquals(1, token.pBuffers.length);


### PR DESCRIPTION
Provide bolierplate template for code that is supposed to close a handle and check the returned error code if failed to do so