### PR TITLE
Shell32.SetCurrentProcessExplicitAppUserModelID

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Release 4.3 (Next release)
 
 Features
 --------
+* [#680](https://github.com/java-native-access/jna/pull/680): Added `SetCurrentProcessExplicitAppUserModelID` to `com.sun.jna.platform.win32.Shell32` for setting the [System.AppUserModel.ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569.aspx) of the `javaw` host process - [@rednoah](https://github.com/rednoah).
 * [#526](https://github.com/java-native-access/jna/pull/526): Added initialization and conversion between Windows SYSTEMTIME and Java Calendar - [@lgoldstein](https://github.com/lgoldstein).
 * [#532](https://github.com/java-native-access/jna/pull/529): Added `com.sun.jna.platform.win32.Mpr`, `com.sun.jna.platform.win32.LmShare`, and `com.sun.jna.platform.win32.Winnetwk` - [@amarcionek](https://github.com/amarcionek).
 * [#532](https://github.com/java-native-access/jna/pull/529): Added `ACCESS_*` definitions to `com.sun.jna.platform.win32.LmAccess` - [@amarcionek](https://github.com/amarcionek).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,6 @@ Release 4.3 (Next release)
 
 Features
 --------
-* [#680](https://github.com/java-native-access/jna/pull/680): Added `SetCurrentProcessExplicitAppUserModelID` to `com.sun.jna.platform.win32.Shell32` for setting the [System.AppUserModel.ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569.aspx) of the `javaw` host process - [@rednoah](https://github.com/rednoah).
 * [#526](https://github.com/java-native-access/jna/pull/526): Added initialization and conversion between Windows SYSTEMTIME and Java Calendar - [@lgoldstein](https://github.com/lgoldstein).
 * [#532](https://github.com/java-native-access/jna/pull/529): Added `com.sun.jna.platform.win32.Mpr`, `com.sun.jna.platform.win32.LmShare`, and `com.sun.jna.platform.win32.Winnetwk` - [@amarcionek](https://github.com/amarcionek).
 * [#532](https://github.com/java-native-access/jna/pull/529): Added `ACCESS_*` definitions to `com.sun.jna.platform.win32.LmAccess` - [@amarcionek](https://github.com/amarcionek).
@@ -56,6 +55,7 @@ Features
 * [#654](https://github.com/java-native-access/jna/pull/654): Support named arguments for `com.sun.jna.platform.win32.COM.util.CallbackProxy` based callbacks - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#659](https://github.com/java-native-access/jna/issues/659): Enable LCID (locale) override for `com.sun.jna.platform.win32.COM.util.ProxyObject`-based COM calls - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#665](https://github.com/java-native-access/jna/pull/665): Added `XSetWMProtocols` and `XGetWMProtocols` to `com.sun.jna.platform.unix.X11` - [@zainab-ali](https://github.com/zainab-ali).
+* [#680](https://github.com/java-native-access/jna/pull/680): Added `SetCurrentProcessExplicitAppUserModelID` and `GetCurrentProcessExplicitAppUserModelID` to `com.sun.jna.platform.win32.Shell32` for setting the [System.AppUserModel.ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569.aspx) of the host process - [@rednoah](https://github.com/rednoah).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
@@ -382,10 +382,8 @@ public interface Shell32 extends ShellAPI, StdCallLibrary {
      * Retrieves the application-defined, explicit Application User Model ID (AppUserModelID) for the current process.
      * 
      * @param ppszAppID
-     *            Type: PWSTR*<br>
      *            A pointer that receives the address of the AppUserModelID assigned to the process. The caller is responsible for freeing this string with {@link Ole32#CoTaskMemFree} when it is no longer needed.
-     * @return Type: HRESULT<br>
-     *         If this function succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
+     * @return If this function succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
      * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd378419(v=vs.85).aspx">MSDN</a>
      */
     HRESULT GetCurrentProcessExplicitAppUserModelID(PointerByReference ppszAppID);
@@ -394,10 +392,8 @@ public interface Shell32 extends ShellAPI, StdCallLibrary {
      * Specifies a unique application-defined Application User Model ID (AppUserModelID) that identifies the current process to the taskbar. This identifier allows an application to group its associated processes and windows under a single taskbar button.
      * 
      * @param appID
-     *            Type: PCWSTR<br>
      *            The AppUserModelID to assign to the current process.
-     * @return Type: HRESULT<br>
-     *         If this function succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
+     * @return If this function succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
      * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd378422(v=vs.85).aspx">MSDN</a>
      */
     HRESULT SetCurrentProcessExplicitAppUserModelID(WString appID);

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
@@ -13,6 +13,7 @@
 package com.sun.jna.platform.win32;
 
 import com.sun.jna.Native;
+import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.HICON;
@@ -376,5 +377,30 @@ public interface Shell32 extends ShellAPI, StdCallLibrary {
      * @see <a href="https://msdn.microsoft.com/en-us/library/ms648069(VS.85).aspx">MSDN</a>
      */
     int ExtractIconEx(String lpszFile, int nIconIndex, HICON[] phiconLarge, HICON[] phiconSmall, int nIcons);
+
+    /**
+     * Retrieves the application-defined, explicit Application User Model ID (AppUserModelID) for the current process.
+     * 
+     * @param ppszAppID
+     *            Type: PWSTR*<br>
+     *            A pointer that receives the address of the AppUserModelID assigned to the process. The caller is responsible for freeing this string with {@link Ole32#CoTaskMemFree} when it is no longer needed.
+     * @return Type: HRESULT<br>
+     *         If this function succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd378419(v=vs.85).aspx">MSDN</a>
+     */
+    HRESULT GetCurrentProcessExplicitAppUserModelID(PointerByReference ppszAppID);
+
+    /**
+     * Specifies a unique application-defined Application User Model ID (AppUserModelID) that identifies the current process to the taskbar. This identifier allows an application to group its associated processes and windows under a single taskbar button.
+     * 
+     * @param appID
+     *            Type: PCWSTR<br>
+     *            The AppUserModelID to assign to the current process.
+     * @return Type: HRESULT<br>
+     *         If this function succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd378422(v=vs.85).aspx">MSDN</a>
+     */
+    HRESULT SetCurrentProcessExplicitAppUserModelID(WString appID);
+
 }
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
@@ -17,6 +17,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import com.sun.jna.Native;
+import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.ShellAPI.APPBARDATA;
 import com.sun.jna.platform.win32.ShellAPI.SHELLEXECUTEINFO;
@@ -232,4 +233,18 @@ public class Shell32Test extends TestCase {
         int iconCount = Shell32.INSTANCE.ExtractIconEx(new File(winDir, "explorer.exe").getAbsolutePath(), -1, null, null, 1);
         assertTrue("Should be at least two icons in explorer.exe", iconCount > 1);
     }
+
+    public void testCurrentProcessExplicitAppUserModelID() {
+        String appUserModelID = "com.sun.jna.platform.win32.Shell32Test";
+
+        HRESULT r1 = Shell32.INSTANCE.SetCurrentProcessExplicitAppUserModelID(new WString(appUserModelID));
+        assertEquals(WinError.S_OK, r1);
+
+        PointerByReference ppszAppID = new PointerByReference();
+        HRESULT r2 = Shell32.INSTANCE.GetCurrentProcessExplicitAppUserModelID(ppszAppID);
+        assertEquals(WinError.S_OK, r2);
+
+        assertEquals(appUserModelID, ppszAppID.getPointer().getWideString(0));
+    }
+
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
@@ -244,9 +244,9 @@ public class Shell32Test extends TestCase {
         HRESULT r2 = Shell32.INSTANCE.GetCurrentProcessExplicitAppUserModelID(ppszAppID);
         assertEquals(WinError.S_OK, r2);
 
-        assertEquals(appUserModelID, ppszAppID.getPointer().getWideString(0));
+        assertEquals(appUserModelID, ppszAppID.getValue().getWideString(0));
 
-        Ole32.INSTANCE.CoTaskMemFree(ppszAppID.getPointer());
+        Ole32.INSTANCE.CoTaskMemFree(ppszAppID.getValue());
     }
 
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Shell32Test.java
@@ -245,6 +245,8 @@ public class Shell32Test extends TestCase {
         assertEquals(WinError.S_OK, r2);
 
         assertEquals(appUserModelID, ppszAppID.getPointer().getWideString(0));
+
+        Ole32.INSTANCE.CoTaskMemFree(ppszAppID.getPointer());
     }
 
 }


### PR DESCRIPTION
Added functions to Shell32 wrapper which are useful Desktop integration for Java GUI applications (on Windows 7 and higher).

- `SetCurrentProcessExplicitAppUserModelID`
- `GetCurrentProcessExplicitAppUserModelID`
