### PR TITLE
Prepare publishing binaries to maven central via sonatype OSS repository hosting

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -120,10 +120,10 @@
   <property name="pom-platform" value="pom-jna-platform.xml" />
 
   <!-- defined maven snapshots and staging repository id and url -->
-  <property name="maven-snapshots-repository-id" value="snapshots.java.net" />
-  <property name="maven-snapshots-repository-url" value="https://maven.java.net/content/repositories/snapshots/" />
-  <property name="maven-staging-repository-id" value="staging.java.net" />
-  <property name="maven-staging-repository-url" value="https://maven.java.net/service/local/staging/deploy/maven2/" />
+  <property name="maven-snapshots-repository-id" value="oss.sonatype.org" />
+  <property name="maven-snapshots-repository-url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
+  <property name="maven-staging-repository-id" value="oss.sonatype.org" />
+  <property name="maven-staging-repository-url" value="https://oss.sonatype.org/service/local/staging/deploy/maven2/" />
 
   <!-- Miscellaneous -->
   <property name="build.compiler.emacs" value="true"/>

--- a/pom-jna-platform.xml
+++ b/pom-jna-platform.xml
@@ -40,6 +40,14 @@
         <role>Owner</role>
       </roles>
     </developer>
+    <developer>
+      <email>mblaesing@doppel-helix.eu</email>
+      <name>Matthias Bläsing</name>
+      <url>https://github.com/matthiasblaesing/</url>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
   </developers>
 
   <dependencies>

--- a/pom-jna.xml
+++ b/pom-jna.xml
@@ -40,6 +40,14 @@
         <role>Owner</role>
       </roles>
     </developer>
+    <developer>
+      <email>mblaesing@doppel-helix.eu</email>
+      <name>Matthias Bläsing</name>
+      <url>https://github.com/matthiasblaesing/</url>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
   </developers>
 
 </project>

--- a/www/PublishingToMavenCentral.md
+++ b/www/PublishingToMavenCentral.md
@@ -4,6 +4,9 @@ Publishing JNA to Maven Central
 One Time
 --------
 
