### PR TITLE
Consolidate LCID handling for COM calls invoked via ProxyObject

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ Features
 * [#644](https://github.com/java-native-access/jna/pull/644): New ant target 'install' for installing JNA artifacts in local m2-repository - [@SevenOf9Sleeper](https://github.com/SevenOf9Sleeper).
 * [#649](https://github.com/java-native-access/jna/pull/649): Bugfix msoffice sample and add two samples taken from MSDN and translated from VisualBasic to Java  - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#654](https://github.com/java-native-access/jna/pull/654): Support named arguments for `com.sun.jna.platform.win32.COM.util.CallbackProxy` based callbacks - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#659](https://github.com/java-native-access/jna/issues/659): Enable LCID (locale) override for `com.sun.jna.platform.win32.COM.util.ProxyObject`-based COM calls - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/Excelautomation_KB_219151_Mod.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/Excelautomation_KB_219151_Mod.java
@@ -24,6 +24,7 @@ import com.sun.jna.platform.win32.Variant;
 import com.sun.jna.platform.win32.Variant.VARIANT;
 import static com.sun.jna.platform.win32.Variant.VARIANT.VARIANT_MISSING;
 import com.sun.jna.platform.win32.WTypes.BSTR;
+import com.sun.jna.platform.win32.WinDef.LCID;
 import java.io.File;
 
 import java.io.IOException;
@@ -39,24 +40,18 @@ import javax.swing.JOptionPane;
  * bindings or enhance the coverage yourself.</p>
  */
 public class Excelautomation_KB_219151_Mod {
-    private static final String FKT_SUM = "SUM";
-    private static final String FKT_RAND = "RAND";
-    private static final String FKT_COLUMN = "COLUMN";
-    private static final String FKT_CHAR = "CHAR";
-//    Variant for de-Locale:
-//    private static final String FKT_SUM = "SUMME";
-//    private static final String FKT_RAND = "ZUFALLSZAHL";
-//    private static final String FKT_COLUMN = "SPALTE";
-//    private static final String FKT_CHAR = "ZEICHEN";
-    
+
     public static void main(String[] args) throws IOException {
         // Initialize COM Subsystem
         Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
         // Initialize Factory for COM object creation
         Factory fact = new Factory();
+        // Set LCID for calls to english locale. Without this formulas need
+        // to be specified in the users locale.
+        fact.setLCID(new LCID(0x0409));
         
         try {
-            // Start word application
+            // Start excel application
             ComExcel_Application excel = fact.createObject(ComExcel_Application.class);
             ComIApplication excelApp = excel.queryInterface(ComIApplication.class);
             
@@ -94,7 +89,7 @@ public class Excelautomation_KB_219151_Mod {
             sheet.getRange("C2", "C6").setFormula("= A2 & \" \" & B2");
             
             // Fill D2:D6 with a formula(=RAND()*100000) and apply format.
-            sheet.getRange("D2", "D6").setFormula("=" + FKT_RAND + "()*100000");
+            sheet.getRange("D2", "D6").setFormula("=RAND()*100000");
             sheet.getRange("D2", "D6").setNumberFormat("$0.00");
 
             // AutoFit columns A:D.
@@ -139,7 +134,7 @@ public class Excelautomation_KB_219151_Mod {
         // Starting at E1, fill headers for the number of columns selected.
         ComIRange oResizeRange = sheet.getRange("E1", "E1").getResize(VARIANT_MISSING, iNumQtrs);
 
-        oResizeRange.setFormula("=\"Q\" & " + FKT_COLUMN + "() - 4 & " + FKT_CHAR + "(10) & \"Sales\"");
+        oResizeRange.setFormula("=\"Q\" & COLUMN() - 4 & CHAR(10) & \"Sales\"");
       
         // Change the Orientation and WrapText properties for the headers.
         oResizeRange.setOrientation(38);
@@ -150,7 +145,7 @@ public class Excelautomation_KB_219151_Mod {
       
         // Fill the columns with a formula and apply a number format.
         oResizeRange = sheet.getRange("E2", "E6").getResize(VARIANT_MISSING, iNumQtrs);
-        oResizeRange.setFormula("="+ FKT_RAND + "()*100");
+        oResizeRange.setFormula("=RAND()*100");
         oResizeRange.setNumberFormat("$0.00");
       
         // Apply borders to the Sales data and headers.
@@ -159,7 +154,7 @@ public class Excelautomation_KB_219151_Mod {
       
         // Add a Totals formula for the sales data and apply a border.
         oResizeRange = sheet.getRange("E8", "E8").getResize(VARIANT_MISSING, iNumQtrs);
-        oResizeRange.setFormula("=" + FKT_SUM + "(E2:E6)");
+        oResizeRange.setFormula("=SUM(E2:E6)");
         Borders oResizeRangeBorders = oResizeRange.getBorders();
         oResizeRangeBorders.setLineStyle(XlLineStyle.xlDouble);
         oResizeRangeBorders.setWeight(XlBorderWeight.xlThick);

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Factory.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Factory.java
@@ -13,9 +13,6 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import java.lang.reflect.Proxy;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import com.sun.jna.platform.win32.Guid.CLSID;
 import com.sun.jna.platform.win32.Guid.GUID;
@@ -29,6 +26,8 @@ import com.sun.jna.platform.win32.COM.COMUtils;
 import com.sun.jna.platform.win32.COM.Dispatch;
 import com.sun.jna.platform.win32.COM.IDispatch;
 import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.WinDef.LCID;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
 import com.sun.jna.ptr.PointerByReference;
 import java.lang.ref.WeakReference;
@@ -37,7 +36,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-public class Factory {
+public class Factory {        
 	/**
 	 * Factory keeps track of COM objects - all objects created with this
          * factory can be disposed by calling {@link Factory#disposeAll() }.
@@ -45,7 +44,6 @@ public class Factory {
 	public Factory() {
             assert COMUtils.comIsInitialized() : "COM not initialized";
 	}
-
 	
 	@Override
 	protected void finalize() throws Throwable {
@@ -201,4 +199,34 @@ public class Factory {
                 this.registeredObjects.clear();
             }
 	}
+        
+        /**
+         * The Constant LOCALE_USER_DEFAULT.
+         */
+        private final static LCID LOCALE_USER_DEFAULT = Kernel32.INSTANCE.GetUserDefaultLCID();
+    
+        private LCID LCID;
+        
+        /**
+         * Retrieve the LCID to be used for COM calls. 
+         * 
+         * @return If {@code setLCID} is not called retrieves the users default
+         *         locale, else the set LCID.
+         */
+        public LCID getLCID() {
+            if(LCID != null) {
+                return LCID;
+            } else {
+                return LOCALE_USER_DEFAULT;
+            }
+        }
+        
+        /**
+         * Set the LCID to use for COM calls.
+         * 
+         * @param value override LCID. NULL resets to default.
+         */
+        public void setLCID(LCID value) {
+            LCID = value;
+        }
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
@@ -33,11 +33,9 @@ import com.sun.jna.platform.win32.OleAuto;
 import com.sun.jna.platform.win32.OleAuto.DISPPARAMS;
 import com.sun.jna.platform.win32.Variant;
 import com.sun.jna.platform.win32.Variant.VARIANT;
-import com.sun.jna.platform.win32.Variant.VariantArg;
 import com.sun.jna.platform.win32.WinDef;
 import com.sun.jna.platform.win32.WinDef.DWORDByReference;
 import com.sun.jna.platform.win32.WinDef.LCID;
-import com.sun.jna.platform.win32.WinDef.UINT;
 import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
 import com.sun.jna.platform.win32.COM.COMException;
@@ -497,12 +495,6 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 		}
 	}
 
-	/** The Constant LOCALE_USER_DEFAULT. */
-	public final static LCID LOCALE_USER_DEFAULT = Kernel32.INSTANCE.GetUserDefaultLCID();
-
-	/** The Constant LOCALE_SYSTEM_DEFAULT. */
-	public final static LCID LOCALE_SYSTEM_DEFAULT = Kernel32.INSTANCE.GetSystemDefaultLCID();
-
 	/*
 	 * @see com.sun.jna.platform.win32.COM.COMBindingBaseObject#oleMethod
 	 */
@@ -547,8 +539,12 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
                 final DISPIDByReference pdispID = new DISPIDByReference();
 
                 // Get DISPID for name passed...
-                HRESULT hr = pDisp.GetIDsOfNames(new REFIID(Guid.IID_NULL), ptName, 1, LOCALE_USER_DEFAULT,
-                                                pdispID);
+                HRESULT hr = pDisp.GetIDsOfNames(
+                        new REFIID(Guid.IID_NULL), 
+                        ptName, 
+                        1, 
+                        factory.getLCID(), 
+                        pdispID);
 
                 COMUtils.checkRC(hr);
                 
@@ -637,8 +633,15 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
 		}
 
 
-                HRESULT hr = pDisp.Invoke(dispId, new REFIID(Guid.IID_NULL), LOCALE_SYSTEM_DEFAULT,
-                                                new WinDef.WORD(finalNType), dp, pvResult, pExcepInfo, puArgErr);
+                HRESULT hr = pDisp.Invoke(
+                        dispId, 
+                        new REFIID(Guid.IID_NULL), 
+                        factory.getLCID(),
+                        new WinDef.WORD(finalNType), 
+                        dp, 
+                        pvResult, 
+                        pExcepInfo, 
+                        puArgErr);
 
 
                 COMUtils.checkRC(hr, pExcepInfo, puArgErr);

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConfigurateLCID_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConfigurateLCID_Test.java
@@ -1,0 +1,69 @@
+package com.sun.jna.platform.win32.COM.util;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
+import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
+import com.sun.jna.platform.win32.Ole32;
+import com.sun.jna.platform.win32.WinDef.LCID;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+
+public class ConfigurateLCID_Test {
+
+    private Factory factory;
+
+    @Before
+    public void before() {
+        Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
+        this.factory = new Factory();
+        // switch to english locale (the test is only valid if office is
+        // installed in a non-english locale
+        this.factory.setLCID(new LCID(0x0409)); 
+    }
+
+    @After
+    public void after() {
+        this.factory.disposeAll();
+        Ole32.INSTANCE.CoUninitialize();
+    }
+
+    @Test
+    @Ignore("Only valid for a non-english locale - run manually")
+    public void testDispatchBaseOnMethodName() throws InterruptedException {
+        ComExcel_Application excel = factory.createObject(ComExcel_Application.class);
+        ComIApplication excelApp = excel.queryInterface(ComIApplication.class);
+
+        // Set visiblite of application
+        excelApp.setProperty("Visible", false);
+        excelApp.setProperty("DisplayAlerts", false);
+
+        // Get a new workbook.
+        IDispatch wb = excelApp.getProperty(IDispatch.class, "Workbooks").invokeMethod(IDispatch.class, "Add");
+        IDispatch sheet = wb.getProperty(IDispatch.class, "ActiveSheet");
+
+        sheet.getProperty(IDispatch.class, "Range", "A1").setProperty("Value", 42);
+        sheet.getProperty(IDispatch.class, "Range", "A2").setProperty("Value", 23);
+        // Set formula with english command
+        sheet.getProperty(IDispatch.class, "Range", "A3").setProperty("Formula", "=SUM(A1:A2)");
+
+        Number result = sheet.getProperty(IDispatch.class, "Range", "A3").getProperty(Number.class, "Value");
+        
+        // The formula should report the sum
+        Assert.assertEquals(65, result.intValue());
+        
+        excelApp.invokeMethod(Void.class, "Quit");
+    }
+
+    @ComObject(progId = "Excel.Application")
+    public interface ComExcel_Application extends IUnknown {
+
+    }
+
+    @ComInterface(iid = "{000208D5-0000-0000-C000-000000000046}")
+    public interface ComIApplication extends IUnknown, IConnectionPoint, IDispatch {
+    }
+}


### PR DESCRIPTION
The system/user default LCID is not always the best/correct value to
use for COM invocations. One example is excel, if the default user
LCID is used, formulas need to be coded in the language of the user.

This commit moves the LCID handling into the factory, so LCID can be
overridden per instantiated factory.

A unittest was added, but marked as ignored, as the test is depending
on the installed excel locale and only usable on non-english locales.
(test was run on a german excel version)

In addition to the unittest the msoffice sample was adjusted to be
usable on non-english locales (manually tested on same german excel
version specified above).

Closes: #659