### PR TITLE
Fix build with mingw-64 on windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,7 @@ Bug Fixes
 * [#664](https://github.com/java-native-access/jna/issues/664): Prevent premature GC of Pointer and Function objects by passing whole object into JNI call in addition to the raw pointer value - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#669](https://github.com/java-native-access/jna/pull/669): Ensure XSI-compliant strerror_r is used, to prevent corrupted error messages on linux - [@DavidKeller](https://github.com/DavidKeller).
 * [#697](https://github.com/java-native-access/jna/issues/697): Ensure disposed memory is removed from Memory#allocatedMemory map - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#731](https://github.com/java-native-access/jna/issues/731): Require mingw-w64 instead of mingw as the alternative to the MSVC build - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.2.1
 =============

--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -301,11 +301,8 @@ w32_short_name(JNIEnv* env, jstring str) {
     size_t size = wcslen(wstr) + 5;
     wchar_t* prefixed = (wchar_t*)alloca(sizeof(wchar_t) * size);
 
-#ifdef _MSC_VER
     swprintf(prefixed, size, L"\\\\?\\%ls", wstr);
-#else
-    swprintf(prefixed, L"\\\\?\\%ls", wstr);
-#endif
+
     if ((required = GetShortPathNameW(prefixed, NULL, 0)) != 0) {
       wchar_t* wshort = (wchar_t*)malloc(sizeof(wchar_t) * required);
       if (GetShortPathNameW(prefixed, wshort, required)) {
@@ -3067,11 +3064,9 @@ Java_com_sun_jna_Native_getWindowHandle0(JNIEnv* UNUSED_JAWT(env), jclass UNUSED
       const wchar_t* suffix = L"/bin/jawt.dll";
       size_t len = wcslen(prop) + wcslen(suffix) + 1;
       path = (wchar_t*)alloca(len * sizeof(wchar_t));
-#ifdef _MSC_VER
+
       swprintf(path, len, L"%s%s", prop, suffix);
-#else
-      swprintf(path, L"%s%s", prop, suffix);
-#endif
+      
       free((void *)prop);
     }
 #undef JAWT_NAME


### PR DESCRIPTION
mingw used to directly use the msvcrt implementation of swprintf which
does does not match the ANSI version. This was fixed in mingw-64 and
so this special case has to be removed.