### PR TITLE
[Travis CI] OSX build error workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 
 install:
   - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew update || true'
+  - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew uninstall libtool && brew install libtool || true'
   - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew install ant || true'
 
 script:


### PR DESCRIPTION
Work around homebrew/glibtoolize interaaction bug on OSX El Capitain.

See if [this](https://github.com/libgd/libgd/issues/266) works, at least until the Travis folks get their OSX environment fixed up.