### PR TITLE
Allow access to base interfaces via ProxyObject and improve binding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@ Features
 * [#608](https://github.com/java-native-access/jna/pull/608): Mavenize the build process - change parent and native pom artifactId/name to differentiate in IDE and build tools. [@bhamail](https://github.com/bhamail)
 * [#613](https://github.com/java-native-access/jna/pull/613): Make Win32Exception extend LastErrorException [@lgoldstein](https://github.com/lgoldstein).
 * [#613](https://github.com/java-native-access/jna/pull/614): Added standard 'Kernel32Util#closeHandle' method that throws a Win32Exception if failed to close the handle [@lgoldstein](https://github.com/lgoldstein).
+* [#616](https://github.com/java-native-access/jna/pull/616): Allow access to base interfaces (most important IDispatch) via ProxyObject and improve binding by allowing to use dispId for the call - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------
@@ -55,7 +56,7 @@ Bug Fixes
 * [#593](https://github.com/java-native-access/jna/pull/593): Improve binding of TypeLib bindings - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#578](https://github.com/java-native-access/jna/pull/578): Fix COM CallbackHandlers, allow usage of VARIANTs directly in c.s.j.p.w.COM.util.ProxyObject and fix native memory leak in c.s.j.p.w.COM.util.ProxyObject - [@matthiasblaesing](https://github.com/matthiasblaesing)
 * [#601](https://github.com/java-native-access/jna/pull/601): Remove COMThread and COM initialization from objects and require callers to initialize COM themselves. Asserts are added to guard correct usage. - [@matthiasblaesing](https://github.com/matthiasblaesing).
-* [#602] https://github.com/java-native-access/jna/pull/602): Make sure SID related memory is properly released once no longer required [@lgoldstein](https://github.com/lgoldstein).
+* [#602](https://github.com/java-native-access/jna/pull/602): Make sure SID related memory is properly released once no longer required [@lgoldstein](https://github.com/lgoldstein).
 * [#610](https://github.com/java-native-access/jna/pull/610): Fixed issue #604: Kernel32#GetLastError() always returns ERROR_SUCCESS [@lgoldstein](https://github.com/lgoldstein).
 
 Release 4.2.1

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
@@ -142,9 +142,7 @@ public class CallbackProxy implements IDispatchCallback {
                         PointerByReference ppvObject = new PointerByReference();
                         IID iid = com.sun.jna.platform.win32.COM.IUnknown.IID_IUNKNOWN;
                         dispatch.QueryInterface(new REFIID(iid), ppvObject);
-                        Unknown rawUnk = new Unknown(ppvObject.getValue());
-					long unknownId = Pointer.nativeValue( rawUnk.getPointer() );
-                        IUnknown unk = CallbackProxy.this.factory.createProxy(IUnknown.class, unknownId, dispatch);
+                        IUnknown unk = CallbackProxy.this.factory.createProxy(IUnknown.class, dispatch);
                         if(targetClass.getAnnotation(ComInterface.class) != null) {
                             rjargs.add(unk.queryInterface(targetClass));
                         } else {

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Factory.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Factory.java
@@ -38,11 +38,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class Factory {
-
 	/**
-	 * Creates a utility COM Factory and a ComThread on which all COM calls are executed.
-	 * NOTE: Remember to call factory.getComThread().terminate() at some appropriate point.
-	 * 
+	 * Factory keeps track of COM objects - all objects created with this
+         * factory can be disposed by calling {@link Factory#disposeAll() }.
 	 */
 	public Factory() {
             assert COMUtils.comIsInitialized() : "COM not initialized";
@@ -86,22 +84,6 @@ public class Factory {
                 assert COMUtils.comIsInitialized() : "COM not initialized";
             
 		ProxyObject jop = new ProxyObject(comInterface, dispatch, this);
-		Object proxy = Proxy.newProxyInstance(comInterface.getClassLoader(), new Class<?>[] { comInterface }, jop);
-		T result = comInterface.cast(proxy);
-		return result;
-	}
-
-	/** only for use when creating ProxyObjects from Callbacks
-	 * 
-	 * @param comInterface
-	 * @param unknownId
-	 * @param dispatch
-	 * @return proxy object
-	 */
-	<T> T createProxy(Class<T> comInterface, long unknownId, IDispatch dispatch) {
-                assert COMUtils.comIsInitialized() : "COM not initialized";
-            
-		ProxyObject jop = new ProxyObject(comInterface, unknownId, dispatch, this);
 		Object proxy = Proxy.newProxyInstance(comInterface.getClassLoader(), new Class<?>[] { comInterface }, jop);
 		T result = comInterface.cast(proxy);
 		return result;

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/IDispatch.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/IDispatch.java
@@ -12,13 +12,17 @@
  */
 package com.sun.jna.platform.win32.COM.util;
 
+import com.sun.jna.platform.win32.OaIdl.DISPID;
+
 /**
  * Java friendly version of {@link com.sun.jna.platform.win32.COM.IDispatch}.
  *
  */
 public interface IDispatch extends IUnknown {
-
 	<T> void setProperty(String name, T value);
 	<T> T getProperty(Class<T> returnType, String name, Object... args);
 	<T> T invokeMethod(Class<T> returnType, String name, Object... args);
+	<T> void setProperty(DISPID dispid, T value);
+	<T> T getProperty(Class<T> returnType, DISPID dispid, Object... args);
+	<T> T invokeMethod(Class<T> returnType, DISPID dispid, Object... args);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/annotation/ComProperty.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/annotation/ComProperty.java
@@ -23,4 +23,5 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface ComProperty {
 	String name() default "";
+        int dispId() default -1; //default to dispid unknown
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/IDispatchTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/IDispatchTest.java
@@ -1,0 +1,62 @@
+package com.sun.jna.platform.win32.COM.util;
+
+import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
+import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IDispatchTest {
+
+    Factory factory;
+
+    @Before
+    public void before() {
+        this.factory = new Factory();
+    }
+
+    @After
+    public void after() {
+        this.factory.disposeAll();
+        this.factory.getComThread().terminate(1000);
+    }
+
+    @Test
+    public void testIDispatch() throws InterruptedException {
+        ComInternetExplorer ieApp = factory.createObject(ComInternetExplorer.class);
+        IDispatch appDispatch = ieApp;
+
+        // Test getting property
+        TestCase.assertFalse(appDispatch.getProperty(Boolean.class, "Visible"));
+
+        // Test setting property
+        appDispatch.setProperty("Visible", Boolean.TRUE);
+        TestCase.assertTrue(appDispatch.getProperty(Boolean.class, "Visible"));
+
+        // Check navigate function and with that the method invocation
+        assert appDispatch.getProperty(String.class, "LocationURL").isEmpty();
+
+        appDispatch.invokeMethod(Void.class, "Navigate2", "http://www.heise.de");
+
+        // Check max. 2s if Navigation happend
+        boolean navigationHappend = false;
+        for (int i = 0; i < 10; i++) {
+            String url = appDispatch.getProperty(String.class, "LocationURL");
+            if (!url.isEmpty()) {
+                navigationHappend = true;
+                break;
+            } else {
+                Thread.sleep(200);
+            }
+        }
+
+        TestCase.assertTrue(navigationHappend);
+     
+        appDispatch.invokeMethod(Void.class, "Quit");
+    }
+
+    @ComObject(progId = "Internet.Explorer.1", clsId = "{0002DF01-0000-0000-C000-000000000046}")
+    interface ComInternetExplorer extends IUnknown, IDispatch {
+    }
+
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/IDispatchTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/IDispatchTest.java
@@ -1,7 +1,13 @@
 package com.sun.jna.platform.win32.COM.util;
 
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.COM.util.annotation.ComMethod;
 import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
+import com.sun.jna.platform.win32.OaIdl.DISPID;
+import com.sun.jna.platform.win32.Ole32;
 import junit.framework.TestCase;
+import static junit.framework.TestCase.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,36 +18,36 @@ public class IDispatchTest {
 
     @Before
     public void before() {
+        Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
         this.factory = new Factory();
     }
 
     @After
     public void after() {
         this.factory.disposeAll();
-        this.factory.getComThread().terminate(1000);
+        Ole32.INSTANCE.CoUninitialize();
     }
-
+    
     @Test
-    public void testIDispatch() throws InterruptedException {
-        ComInternetExplorer ieApp = factory.createObject(ComInternetExplorer.class);
-        IDispatch appDispatch = ieApp;
+    public void testDispatchBaseOnMethodName() throws InterruptedException {
+        ComInternetExplorerMethodname ieApp = factory.createObject(ComInternetExplorerMethodname.class);
 
         // Test getting property
-        TestCase.assertFalse(appDispatch.getProperty(Boolean.class, "Visible"));
+        TestCase.assertFalse(ieApp.getVisible());
 
         // Test setting property
-        appDispatch.setProperty("Visible", Boolean.TRUE);
-        TestCase.assertTrue(appDispatch.getProperty(Boolean.class, "Visible"));
+        ieApp.setVisible(Boolean.TRUE);
+        TestCase.assertTrue(ieApp.getVisible());
 
         // Check navigate function and with that the method invocation
-        assert appDispatch.getProperty(String.class, "LocationURL").isEmpty();
-
-        appDispatch.invokeMethod(Void.class, "Navigate2", "http://www.heise.de");
+        assertTrue(ieApp.getLocationURL().isEmpty());
+        
+        ieApp.Navigate2("https://github.com/java-native-access/");
 
         // Check max. 2s if Navigation happend
         boolean navigationHappend = false;
         for (int i = 0; i < 10; i++) {
-            String url = appDispatch.getProperty(String.class, "LocationURL");
+            String url = ieApp.getLocationURL();
             if (!url.isEmpty()) {
                 navigationHappend = true;
                 break;
@@ -51,12 +57,202 @@ public class IDispatchTest {
         }
 
         TestCase.assertTrue(navigationHappend);
-     
-        appDispatch.invokeMethod(Void.class, "Quit");
+        
+        ieApp.Quit();
     }
-
+    
     @ComObject(progId = "Internet.Explorer.1", clsId = "{0002DF01-0000-0000-C000-000000000046}")
-    interface ComInternetExplorer extends IUnknown, IDispatch {
+    interface ComInternetExplorerMethodname {
+        @ComProperty
+        String getLocationURL();
+        
+        @ComMethod
+        void Navigate2(String url);
+        
+        @ComProperty
+        Boolean getVisible();
+        
+        @ComProperty
+        void setVisible(Boolean visible);
+        
+        @ComMethod
+        void Quit();
     }
 
+    @Test
+    public void testDispatchBaseOnNamed() throws InterruptedException {
+        ComInternetExplorerNamed ieApp = factory.createObject(ComInternetExplorerNamed.class);
+
+        // Test getting property
+        TestCase.assertFalse(ieApp.getVisible_MOD());
+
+        // Test setting property
+        ieApp.setVisible_MOD(Boolean.TRUE);
+        TestCase.assertTrue(ieApp.getVisible_MOD());
+
+        // Check navigate function and with that the method invocation
+        assertTrue(ieApp.getLocationURL_MOD().isEmpty());
+        
+        ieApp.Navigate2_MOD("https://github.com/java-native-access/");
+
+        // Check max. 2s if Navigation happend
+        boolean navigationHappend = false;
+        for (int i = 0; i < 10; i++) {
+            String url = ieApp.getLocationURL_MOD();
+            if (!url.isEmpty()) {
+                navigationHappend = true;
+                break;
+            } else {
+                Thread.sleep(200);
+            }
+        }
+
+        TestCase.assertTrue(navigationHappend);
+        
+        ieApp.Quit_MOD();
+    }
+    
+    @ComObject(progId = "Internet.Explorer.1", clsId = "{0002DF01-0000-0000-C000-000000000046}")
+    interface ComInternetExplorerNamed {
+        @ComProperty(name="LocationURL")
+        String getLocationURL_MOD();
+        
+        @ComMethod(name="Navigate2")
+        void Navigate2_MOD(String url);
+        
+        @ComProperty(name="Visible")
+        Boolean getVisible_MOD();
+        
+        @ComProperty(name="Visible")
+        void setVisible_MOD(Boolean visible);
+        
+        @ComMethod(name="Quit")
+        void Quit_MOD();
+    }
+    
+    @Test
+    public void testDispatchBaseOnDISPID() throws InterruptedException {
+        ComInternetExplorerDISPID ieApp = factory.createObject(ComInternetExplorerDISPID.class);
+
+        // Test getting property
+        TestCase.assertFalse(ieApp.getVisible_MOD());
+
+        // Test setting property
+        ieApp.setVisible_MOD(Boolean.TRUE);
+        TestCase.assertTrue(ieApp.getVisible_MOD());
+
+        // Check navigate function and with that the method invocation
+        assertTrue(ieApp.getLocationURL_MOD().isEmpty());
+        
+        ieApp.Navigate2_MOD("https://github.com/java-native-access/");
+
+        // Check max. 2s if Navigation happend
+        boolean navigationHappend = false;
+        for (int i = 0; i < 10; i++) {
+            String url = ieApp.getLocationURL_MOD();
+            if (!url.isEmpty()) {
+                navigationHappend = true;
+                break;
+            } else {
+                Thread.sleep(200);
+            }
+        }
+
+        TestCase.assertTrue(navigationHappend);
+        
+        ieApp.Quit_MOD();
+    }
+    
+    @ComObject(progId = "Internet.Explorer.1", clsId = "{0002DF01-0000-0000-C000-000000000046}")
+    interface ComInternetExplorerDISPID {
+        @ComProperty(dispId = 0x000000d3)
+        String getLocationURL_MOD();
+        
+        @ComMethod(dispId = 0x000001f4)
+        void Navigate2_MOD(String url);
+        
+        @ComProperty(dispId = 0x00000192)
+        Boolean getVisible_MOD();
+        
+        @ComProperty(dispId = 0x00000192)
+        void setVisible_MOD(Boolean visible);
+        
+        @ComMethod(dispId = 0x0000012c)
+        void Quit_MOD();
+    }
+    
+    @Test
+    public void testIDispatchName() throws InterruptedException {
+        ComInternetExplorerIDispatch ieApp = factory.createObject(ComInternetExplorerIDispatch.class);
+
+        // Test getting property
+        TestCase.assertFalse(ieApp.getProperty(Boolean.class, "Visible"));
+
+        // Test setting property
+        ieApp.setProperty("Visible", Boolean.TRUE);
+        TestCase.assertTrue(ieApp.getProperty(Boolean.class, "Visible"));
+
+        // Check navigate function and with that the method invocation
+        assertTrue(ieApp.getProperty(String.class, "LocationURL").isEmpty());
+
+        ieApp.invokeMethod(Void.class, "Navigate2", "https://github.com/java-native-access/");
+
+        // Check max. 2s if Navigation happend
+        boolean navigationHappend = false;
+        for (int i = 0; i < 10; i++) {
+            String url = ieApp.getProperty(String.class, "LocationURL");
+            if (!url.isEmpty()) {
+                navigationHappend = true;
+                break;
+            } else {
+                Thread.sleep(200);
+            }
+        }
+
+        TestCase.assertTrue(navigationHappend);
+        
+        ieApp.invokeMethod(Void.class, "Quit");
+    }
+    
+    @Test
+    public void testIDispatchDISPID() throws InterruptedException {
+        DISPID locationURL = new DISPID(0x000000d3);
+        DISPID visible = new DISPID(0x00000192);
+        DISPID quit = new DISPID(0x0000012c);
+        DISPID navigate2 = new DISPID(0x000001f4);
+        
+        ComInternetExplorerIDispatch ieApp = factory.createObject(ComInternetExplorerIDispatch.class);
+
+        // Test getting property
+        TestCase.assertFalse(ieApp.getProperty(Boolean.class, visible));
+
+        // Test setting property
+        ieApp.setProperty(visible, Boolean.TRUE);
+        TestCase.assertTrue(ieApp.getProperty(Boolean.class, visible));
+
+        // Check navigate function and with that the method invocation
+        assertTrue(ieApp.getProperty(String.class, locationURL).isEmpty());
+
+        ieApp.invokeMethod(Void.class, navigate2, "https://github.com/java-native-access/");
+
+        // Check max. 2s if Navigation happend
+        boolean navigationHappend = false;
+        for (int i = 0; i < 10; i++) {
+            String url = ieApp.getProperty(String.class, locationURL);
+            if (!url.isEmpty()) {
+                navigationHappend = true;
+                break;
+            } else {
+                Thread.sleep(200);
+            }
+        }
+
+        TestCase.assertTrue(navigationHappend);
+        
+        ieApp.invokeMethod(Void.class, quit);
+    }
+    
+    @ComObject(progId = "Internet.Explorer.1", clsId = "{0002DF01-0000-0000-C000-000000000046}")
+    interface ComInternetExplorerIDispatch extends IDispatch {
+    }
 }


### PR DESCRIPTION
The ProxyObject implements several base interfaces directly, but the methods were not correctly handled. This pull modifies the InvocationHandler part to select methods based on declaration interface with direct method invocation, instead of manually redirecting each method.

The second part adds more robustness (and speed as sideeffect) to ProxyObject by using dispIDs if they are available, making reflection via GetIDsByName unnessary.