### PR TITLE
Followup fixes for some regressions

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMUtils.java
@@ -12,6 +12,7 @@
  */
 package com.sun.jna.platform.win32.COM;
 
+import com.sun.jna.LastErrorException;
 import java.util.ArrayList;
 
 import com.sun.jna.Native;
@@ -109,8 +110,14 @@ public abstract class COMUtils {
     public static void checkRC(HRESULT hr, EXCEPINFO pExcepInfo,
             IntByReference puArgErr) {
         if (FAILED(hr)) {
-            String formatMessageFromHR = Kernel32Util.formatMessage(hr);
-            throw new COMException(formatMessageFromHR, pExcepInfo, puArgErr);
+            String formatMessage;
+            try {
+                formatMessage = Kernel32Util.formatMessage(hr) + "(HRESULT: " + Integer.toHexString(hr.intValue()) + ")";
+            } catch (LastErrorException ex) {
+                // throws if HRESULT can't be resolved
+                formatMessage = "(HRESULT: " + Integer.toHexString(hr.intValue()) + ")";
+            }
+            throw new COMException(formatMessage, pExcepInfo, puArgErr);
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
@@ -133,7 +133,7 @@ public class CallbackProxy implements IDispatchCallback {
                 for ( int i = 0; i < vargs.variantArg.length; i++) {
                     Class targetClass = params[vargs.variantArg.length - 1 - i];
                     Variant.VARIANT varg = vargs.variantArg[i];
-                    Object jarg = Convert.toJavaObject(varg, targetClass, factory, true);
+                    Object jarg = Convert.toJavaObject(varg, targetClass, factory, true, false);
                     rjargs.add(jarg);
                 }
             }

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/CallbackProxy.java
@@ -199,19 +199,13 @@ public class CallbackProxy implements IDispatchCallback {
 	public HRESULT QueryInterface(REFIID refid, PointerByReference ppvObject) {
 		if (null == ppvObject) {
 			return new HRESULT(WinError.E_POINTER);
-		}
-
-		if (refid.equals(this.listenedToRiid)) {
+		} else if (refid.equals(this.listenedToRiid)) {
 			ppvObject.setValue(this.getPointer());
 			return WinError.S_OK;
-		}
-
-		if (new Guid.IID(refid.getPointer()).equals(Unknown.IID_IUNKNOWN)) {
+		} else if (refid.getValue().equals(Unknown.IID_IUNKNOWN)) {
 			ppvObject.setValue(this.getPointer());
 			return WinError.S_OK;
-		}
-
-		if (new Guid.IID(refid.getPointer()).equals(Dispatch.IID_IDISPATCH)) {
+		} else if (refid.getValue().equals(Dispatch.IID_IDISPATCH)) {
 			ppvObject.setValue(this.getPointer());
 			return WinError.S_OK;
 		}

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
@@ -366,7 +366,7 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 
             COMUtils.checkRC(hr);
 
-            return convertAndFreeReturn(result, returnType);
+            return (T) Convert.toJavaObject(result, returnType, factory, false, true);
         }
         
 	@Override
@@ -398,14 +398,8 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
                 
 		COMUtils.checkRC(hr);
 
-                return convertAndFreeReturn(result, returnType);
+                return (T) Convert.toJavaObject(result, returnType, factory, false, true);
 	}
-
-        private <T> T convertAndFreeReturn(VARIANT.ByReference result, Class<T> returnType) {
-            Object jobj = Convert.toJavaObject(result, returnType, factory, false);
-            Convert.free(result, returnType);
-            return returnType.cast(jobj);
-        }
 
 	@Override
 	public <T> T queryInterface(Class<T> comInterface) throws COMException {

--- a/contrib/platform/src/com/sun/jna/platform/win32/Guid.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Guid.java
@@ -512,7 +512,27 @@ public interface Guid {
         public IID getValue() {
             return new IID(getPointer());
         }
-        
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null) {
+                return false;
+            }
+            if (this == o) {
+                return true;
+            }
+            if (getClass() != o.getClass()) {
+                return false;
+            }
+
+            REFIID other = (REFIID) o;
+            return getValue().equals(other.getValue());
+        }
+
+        @Override
+        public int hashCode() {
+            return getValue().hashCode();
+        }
     }
     
     /**

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/COMUtilsTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/COMUtilsTest.java
@@ -1,18 +1,29 @@
 package com.sun.jna.platform.win32.COM;
 
-import junit.framework.TestCase;
+import com.sun.jna.platform.win32.WinNT;
+import org.junit.Test;
 
-public class COMUtilsTest extends TestCase {
+import static org.junit.Assert.*;
 
+public class COMUtilsTest {
+
+    @Test
     public void testSUCCEEDED() throws Exception {
         assertTrue(COMUtils.SUCCEEDED(COMUtils.S_OK));
         assertTrue(COMUtils.SUCCEEDED(COMUtils.S_FALSE));
         assertFalse(COMUtils.SUCCEEDED(COMUtils.E_UNEXPECTED));
     }
 
+    @Test
     public void testFAILED() throws Exception {
         assertFalse(COMUtils.FAILED(COMUtils.S_OK));
         assertFalse(COMUtils.FAILED(COMUtils.S_FALSE));
         assertTrue(COMUtils.FAILED(COMUtils.E_UNEXPECTED));
+    }
+    
+    @Test(expected = COMException.class)
+    public void testCreateCOMExceptionFromCustomHRESULT() {
+        // This resulted in a LastErrorException instead of COMException
+        COMUtils.checkRC(new WinNT.HRESULT(0x80040200));
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
@@ -1,6 +1,10 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
+import com.sun.jna.platform.win32.COM.util.annotation.ComMethod;
+import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
 import com.sun.jna.platform.win32.OaIdl.DATE;
 import com.sun.jna.platform.win32.OaIdl.VARIANT_BOOL;
 import com.sun.jna.platform.win32.Ole32;
@@ -42,8 +46,8 @@ public class ConvertTest {
         VARIANT testValue = new Variant.VARIANT(42);
         VARIANT resultVariant = Convert.toVariant(testValue);
         assertSame(testValue, resultVariant);
-        assertSame(testValue, Convert.toJavaObject(resultVariant, VARIANT.class, fact, true));
-        assertSame(42, Convert.toJavaObject(testValue, Object.class, fact, true));
+        assertSame(testValue, Convert.toJavaObject(resultVariant, VARIANT.class, fact, false, false));
+        assertSame(42, Convert.toJavaObject(testValue, Object.class, fact, false, false));
     }
 
     @Test
@@ -53,13 +57,13 @@ public class ConvertTest {
         BSTR testValue = new BSTR(testString);
         VARIANT resultVariant = Convert.toVariant(testValue);
         assertEquals(testString, resultVariant.stringValue());
-        assertEquals(testString, Convert.toJavaObject(resultVariant, Object.class, fact, true));
-        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, true));
-        
+        assertEquals(testString, Convert.toJavaObject(resultVariant, Object.class, fact, false, false));
+        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, false, false));
+
         resultVariant = Convert.toVariant(testString);
         assertEquals(testString, resultVariant.stringValue());
-        assertEquals(testString, Convert.toJavaObject(resultVariant, Object.class, fact, true));
-        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, true));
+        assertEquals(testString, Convert.toJavaObject(resultVariant, Object.class, fact, false, false));
+        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, false, false));
     }
 
     @Test
@@ -67,48 +71,48 @@ public class ConvertTest {
         VARIANT_BOOL testVariantBOOL = new VARIANT_BOOL(true);
         VARIANT resultVariantBOOL = Convert.toVariant(testVariantBOOL);
         assertEquals(true, resultVariantBOOL.booleanValue());
-        assertEquals(true, Convert.toJavaObject(resultVariantBOOL, Object.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultVariantBOOL, Boolean.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultVariantBOOL, boolean.class, fact, true));
-     
+        assertEquals(true, Convert.toJavaObject(resultVariantBOOL, Object.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultVariantBOOL, Boolean.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultVariantBOOL, boolean.class, fact, false, false));
+
         BOOL testBOOL = new BOOL(true);
         VARIANT resultBOOL = Convert.toVariant(testBOOL);
         assertEquals(true, resultBOOL.booleanValue());
-        assertEquals(true, Convert.toJavaObject(resultBOOL, Object.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultBOOL, Boolean.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultBOOL, boolean.class, fact, true));
+        assertEquals(true, Convert.toJavaObject(resultBOOL, Object.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultBOOL, Boolean.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultBOOL, boolean.class, fact, false, false));
 
         Boolean testBooleanObj = true;
         VARIANT resultBooleanObj = Convert.toVariant(testBooleanObj);
         boolean testBoolean = true;
         VARIANT resultBoolean = Convert.toVariant(testBoolean);
-        
+
         assertEquals(true, resultBooleanObj.booleanValue());
         assertEquals(true, resultBoolean.booleanValue());
-        assertEquals(true, Convert.toJavaObject(resultBooleanObj, Object.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultBoolean, Object.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultBooleanObj, boolean.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultBoolean, boolean.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultBooleanObj, Boolean.class, fact, true));
-        assertEquals(true, Convert.toJavaObject(resultBoolean, Boolean.class, fact, true));
+        assertEquals(true, Convert.toJavaObject(resultBooleanObj, Object.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultBoolean, Object.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultBooleanObj, boolean.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultBoolean, boolean.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultBooleanObj, Boolean.class, fact, false, false));
+        assertEquals(true, Convert.toJavaObject(resultBoolean, Boolean.class, fact, false, false));
     }
-    
+
     @Test
     public void testConvertIntTypes() {
         LONG testLONG = new LONG(42);
         VARIANT resultLONG = Convert.toVariant(testLONG);
         assertEquals(42, resultLONG.longValue());
-        assertEquals(Integer.class, Convert.toJavaObject(resultLONG, Object.class, fact, true).getClass());
-        assertEquals(42, Convert.toJavaObject(resultLONG, int.class, fact, true));
-        assertEquals(42, Convert.toJavaObject(resultLONG, Integer.class, fact, true));
+        assertEquals(Integer.class, Convert.toJavaObject(resultLONG, Object.class, fact, false, false).getClass());
+        assertEquals(42, Convert.toJavaObject(resultLONG, int.class, fact, false, false));
+        assertEquals(42, Convert.toJavaObject(resultLONG, Integer.class, fact, false, false));
 
         SHORT testSHORT = new SHORT(42);
         VARIANT resultSHORT = Convert.toVariant(testSHORT);
         assertEquals(42, resultSHORT.longValue());
-        assertEquals(Short.class, Convert.toJavaObject(resultSHORT, Object.class, fact, true).getClass());
-        assertEquals((short) 42, Convert.toJavaObject(resultSHORT, short.class, fact, true));
-        assertEquals((short) 42, Convert.toJavaObject(resultSHORT, Short.class, fact, true));
-        
+        assertEquals(Short.class, Convert.toJavaObject(resultSHORT, Object.class, fact, false, false).getClass());
+        assertEquals((short) 42, Convert.toJavaObject(resultSHORT, short.class, fact, false, false));
+        assertEquals((short) 42, Convert.toJavaObject(resultSHORT, Short.class, fact, false, false));
+
         BYTE testBYTE = new BYTE(42);
         VARIANT resultBYTE = Convert.toVariant(testBYTE);
         Byte testByteObj = 42;
@@ -119,38 +123,37 @@ public class ConvertTest {
         assertEquals(42, resultBYTE.longValue());
         assertEquals(42, resultByteObj.longValue());
         assertEquals(42, resultByte.longValue());
-        assertEquals(Byte.class, Convert.toJavaObject(resultBYTE, Object.class, fact, true).getClass());
-        assertEquals(Byte.class, Convert.toJavaObject(resultByteObj, Object.class, fact, true).getClass());
-        assertEquals(Byte.class, Convert.toJavaObject(resultByte, Object.class, fact, true).getClass());
-        assertEquals((byte) 42, Convert.toJavaObject(resultBYTE, byte.class, fact, true));
-        assertEquals((byte) 42, Convert.toJavaObject(resultByteObj, byte.class, fact, true));
-        assertEquals((byte) 42, Convert.toJavaObject(resultByte, byte.class, fact, true));
-        assertEquals((byte) 42, Convert.toJavaObject(resultBYTE, Byte.class, fact, true));
-        assertEquals((byte) 42, Convert.toJavaObject(resultByteObj, Byte.class, fact, true));
-        assertEquals((byte) 42, Convert.toJavaObject(resultByte, Byte.class, fact, true));
+        assertEquals(Byte.class, Convert.toJavaObject(resultBYTE, Object.class, fact, false, false).getClass());
+        assertEquals(Byte.class, Convert.toJavaObject(resultByteObj, Object.class, fact, false, false).getClass());
+        assertEquals(Byte.class, Convert.toJavaObject(resultByte, Object.class, fact, false, false).getClass());
+        assertEquals((byte) 42, Convert.toJavaObject(resultBYTE, byte.class, fact, false, false));
+        assertEquals((byte) 42, Convert.toJavaObject(resultByteObj, byte.class, fact, false, false));
+        assertEquals((byte) 42, Convert.toJavaObject(resultByte, byte.class, fact, false, false));
+        assertEquals((byte) 42, Convert.toJavaObject(resultBYTE, Byte.class, fact, false, false));
+        assertEquals((byte) 42, Convert.toJavaObject(resultByteObj, Byte.class, fact, false, false));
+        assertEquals((byte) 42, Convert.toJavaObject(resultByte, Byte.class, fact, false, false));
 
         Character testCharObj = 42;
         VARIANT resultCharObj = Convert.toVariant(testCharObj);
         char testChar = 42;
         VARIANT resultChar = Convert.toVariant(testChar);
-        
+
         assertEquals(42, resultCharObj.longValue());
         assertEquals(42, resultChar.longValue());
-        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultCharObj, Object.class, fact, true));
-        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultChar, Object.class, fact, true));
-        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultCharObj, char.class, fact, true));
-        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultChar, char.class, fact, true));
-        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultCharObj, Character.class, fact, true));
-        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultChar, Character.class, fact, true));
-
+        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultCharObj, Object.class, fact, false, false));
+        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultChar, Object.class, fact, false, false));
+        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultCharObj, char.class, fact, false, false));
+        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultChar, char.class, fact, false, false));
+        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultCharObj, Character.class, fact, false, false));
+        assertEquals(testCharObj, (Character) Convert.toJavaObject(resultChar, Character.class, fact, false, false));
 
         CHAR testCHAR = new CHAR(42);
         VARIANT resultCHAR = Convert.toVariant(testCHAR);
 
         assertEquals(42, resultCHAR.longValue());
-        assertEquals((byte) 42, Convert.toJavaObject(resultCHAR, Object.class, fact, true));
-        assertEquals((byte) 42, Convert.toJavaObject(resultCHAR, byte.class, fact, true));
-        assertEquals((byte) 42, Convert.toJavaObject(resultCHAR, Byte.class, fact, true));
+        assertEquals((byte) 42, Convert.toJavaObject(resultCHAR, Object.class, fact, false, false));
+        assertEquals((byte) 42, Convert.toJavaObject(resultCHAR, byte.class, fact, false, false));
+        assertEquals((byte) 42, Convert.toJavaObject(resultCHAR, Byte.class, fact, false, false));
 
         Short testShortObj = 42;
         VARIANT resultShortObj = Convert.toVariant(testShortObj);
@@ -159,12 +162,12 @@ public class ConvertTest {
 
         assertEquals(42, resultShortObj.longValue());
         assertEquals(42, resultShort.longValue());
-        assertEquals((short) 42, Convert.toJavaObject(resultShortObj, Object.class, fact, true));
-        assertEquals((short) 42, Convert.toJavaObject(resultShort, Object.class, fact, true));
-        assertEquals((short) 42, Convert.toJavaObject(resultShortObj, short.class, fact, true));
-        assertEquals((short) 42, Convert.toJavaObject(resultShort, short.class, fact, true));
-        assertEquals((short) 42, Convert.toJavaObject(resultShortObj, Short.class, fact, true));
-        assertEquals((short) 42, Convert.toJavaObject(resultShort, Short.class, fact, true));
+        assertEquals((short) 42, Convert.toJavaObject(resultShortObj, Object.class, fact, false, false));
+        assertEquals((short) 42, Convert.toJavaObject(resultShort, Object.class, fact, false, false));
+        assertEquals((short) 42, Convert.toJavaObject(resultShortObj, short.class, fact, false, false));
+        assertEquals((short) 42, Convert.toJavaObject(resultShort, short.class, fact, false, false));
+        assertEquals((short) 42, Convert.toJavaObject(resultShortObj, Short.class, fact, false, false));
+        assertEquals((short) 42, Convert.toJavaObject(resultShort, Short.class, fact, false, false));
 
         Integer testIntegerObj = 42;
         VARIANT resultIntegerObj = Convert.toVariant(testIntegerObj);
@@ -173,12 +176,12 @@ public class ConvertTest {
 
         assertEquals(42, resultIntegerObj.longValue());
         assertEquals(42, resultInteger.longValue());
-        assertEquals((int) 42, Convert.toJavaObject(resultIntegerObj, Object.class, fact, true));
-        assertEquals((int) 42, Convert.toJavaObject(resultInteger, Object.class, fact, true));
-        assertEquals((int) 42, Convert.toJavaObject(resultIntegerObj, int.class, fact, true));
-        assertEquals((int) 42, Convert.toJavaObject(resultInteger, int.class, fact, true));
-        assertEquals((int) 42, Convert.toJavaObject(resultIntegerObj, Integer.class, fact, true));
-        assertEquals((int) 42, Convert.toJavaObject(resultInteger, Integer.class, fact, true));
+        assertEquals((int) 42, Convert.toJavaObject(resultIntegerObj, Object.class, fact, false, false));
+        assertEquals((int) 42, Convert.toJavaObject(resultInteger, Object.class, fact, false, false));
+        assertEquals((int) 42, Convert.toJavaObject(resultIntegerObj, int.class, fact, false, false));
+        assertEquals((int) 42, Convert.toJavaObject(resultInteger, int.class, fact, false, false));
+        assertEquals((int) 42, Convert.toJavaObject(resultIntegerObj, Integer.class, fact, false, false));
+        assertEquals((int) 42, Convert.toJavaObject(resultInteger, Integer.class, fact, false, false));
 
         Long testLongObj = 42L;
         VARIANT resultLongObj = Convert.toVariant(testLongObj);
@@ -187,31 +190,31 @@ public class ConvertTest {
 
         assertEquals(42, resultLongObj.longValue());
         assertEquals(42, resultLong.longValue());
-        assertEquals((long) 42, Convert.toJavaObject(resultLongObj, Object.class, fact, true));
-        assertEquals((long) 42, Convert.toJavaObject(resultLong, Object.class, fact, true));
-        assertEquals((long) 42, Convert.toJavaObject(resultLongObj, long.class, fact, true));
-        assertEquals((long) 42, Convert.toJavaObject(resultLong, long.class, fact, true));
-        assertEquals((long) 42, Convert.toJavaObject(resultLongObj, Long.class, fact, true));
-        assertEquals((long) 42, Convert.toJavaObject(resultLong, Long.class, fact, true));
+        assertEquals((long) 42, Convert.toJavaObject(resultLongObj, Object.class, fact, false, false));
+        assertEquals((long) 42, Convert.toJavaObject(resultLong, Object.class, fact, false, false));
+        assertEquals((long) 42, Convert.toJavaObject(resultLongObj, long.class, fact, false, false));
+        assertEquals((long) 42, Convert.toJavaObject(resultLong, long.class, fact, false, false));
+        assertEquals((long) 42, Convert.toJavaObject(resultLongObj, Long.class, fact, false, false));
+        assertEquals((long) 42, Convert.toJavaObject(resultLong, Long.class, fact, false, false));
     }
-    
+
     @Test
     public void testConvertFloat() {
         Float testFloatObj = 42.23f;
         VARIANT resultFloatObj = Convert.toVariant(testFloatObj);
         float testFloat = 42.23f;
         VARIANT resultFloat = Convert.toVariant(testFloat);
-        
+
         assertEquals(42.23f, resultFloatObj.floatValue(), 0.01);
         assertEquals(42.23f, resultFloat.floatValue(), 0.01);
         assertEquals(42.23d, resultFloat.doubleValue(), 0.01);
-        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloatObj, Object.class, fact, true), 0.01);
-        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloat, Object.class, fact, true), 0.01);
-        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloatObj, float.class, fact, true), 0.01);
-        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloat, float.class, fact, true), 0.01);
-        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloatObj, Float.class, fact, true), 0.01);
-        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloat, Float.class, fact, true), 0.01);
-        assertEquals(42.23d, (Double) Convert.toJavaObject(resultFloat, double.class, fact, true), 0.01);
+        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloatObj, Object.class, fact, false, false), 0.01);
+        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloat, Object.class, fact, false, false), 0.01);
+        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloatObj, float.class, fact, false, false), 0.01);
+        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloat, float.class, fact, false, false), 0.01);
+        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloatObj, Float.class, fact, false, false), 0.01);
+        assertEquals(42.23f, (Float) Convert.toJavaObject(resultFloat, Float.class, fact, false, false), 0.01);
+        assertEquals(42.23d, (Double) Convert.toJavaObject(resultFloat, double.class, fact, false, false), 0.01);
 
         Double testDoubleObj = 42.23;
         VARIANT resultDoubleObj = Convert.toVariant(testDoubleObj);
@@ -221,15 +224,15 @@ public class ConvertTest {
         assertEquals(42.23, resultDoubleObj.doubleValue(), 0.01);
         assertEquals(42.23, resultDouble.doubleValue(), 0.01);
         assertEquals(42.23f, resultDouble.floatValue(), 0.01);
-        assertEquals(42.23, (Double) Convert.toJavaObject(resultDoubleObj, Object.class, fact, true), 0.01);
-        assertEquals(42.23, (Double) Convert.toJavaObject(resultDouble, Object.class, fact, true), 0.01);
-        assertEquals(42.23, (Double) Convert.toJavaObject(resultDoubleObj, double.class, fact, true), 0.01);
-        assertEquals(42.23, (Double) Convert.toJavaObject(resultDouble, double.class, fact, true), 0.01);
-        assertEquals(42.23, (Double) Convert.toJavaObject(resultDoubleObj, Double.class, fact, true), 0.01);
-        assertEquals(42.23, (Double) Convert.toJavaObject(resultDouble, Double.class, fact, true), 0.01);
-        assertEquals(42.23f, (Float) Convert.toJavaObject(resultDouble, float.class, fact, true), 0.01);
+        assertEquals(42.23, (Double) Convert.toJavaObject(resultDoubleObj, Object.class, fact, false, false), 0.01);
+        assertEquals(42.23, (Double) Convert.toJavaObject(resultDouble, Object.class, fact, false, false), 0.01);
+        assertEquals(42.23, (Double) Convert.toJavaObject(resultDoubleObj, double.class, fact, false, false), 0.01);
+        assertEquals(42.23, (Double) Convert.toJavaObject(resultDouble, double.class, fact, false, false), 0.01);
+        assertEquals(42.23, (Double) Convert.toJavaObject(resultDoubleObj, Double.class, fact, false, false), 0.01);
+        assertEquals(42.23, (Double) Convert.toJavaObject(resultDouble, Double.class, fact, false, false), 0.01);
+        assertEquals(42.23f, (Float) Convert.toJavaObject(resultDouble, float.class, fact, false, false), 0.01);
     }
-    
+
     @Test
     public void testConvertDate() {
         Date testDate = new Date(2015 - 1900, 1, 1, 9, 0, 0);
@@ -239,21 +242,47 @@ public class ConvertTest {
 
         assertEquals(testDate, resultDate.dateValue());
         assertEquals(testDate, resultDATE.dateValue());
-        assertEquals(testDate, Convert.toJavaObject(resultDate, Object.class, fact, true));
-        assertEquals(testDate, Convert.toJavaObject(resultDATE, Object.class, fact, true));
-        assertEquals(testDate, Convert.toJavaObject(resultDate, Date.class, fact, true));
-        assertEquals(testDate, Convert.toJavaObject(resultDATE, Date.class, fact, true));
+        assertEquals(testDate, Convert.toJavaObject(resultDate, Object.class, fact, false, false));
+        assertEquals(testDate, Convert.toJavaObject(resultDATE, Object.class, fact, false, false));
+        assertEquals(testDate, Convert.toJavaObject(resultDate, Date.class, fact, false, false));
+        assertEquals(testDate, Convert.toJavaObject(resultDATE, Date.class, fact, false, false));
     }
-        
+
     @Test
     public void testConvertEnum() {
         TestEnum testEnum = TestEnum.Val2;
         VARIANT resultEnum = Convert.toVariant(testEnum);
         assertEquals((int) testEnum.getValue(), resultEnum.intValue());
-        assertEquals((int) testEnum.getValue(), Convert.toJavaObject(resultEnum, Object.class, fact, true));
-        assertEquals(testEnum, Convert.toJavaObject(resultEnum, TestEnum.class, fact, true));
+        assertEquals((int) testEnum.getValue(), Convert.toJavaObject(resultEnum, Object.class, fact, false, false));
+        assertEquals(testEnum, Convert.toJavaObject(resultEnum, TestEnum.class, fact, false, false));
     }
 
+    @Test
+    public void testReturnPrimitiveVoid() {
+        FileSystemObject app = fact.createObject(FileSystemObject.class);
+        // It is assumed that "C" is the holy drive letter, that will
+        // always be present
+        assertTrue(app.DriveExistsPrimitive("C:"));
+        assertTrue(app.DriveExistsObject("C:"));
+        app.DriveExistsVoid("C:");
+    }
+}
+
+@ComObject(clsId = "{0D43FE01-F093-11CF-8940-00A0C9054228}")
+interface FileSystemObject extends IFileSystem3 {
+}
+
+@ComInterface(iid = "{2A0B9D10-4B87-11D3-A97A-00104B365C9F}")
+interface IFileSystem3 extends IUnknown, IConnectionPoint {
+
+    @ComMethod(dispId = 0x0000271f)
+    boolean DriveExistsPrimitive(String driveName);
+
+    @ComMethod(dispId = 0x0000271f)
+    Boolean DriveExistsObject(String driveName);
+
+    @ComMethod(dispId = 0x0000271f)
+    void DriveExistsVoid(String driveName);
 }
 
 enum TestEnum implements IComEnum {


### PR DESCRIPTION
- FormatMessage throws a LastErrorException when HRESULT can't be resolved
- Primitives + void can't be returned from COM calls (failing the final cast)
- REFIID#equals was in past based on content, this is now the case again

Please see the individual commits for details, the commits again form seperate units for each part.