### PR TITLE
Improve SAFEARRAY (Closeable, Autoconversion, VARIANT wrapping)

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Convert.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Convert.java
@@ -31,6 +31,7 @@ import com.sun.jna.platform.win32.WinDef.CHAR;
 import com.sun.jna.platform.win32.WinDef.LONG;
 import com.sun.jna.platform.win32.WinDef.SHORT;
 import com.sun.jna.platform.win32.OaIdl;
+import com.sun.jna.platform.win32.OaIdl.SAFEARRAY;
 import static com.sun.jna.platform.win32.Variant.VT_ARRAY;
 import static com.sun.jna.platform.win32.Variant.VT_BOOL;
 import static com.sun.jna.platform.win32.Variant.VT_BSTR;
@@ -50,7 +51,6 @@ import static com.sun.jna.platform.win32.Variant.VT_NULL;
 import static com.sun.jna.platform.win32.Variant.VT_R4;
 import static com.sun.jna.platform.win32.Variant.VT_R8;
 import static com.sun.jna.platform.win32.Variant.VT_RECORD;
-import static com.sun.jna.platform.win32.Variant.VT_SAFEARRAY;
 import static com.sun.jna.platform.win32.Variant.VT_UI1;
 import static com.sun.jna.platform.win32.Variant.VT_UI2;
 import static com.sun.jna.platform.win32.Variant.VT_UI4;
@@ -128,6 +128,8 @@ class Convert {
 		} else if (value instanceof IComEnum) {
 			IComEnum enm = (IComEnum) value;
 			return new VARIANT(new WinDef.LONG(enm.getValue()));
+                } else if (value instanceof SAFEARRAY) {
+                        return new VARIANT((SAFEARRAY) value);
 		} else {
 			return null;
 		}
@@ -243,8 +245,7 @@ class Convert {
                             break;
                         case VT_RECORD:
                         default:
-                            if ((varType & VT_ARRAY) > 0
-                                    || ((varType & VT_SAFEARRAY) > 0)) {
+                            if ((varType & VT_ARRAY) > 0) {
                                 targetClass = OaIdl.SAFEARRAY.class;
                             }
                     }

--- a/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
@@ -57,6 +57,7 @@ import static com.sun.jna.platform.win32.Variant.VT_UNKNOWN;
 import static com.sun.jna.platform.win32.Variant.VT_VARIANT;
 import com.sun.jna.ptr.ByReference;
 import com.sun.jna.ptr.PointerByReference;
+import java.io.Closeable;
 import java.util.Date;
 
 /**
@@ -509,7 +510,8 @@ public interface OaIdl {
     };
 
     /**
-     * General comment: All indices in the helper methods use java int.
+     * Implementation of SAFEARRAY. Implements Closable, which in this case 
+     * delegates to destroy, to free native memory on close.
      * 
      * <p>VARTYPE for the SAFEARRAY can be:</p>
      *
@@ -536,11 +538,14 @@ public interface OaIdl {
      * <li>VT_VARIANT</li>
      * </ul>
      * 
+     * <p>General comment: All indices in the helper methods use java int.</p>
+     * 
      * <p>The native type for the indices is LONG, which is defined as:</p>
      * 
      * <blockquote>A 32-bit signed integer. The range is �2147483648 through 2147483647 decimal.</blockquote>
      */
-    public static class SAFEARRAY extends Structure {
+    public static class SAFEARRAY extends Structure implements Closeable {
+
         public static class ByReference extends SAFEARRAY implements
                 Structure.ByReference {
         }
@@ -878,6 +883,13 @@ public interface OaIdl {
             COMUtils.checkRC(res);
         }
 
+        /**
+         * Implemented to satisfy Closeable interface, delegates to destroy.
+         */
+        public void close() {
+            destroy();
+        }
+        
         /**
          * Retrieve lower bound for the selected dimension.
          *

--- a/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
@@ -295,7 +295,7 @@ public interface Variant {
         }
         
         public void setValue(SAFEARRAY array) {
-            this.setValue(array.getVarType().intValue() | VT_SAFEARRAY, array);
+            this.setValue(array.getVarType().intValue() | VT_ARRAY, array);
         }
 
         public void setValue(VARTYPE vt, Object value) {
@@ -428,7 +428,7 @@ public interface Variant {
                 this._variant.__variant.writeField("pvRecord", value);
                 break;
             default:
-                if ((varType & VT_ARRAY) > 0 || (varType & VT_SAFEARRAY) > 0) {
+                if ((varType & VT_ARRAY) > 0) {
                     if ((varType & VT_BYREF) > 0) {
                         this._variant.__variant.writeField("pparray", value);
                     } else {
@@ -530,7 +530,7 @@ public interface Variant {
             case VT_RECORD:
                 return this._variant.__variant.readField("pvRecord");
             default:
-                if((varType & VT_ARRAY) > 0 || ((varType & VT_SAFEARRAY) > 0)) {
+                if((varType & VT_ARRAY) > 0) {
                     if((varType & VT_BYREF) > 0) {
                         return this._variant.__variant.readField("pparray");
                     } else {

--- a/contrib/platform/test/com/sun/jna/platform/win32/VariantTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/VariantTest.java
@@ -247,7 +247,7 @@ public class VariantTest extends TestCase {
         SAFEARRAY safearray = OaIdl.SAFEARRAY.createSafeArray(new VARTYPE(Variant.VT_I1), 5);
         try {
             VARIANT variant = new VARIANT(safearray);
-            assertThat(variant.getVarType().intValue(), equalTo((int) (Variant.VT_I1 | Variant.VT_SAFEARRAY)));
+            assertThat(variant.getVarType().intValue(), equalTo((int) (Variant.VT_I1 | Variant.VT_ARRAY)));
             Object wrappedValue = variant.getValue();
             assertThat(wrappedValue, instanceOf(SAFEARRAY.class));
             assertThat(safearray.getUBound(0), is(4));


### PR DESCRIPTION
- SAFEARRAY now implements Closeable - on recent java versions this
  allows handling SAFEARRAY using try-with-resource
- When wrapped in a VARIANT the correct type is not VT_SAFEARRAY, but
  VT_ARRAY or'd with the type of the SAFEARRAY elements
- VT_SAFEARRAY is not a valid value for VARIANT:
  https://msdn.microsoft.com/de-de/library/windows/desktop/ms221170(v=vs.85).aspx
- When used with com.sun.jna.platform.win32.com.util.ProxyObject
  SAFEARRAY is correctly wrapped into a VARIANT