### PR TITLE
Fix #392 - Ensure XSI-compliant strerror_r is used.

### DIFF
--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -85,7 +85,6 @@ static inline char * STR_ERROR(int code, char * buf, size_t len) {
 #endif
 
 #include <stdlib.h>
-#include <alloca.h>
 #include <wchar.h>
 #include <jni.h>
 

--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -16,6 +16,10 @@
  * Lesser General Public License for more details.
  */
 
+#include "dispatch.h"
+
+#include <string.h>
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -45,6 +49,7 @@
 #else
 #include <dlfcn.h>
 #include <errno.h>
+#include <assert.h>
 #define STRTYPE char*
 #ifdef USE_DEFAULT_LIBNAME_ENCODING
 #define NAME2CSTR(ENV,JSTR) newCString(ENV,JSTR)
@@ -53,8 +58,21 @@
 #endif
 #define DEFAULT_LOAD_OPTS (RTLD_LAZY|RTLD_GLOBAL)
 #define LOAD_LIBRARY(NAME,OPTS) dlopen(NAME, OPTS)
-#define LOAD_ERROR(BUF,LEN) (snprintf(BUF, LEN, "%s", dlerror()), BUF)
-#define STR_ERROR(CODE,BUF,LEN) (strerror_r(CODE, BUF, LEN), BUF)
+static inline char * LOAD_ERROR(char * buf, size_t len) {
+    const size_t count = snprintf(buf, len, "%s", dlerror());
+    assert(count <= len && "snprintf() output has been truncated");
+    return buf;
+}
+static inline char * STR_ERROR(int code, char * buf, size_t len) {
+    // The conversion will fail if code is not a valid error code.
+    int err = strerror_r(code, buf, len);
+    if (err)
+        // Depending on glib version, "Unknown error" error code
+        // may be returned or passed using errno.
+        err = strerror_r(err > 0 ? err : errno, buf, len);
+    assert(err == 0 && "strerror_r() conversion has failed");
+    return buf;
+}
 #define FREE_LIBRARY(HANDLE) dlclose(HANDLE)
 #define FIND_ENTRY(HANDLE, NAME) dlsym(HANDLE, NAME)
 #endif
@@ -67,15 +85,9 @@
 #endif
 
 #include <stdlib.h>
-// Force XSI-compliant strerror_r (http://unixhelp.ed.ac.uk/CGI/man-cgi?strerror)
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 600
-#endif
-#include <string.h>
+#include <alloca.h>
 #include <wchar.h>
 #include <jni.h>
-
-#include "dispatch.h"
 
 #ifndef NO_JAWT
 #include <jawt.h>

--- a/native/dispatch.h
+++ b/native/dispatch.h
@@ -36,6 +36,7 @@
 #define GET_LAST_ERROR() GetLastError()
 #define SET_LAST_ERROR(CODE) SetLastError(CODE)
 #else
+#define _XOPEN_SOURCE 600
 #define GET_LAST_ERROR() errno
 #define SET_LAST_ERROR(CODE) (errno = (CODE))
 #endif /* _WIN32 */

--- a/native/dispatch.h
+++ b/native/dispatch.h
@@ -18,7 +18,7 @@
 #include "ffi.h"
 #include "com_sun_jna_Function.h"
 #include "com_sun_jna_Native.h"
-#if defined(__sun__) || defined(_AIX)
+#if defined(__sun__) || defined(_AIX) || defined(__linux__)
 #  include <alloca.h>
 #endif
 #ifdef _WIN32

--- a/native/protect.h
+++ b/native/protect.h
@@ -44,6 +44,7 @@
 #ifdef __GNUC__
 #include <excpt.h>
 #else
+#include <windows.h>
 // copied from mingw header
 typedef EXCEPTION_DISPOSITION (*PEXCEPTION_HANDLER)
   (struct _EXCEPTION_RECORD*, void*, struct _CONTEXT*, void*);

--- a/native/snprintf.h
+++ b/native/snprintf.h
@@ -1,5 +1,6 @@
 #ifndef _SNPRINTF_H
 #define _SNPRINTF_H
+#if _MSC_VER < 1900 // Before Visual Studio 2015
 // snprintf on windows is broken; always nul-terminate manually
 // DO NOT rely on the return value...
 static int snprintf(char * str, size_t size, const char * format, ...) {
@@ -10,4 +11,5 @@ static int snprintf(char * str, size_t size, const char * format, ...) {
   va_end(ap);
   return retval;
 }
+#endif
 #endif /* _SNPRINTF_H */


### PR DESCRIPTION
This `_XOPEN_SOURCE` macro was used after some standard header includes. [Which is not POSIX compliant](http://pubs.opengroup.org/onlinepubs/007904975/functions/xsh_chap02_02.html).

Depending on libc implementation, if one of theses headers were using `<string.h>`, the later presence of `_XOPEN_SOURCE` macro would't matter as the `<string.h>` would't be included again.

This prevents uninitialized buffer from being passed to `printf` (search for `STR_ERROR` in dispatch.c). 

Signed-off-by: David Keller <david.keller@enyx.fr>

