### PR TITLE
Fix NullPointer Exception in TlbCodegenerator

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/tlb/imp/TlbCoClass.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/tlb/imp/TlbCoClass.java
@@ -97,21 +97,18 @@ public class TlbCoClass extends TlbBase {
             FUNCDESC funcDesc = typeInfoUtil.getFuncDesc(i);
             
             TlbAbstractMethod method = null;
-            if (funcDesc.invkind.equals(INVOKEKIND.INVOKE_FUNC)) {
-                if(this.isVTableMode())
+            if (funcDesc.invkind.value == INVOKEKIND.INVOKE_FUNC.value) {
+                if(this.isVTableMode()) {
                     method = new TlbFunctionVTable(i, index, typeLibUtil, funcDesc, typeInfoUtil);
-                else
+                } else {
                     method = new TlbFunctionDispId(i, index, typeLibUtil, funcDesc, typeInfoUtil);
-            } else if (funcDesc.invkind.equals(INVOKEKIND.INVOKE_PROPERTYGET)) {
-                method = new TlbPropertyGet(i, index, typeLibUtil, funcDesc,
-                        typeInfoUtil);
-            } else if (funcDesc.invkind.equals(INVOKEKIND.INVOKE_PROPERTYPUT)) {
-                method = new TlbPropertyPut(i, index, typeLibUtil, funcDesc,
-                        typeInfoUtil);
-            } else if (funcDesc.invkind
-                    .equals(INVOKEKIND.INVOKE_PROPERTYPUTREF)) {
-                method = new TlbPropertyPut(i, index, typeLibUtil, funcDesc,
-                        typeInfoUtil);
+            }
+            } else if (funcDesc.invkind.value == INVOKEKIND.INVOKE_PROPERTYGET.value) {
+                method = new TlbPropertyGet(i, index, typeLibUtil, funcDesc, typeInfoUtil);
+            } else if (funcDesc.invkind.value == INVOKEKIND.INVOKE_PROPERTYPUT.value) {
+                method = new TlbPropertyPut(i, index, typeLibUtil, funcDesc, typeInfoUtil);
+            } else if (funcDesc.invkind.value == INVOKEKIND.INVOKE_PROPERTYPUTREF.value) {
+                method = new TlbPropertyPut(i, index, typeLibUtil, funcDesc, typeInfoUtil);
             }
                 
             if(!isReservedMethod(method.getMethodName()))

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/tlb/imp/TlbDispInterface.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/tlb/imp/TlbDispInterface.java
@@ -73,27 +73,21 @@ public class TlbDispInterface extends TlbBase {
             TlbAbstractMethod method = null;
 
             if (!isReservedMethod(methodName)) {
-                if (funcDesc.invkind.equals(INVOKEKIND.INVOKE_FUNC)) {
-                    method = new TlbFunctionStub(index, typeLibUtil, funcDesc,
-                            typeInfoUtil);
-                } else if (funcDesc.invkind
-                        .equals(INVOKEKIND.INVOKE_PROPERTYGET)) {
-                    method = new TlbPropertyGetStub(index, typeLibUtil,
-                            funcDesc, typeInfoUtil);
-                } else if (funcDesc.invkind
-                        .equals(INVOKEKIND.INVOKE_PROPERTYPUT)) {
-                    method = new TlbPropertyPutStub(index, typeLibUtil,
-                            funcDesc, typeInfoUtil);
-                } else if (funcDesc.invkind
-                        .equals(INVOKEKIND.INVOKE_PROPERTYPUTREF)) {
-                    method = new TlbPropertyPutStub(index, typeLibUtil,
-                            funcDesc, typeInfoUtil);
+                if (funcDesc.invkind.value == INVOKEKIND.INVOKE_FUNC.value) {
+                    method = new TlbFunctionStub(index, typeLibUtil, funcDesc, typeInfoUtil);
+                } else if (funcDesc.invkind.value == INVOKEKIND.INVOKE_PROPERTYGET.value) {
+                    method = new TlbPropertyGetStub(index, typeLibUtil, funcDesc, typeInfoUtil);
+                } else if (funcDesc.invkind.value == INVOKEKIND.INVOKE_PROPERTYPUT.value) {
+                    method = new TlbPropertyPutStub(index, typeLibUtil, funcDesc, typeInfoUtil);
+                } else if (funcDesc.invkind.value == INVOKEKIND.INVOKE_PROPERTYPUTREF.value) {
+                    method = new TlbPropertyPutStub(index, typeLibUtil, funcDesc, typeInfoUtil);
                 }
 
                 this.content += method.getClassBuffer();
 
-                if (i < cFuncs - 1)
+                if (i < cFuncs - 1) {
                     this.content += CR;
+                }
             }
 
             // Release our function description stuff


### PR DESCRIPTION
This is only manually tested and the resulting code was only superficially checked. I noticed the problem in the past when I first looked at JNA as a potential way to call COM code.

The commit changes the TlbImp to change from failing with a NullPointerException to producing code.

Checked with the OLE 2.0 and Word 15 typelib.

I don't consider this important enough for a CHANGES.md entry.