+* Create an account in the [sonatype jira](https://issues.sonatype.org/secure/Signup!default.jspa)
+* Get the account enabled for publishing to the net.java.dev.jna groupId
+  (contact an existing uploader for this)
 * Set up your gpg keys as described [here](http://central.sonatype.org/pages/working-with-pgp-signatures.html). Make sure you distribute your public key.
 * Make sure you have a settings.xml file (in directory: ${user.home}/.m2/). For example:
 
@@ -13,21 +16,19 @@ One Time
             ...
                 <!-- java.net repos for sync to maven central -->
                 <server>
-                    <id>snapshots.java.net</id>
-                    <username>myjavanetuser</username>
-                    <password>myjavanetpwd</password>
-                </server>
-                <server>
-                    <id>staging.java.net</id>
-                    <username>myjavanetuser</username>
-                    <password>myjavanetpwd</password>
+                    <id>oss.sonatype.org</id>
+                    <username>myossrhuser</username>
+                    <password>myossrhpwd</password>
                 </server>
             ...
             </servers>
         ...
         <settings>
 
-  Because we are still deploying to maven repositories via java.net, see [Java.net Maven Repository Usage Guide](http://java.net/projects/maven2-repository/pages/MigrationAndCleanupRelatedDocumentation) for more info.
+  The binaries are hosted in the Sonatype OSSRH (OSS Repository Hosting) system,
+  and mirrored from there to maven central.
+
+  See [OSSRH Guide](http://central.sonatype.org/pages/ossrh-guide.html) for more info.
 
 Publish Snapshot
 ----------------
@@ -37,9 +38,9 @@ Publish Snapshot
 Before doing a full jna release, we can publish a development SNAPSHOT of the "next" release for people to test. The
 SNAPSHOT will be published in the staging repository:
 
-   https://maven.java.net/content/repositories/snapshots/
+   [https://oss.sonatype.org/content/repositories/snapshots/](https://oss.sonatype.org/content/repositories/snapshots/)
 
-see: https://maven.java.net/content/repositories/snapshots/net/java/dev/jna/ for the various jars.
+see: [https://oss.sonatype.org/content/repositories/snapshots/net/java/dev/jna/](https://oss.sonatype.org/content/repositories/snapshots/net/java/dev/jna/) for the various jars.
 
 To publish a development SNAPSHOT do the following:
 
@@ -54,8 +55,5 @@ Publish Release
 
 * Verify the &lt;version> tags in [pom-jna.xml](https://github.com/java-native-access/jna/blob/master/pom-jna.xml) and [pom-jna-platform.xml](https://github.com/java-native-access/jna/blob/master/pom-jna-platform.xml)
   match the version (jna.version) in [build.xml](https://github.com/java-native-access/jna/blob/master/build.xml).
-* Run `ant -Dmaven-release=true stage`. This uploads current checkout to [maven.java.net](https://maven.java.net).
+* Run `ant -Dmaven-release=true stage`. This uploads current checkout to [oss.sonatype.org](https://oss.sonatype.org).
 * Follow steps from [Releasing the Deployment](http://central.sonatype.org/pages/releasing-the-deployment.html).
-  Note that the releases are managed from [maven.java.net](https://maven.java.net).
-
-

--- a/www/PublishingToMavenCentral.md
+++ b/www/PublishingToMavenCentral.md
@@ -8,13 +8,13 @@ One Time
 * Get the account enabled for publishing to the net.java.dev.jna groupId
   (contact an existing uploader for this)
 * Set up your gpg keys as described [here](http://central.sonatype.org/pages/working-with-pgp-signatures.html). Make sure you distribute your public key.
-* Make sure you have a settings.xml file (in directory: ${user.home}/.m2/). For example:
+* Make sure you have a settings.xml file (in directory: ${user.home}/.m2/).
+  For example (Replace *myossrhuser* and *myossrhpwd* with the account credentials):
 
         <settings>
         ...
             <servers>
             ...
-                <!-- java.net repos for sync to maven central -->
                 <server>
                     <id>oss.sonatype.org</id>
                     <username>myossrhuser</username>
@@ -53,7 +53,8 @@ full release is performed).
 Publish Release
 ---------------
 
-* Verify the &lt;version> tags in [pom-jna.xml](https://github.com/java-native-access/jna/blob/master/pom-jna.xml) and [pom-jna-platform.xml](https://github.com/java-native-access/jna/blob/master/pom-jna-platform.xml)
+* Verify the &lt;version> tags in [pom-jna.xml](https://github.com/java-native-access/jna/blob/master/pom-jna.xml) 
+  and [pom-jna-platform.xml](https://github.com/java-native-access/jna/blob/master/pom-jna-platform.xml)
   match the version (jna.version) in [build.xml](https://github.com/java-native-access/jna/blob/master/build.xml).
 * Run `ant -Dmaven-release=true stage`. This uploads current checkout to [oss.sonatype.org](https://oss.sonatype.org).
 * Follow steps from [Releasing the Deployment](http://central.sonatype.org/pages/releasing-the-deployment.html).


### PR DESCRIPTION
After the announced shutdown of the java.net/kenai hosting by oracle, JNA needed a new home for pushing binaries to maven central. The  OSSRH (OSS Repository Hosting) service offered by sonatype was asked to provide the new home, and that request was granted.

The release process is very similar to the deployment on the java.net infrastructure and the necessary changes can be found below.

The first snapshots were pushed to the OSSRH to test deployment, the POMs were modified to contain my data to allow uploading, as sonatype requires the developer information to be present (I asume it is verified then).

Further uploaders are possible, but the old java.net accounts can't be used for that. Sonatype requires uploaders to have an account in their jira (this is synchronized to their nexus instance).

I suggest to use this pull request to gather the initial list.