### PR TITLE
Correct Windows/Cygwin build error as reported in issue #603

### DIFF
--- a/native/libffi/msvcc.sh
+++ b/native/libffi/msvcc.sh
@@ -237,7 +237,7 @@ if [ -n "$assembly" ]; then
     fi
     ppsrc="$outdir/$(basename $src|sed 's/.S$/.asm/g')"
     echo "$cl -nologo -EP $includes $defines $src > $ppsrc"
-    "$cl" -nologo -EP $includes $defines $src > $ppsrc || exit $?
+    eval "\"$cl\" -nologo -EP $includes $defines $src > $ppsrc || exit $?"
     output="$(echo $output | sed 's%/F[dpa][^ ]*%%g')"
     args="-nologo $safeseh $single $output $ppsrc"
 


### PR DESCRIPTION
Prevents wrong quote surrounding that leads to 

> fatal error C1083: Cannot open include file: 'fficonfig.h': No such file or directory