### PR TITLE
Correct assumption about resolution of VT_DATE

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
@@ -231,12 +231,20 @@ public interface OaIdl {
 
         public Date getAsJavaDate() {
             long days = (((long) this.date) * MICRO_SECONDS_PER_DAY) + DATE_OFFSET;
-            int hours = (int) (24 * Math.abs(this.date - ((long) this.date)));
+            double timePart = 24 * Math.abs(this.date - ((long) this.date));
+            int hours = (int) timePart;
+            timePart = 60 * (timePart - ((int) timePart));
+            int minutes = (int) timePart;
+            timePart = 60 * (timePart - ((int) timePart));
+            int seconds = (int) timePart;
+            timePart = 1000 * (timePart - ((int) timePart));
+            int milliseconds = (int) timePart;
             
             Date baseDate = new Date(days);
             baseDate.setHours(hours);
-            baseDate.setMinutes(0);
-            baseDate.setSeconds(0);
+            baseDate.setMinutes(minutes);
+            baseDate.setSeconds(seconds);
+            baseDate.setTime(baseDate.getTime() + milliseconds);
             return baseDate;
         }
         
@@ -244,10 +252,16 @@ public interface OaIdl {
             double msSinceOrigin = javaDate.getTime() - DATE_OFFSET;
             double daysAsFract = msSinceOrigin / MICRO_SECONDS_PER_DAY;
             
-            double dayPart = Math.floor(daysAsFract);
-            double hourPart = Math.signum(daysAsFract) * (javaDate.getHours() / 24d);
+            Date dayDate = new Date(javaDate.getTime());
+            dayDate.setHours(0);
+            dayDate.setMinutes(0);
+            dayDate.setSeconds(0);
+            dayDate.setTime(dayDate.getTime() / 1000 * 1000); // Clear milliseconds
             
-            this.date = dayPart + hourPart;
+            double integralPart = Math.floor(daysAsFract);
+            double fractionalPart = Math.signum(daysAsFract) * ((javaDate.getTime() - dayDate.getTime()) / (24d * 60 * 60 * 1000));
+            
+            this.date = integralPart + fractionalPart;
         }
         
         @Override

--- a/contrib/platform/test/com/sun/jna/platform/win32/VariantTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/VariantTest.java
@@ -126,7 +126,17 @@ public class VariantTest extends TestCase {
         assertThat(new DATE(5.50d).getAsJavaDate(), equalTo(new Date(1900 - 1900, 1 - 1, 4, 12, 0, 0)));
         assertThat(new DATE(5.875d).getAsJavaDate(), equalTo(new Date(1900 - 1900, 1 - 1, 4, 21, 0, 0)));
         
+        // Test roundtripping with sub hour resolution
+        // This test allows for a rounding error of 500ms, this follows MSDN:
+        // https://msdn.microsoft.com/en-us/library/aa393691.aspx
+        // the resolution is higher, but it is not requested to be
         
+        // Date was choosen from the example that made the problem visible
+        // in testing
+        Date testDate = new Date(2016 - 1900, 10 - 1, 12, 2, 59, 19);
+        
+        assertTrue("java.util.Date -> com.sun.jna.platform.win32.OaIdl.DATE -> java.util.Date roundtrip failed",
+                Math.abs(new DATE(testDate).getAsJavaDate().getTime() - testDate.getTime()) < 500);
     }
 
     public void testVariantConstructors() {


### PR DESCRIPTION
It was interpreted, that the VT_DATA resolution was limited to hour
increments. At the time of this patch the whole way can't be reconstructed,
but tests in a production environment, comparing different COM
implementations (JIntegra and JNA) exposed the different interpreations.

The current implementation follows the advise from:

https://blogs.msdn.microsoft.com/joshpoley/2007/12/19/datetime-formats-and-conversions/

and the definition from (though this description does not show an example handling minutes):

https://msdn.microsoft.com/de-de/library/cc237601.aspx