### PR TITLE
Added AppVeyor Windows CI [don't merge]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Java Native Access - JNA](https://github.com/java-native-access/jna/raw/master/www/images/jnalogo.jpg "Java Native Access - JNA")
 
 [![Build Status](https://travis-ci.org/java-native-access/jna.svg?branch=master)](https://travis-ci.org/java-native-access/jna)
+[![Build status](https://ci.appveyor.com/api/projects/status/j6vmpjrw5iktb8iu/branch/master?svg=true)](https://ci.appveyor.com/project/dblock/jna-gsxuq/branch/master)
 
 Java Native Access (JNA)
 ========================
@@ -64,7 +65,7 @@ JNA
 ---
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.java.dev.jna/jna/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.java.dev.jna/jna)&nbsp;[jna.jar](http://repo1.maven.org/maven2/net/java/dev/jna/jna/4.5.1/jna-4.5.1.jar)
-  
+
 This is the core artifact of JNA and contains only the binding library and the
 core helper classes.
 
@@ -73,8 +74,8 @@ JNA Platform
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.java.dev.jna/jna-platform/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.java.dev.jna/jna-platform) &nbsp; [jna-platform.jar](http://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/4.5.1/jna-platform-4.5.1.jar)
 
-This artifact holds cross-platform mappings and mappings for a number of commonly used platform 
-functions, including a large number of Win32 mappings as well as a set of utility classes 
+This artifact holds cross-platform mappings and mappings for a number of commonly used platform
+functions, including a large number of Win32 mappings as well as a set of utility classes
 that simplify native access. The code is tested and the utility interfaces ensure that
 native memory management is taken care of correctly.
 
@@ -172,5 +173,4 @@ License
 This library is licensed under the LGPL, version 2.1 or later, and (from version 4.0 onward) the Apache Software License, version 2.0. Commercial license arrangements are negotiable.
 
 *NOTE: Oracle is not sponsoring this project, even though the package name (com.sun.jna) might imply otherwise.*
-
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+os: Windows Server 2012
+
+environment:
+  ANT_VERSION: 1.9.7
+
+install:
+  - cmd: choco install ant -y -f -i > nul
+  - cmd: choco install cygwin -y -f -i > nul
+  - cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - cmd: set PATH=%JAVA_HOME%\bin;%PATH%
+  - cmd: '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"'
+  - cmd: refreshenv
+
+build_script:
+  - cmd: ant dist
+
+test_script:
+  - cmd: C:\cygwin\bin\sh -lc "uname -a;
+         cd /cygdrive/c/projects/jna;
+         ant test;
+         ant test-platform"
+


### PR DESCRIPTION
This configures AppVeyor and runs build and tests on Windows. It's currently failing due to a slew of unit tests, mostly because of missing dependencies, but some look legit. 

I am happy to babysit this PR, but I will need someone more committed to fix the issues.

This PR is being built in https://ci.appveyor.com/project/dblock/jna-gsxuq/build/1.0.1.

Complete build with test failures in https://ci.appveyor.com/project/dblock/jna/build/1.0.16.
