### PR TITLE
Exception from COMBindingBaseObject swallows real reason + HRESULT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@ Bug Fixes
 * [#610](https://github.com/java-native-access/jna/pull/610): Fixed issue #604: Kernel32#GetLastError() always returns ERROR_SUCCESS [@lgoldstein](https://github.com/lgoldstein).
 * [#633](https://github.com/java-native-access/jna/pull/633): Restore default usage of platform native encoding for Java strings passed to native functions (was hard-coded to UTF-8 in 4.0 and later) [@amake](https://github.com/amake)
 * [#634](https://github.com/java-native-access/jna/pull/634): Improve BSTR handling and add `SysStringByteLen` and `SysStringLen` to `com.sun.jna.platform.win32.OleAuto` - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#646](https://github.com/java-native-access/jna/issues/646): `platform.win32.COM.COMBindingBaseObject` swallows reason if instantiation fails - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.2.1
 =============

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ComExceptionWithoutInitializationTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ComExceptionWithoutInitializationTest.java
@@ -1,0 +1,54 @@
+package com.sun.jna.platform.win32.COM;
+
+import com.sun.jna.platform.win32.Guid;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class ComExceptionWithoutInitializationTest {
+
+    @Test
+    public void testCorrectExceptionOnFailedInitialization() {
+        String message = null;
+        try {
+            InternetExplorer ie = new InternetExplorer();
+        } catch (COMException ex) {
+            message = ex.getMessage();
+        }
+        
+        // This invocation must raise an exception, as the COM thread is not
+        // initialized, in the message it is expected, that the HRESULT is reported
+        // and the HRESULT resulting from calling into COM with it being initialized
+        // is 800401f0. The message is also expected to point the to correct
+        // initialization via CoInitialize
+        assertNotNull(message);
+        assertTrue(message.contains("HRESULT"));
+        assertTrue(message.contains("800401f0"));
+        assertTrue(message.contains("CoInitialize"));
+    }
+
+    /**
+     * InternetExplorer / IWebBrowser2 - see
+     * http://msdn.microsoft.com/en-us/library/aa752127(v=vs.85).aspx
+     */
+    private static class InternetExplorer extends COMLateBindingObject {
+
+        public InternetExplorer(IDispatch iDispatch) {
+            super(iDispatch);
+        }
+
+        public InternetExplorer() {
+            super(new Guid.CLSID("{0002DF01-0000-0000-C000-000000000046}"), true);
+        }
+        
+        /**
+         * IWebBrowser2::get_LocationURL<br>
+         * Read-only COM property.<br>
+         *
+         * @return the URL of the resource that is currently displayed.
+         */
+        public String getURL() {
+            return getStringProperty("LocationURL");
+        }
+    }
+}


### PR DESCRIPTION
The exception thrown from COMBindingBaseObject when instatiation fails
is misleading:

COM object with CLSID {0002DF01-0000-0000-C000-000000000046} not registered properly!

In the concrete case COM was not properly initialized, the same error now
reports (in german locale):

CoInitialize wurde nicht aufgerufen.(HRESULT: 800401f0) (puArgErr=)

For english locale this should be along the lines of:

CoInitialize was not called.(HRESULT: 800401f0) (puArgErr=)

The message now points out the correct problem (as far as the windows
error code translation works) and the HRESULT can be used for a locale
independend report + search.

Closes #646

Please note: The change in COMBindingBaseObject looks worse in the diff, than it is. The two constructors (the clsid and the progid ones) were mostly duplicated code. The duplicate part was merged into the init method, and the constructors delegate to that method.