### PR TITLE
Added MSWord COM Interfaces, Long properties to ComLateBindingObject, and JUnit 4 Tests.

### DIFF
--- a/contrib/msoffice/README.md
+++ b/contrib/msoffice/README.md
@@ -1,0 +1,19 @@
+This project contains wrappers for invoking Microsoft Word and Microsoft Excel using the JNA library.
+
+There are lines of development here: 
+
+* Pure OLE2 Automation, using the objects com.sun.jna.platform.win32.COM.office.MSWord and com.sun.jna.platform.win32.COM.MSExcel
+
+* Java Representation of COM Classes and Interfaces, using the objects under com.sun.jna.platform.win32.util.office
+
+The first approach is simpler to use than the second one; if there is no need for complex interactions with the API, or a simple Office automation is desired, then use the first approach.
+
+The second approach is more complex to use, and requires detailed knowledge of the COM interactions between the different objects. It is the best approach to implement complex interactions with the Microsoft Office applications from a Java application.
+
+There is a lot of work to be done for both approaches:
+
+* Transform JUnit 3 testcases into JUnit 4 testcases.
+* Convert "Demos" into JUnit 4 annotated testcases.
+* Write additional JUnit 4 annotated testcases.
+* Add all interfaces.
+* Add all operations of each interface.

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/office/MSWord.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/office/MSWord.java
@@ -111,6 +111,11 @@ public class MSWord extends COMLateBindingObject {
         public Documents(IDispatch iDispatch) throws COMException {
             super(iDispatch);
         }
+        
+        
+        public long getCount() {
+        	return this.getLongProperty("Count");
+        }
     }
 
     public class ActiveDocument extends COMLateBindingObject {

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/MSOfficeWordDemo.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/MSOfficeWordDemo.java
@@ -105,6 +105,8 @@ public class MSOfficeWordDemo {
 			msWord.getSelection().TypeText("Hello some changes from JNA!\n");
 			// save the document and prompt the user
 			msWord.getDocuments().Save(false, WdOriginalFormat.wdPromptUser);
+			long l=msWord.getDocuments().Count();
+			System.out.println("Number of documents:"+l);
 		} finally {
                         // Make sure the word instance is shut down
 			if (msWord != null) {

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIApplication.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIApplication.java
@@ -31,10 +31,25 @@ import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
 public interface ComIApplication {
 
 	@ComProperty
+	String getCaption();
+	
+	@ComProperty
+	void setCaption(String caption);
+	
+	@ComProperty
+	String getName();
+	
+	@ComProperty
 	String getVersion();
 
 	@ComProperty
 	boolean getVisible();
+	
+	@ComProperty
+	ComIWindows getWindows();
+	
+    @ComProperty
+	ComIWindow getActiveWindow();
 	
 	@ComProperty
 	void setVisible(boolean value);
@@ -45,16 +60,25 @@ public interface ComIApplication {
 	@ComProperty
 	ComISelection getSelection();
 	
+	//The normal template is the one that is assigned as default when creating a new document.
+	//The default name is "normal.dot", and it is located in the users local directory for office templates.
+	@ComProperty
+	ComITemplate getNormalTemplate();
+	
 	@ComProperty
 	ComIDocument getActiveDocument();
 
 	@ComMethod
 	void Quit();
 	
-        /**
-         * <p>
-         * id(0x172)</p>
-         */
-        @ComMethod(name = "InchesToPoints", dispId = 0x172)
-        Float InchesToPoints(Float Inches);
+    /**
+     * <p>
+     * id(0x172)</p>
+     */
+    @ComMethod(name = "InchesToPoints", dispId = 0x172)
+    Float InchesToPoints(Float Inches);
+
+    @ComMethod(name="Activate", dispId=0x181)
+	void Activate();
+
 }

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIApplication.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIApplication.java
@@ -50,6 +50,9 @@ public interface ComIApplication {
 	
     @ComProperty
 	ComIWindow getActiveWindow();
+    
+    @ComProperty
+    ComIOptions getOptions();
 	
 	@ComProperty
 	void setVisible(boolean value);

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIDocument.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIDocument.java
@@ -62,6 +62,16 @@ public interface ComIDocument {
         @ComProperty(name = "Tables", dispId = 0x6)
         Tables getTables();
         
+        @ComProperty
+        ComITemplate getAttachedTemplate();
+        
+        @ComProperty
+        void setSaved(boolean bSaved);
+        
+        @ComProperty
+        boolean getSaved();
+        
+        
         /**
          * <p>id(0x228)</p>
          */
@@ -81,4 +91,16 @@ public interface ComIDocument {
                 Boolean BitmapMissingFonts,
                 Boolean UseISO19005_1,
                 Object FixedFormatExtClassPtr);
+        
+        @ComMethod
+        void CheckGrammar();
+        
+        @ComMethod
+        void CheckSpelling();
+        
+        @ComMethod
+        void Repaginate();
+        
+
+        
 }

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIDocuments.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIDocuments.java
@@ -24,8 +24,12 @@
 package com.sun.jna.platform.win32.COM.util.office.word;
 
 import com.sun.jna.platform.win32.COM.util.annotation.ComMethod;
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
 
 public interface ComIDocuments {
+	
+	@ComProperty(name = "Count", dispId = 0x2)
+    Long Count();
 
 	@ComMethod
 	ComIDocument Open(String fileName);

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIDocuments.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIDocuments.java
@@ -36,6 +36,9 @@ public interface ComIDocuments {
 
 	@ComMethod
 	ComIDocument Add();
+	
+	@ComMethod
+	ComIDocument Add(String template);
 
 	@ComMethod
 	void Save(boolean noPrompt, WdOriginalFormat originalFormat);

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIOptions.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIOptions.java
@@ -1,0 +1,12 @@
+package com.sun.jna.platform.win32.COM.util.office.word;
+
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
+
+public interface ComIOptions {
+
+	@ComProperty
+	boolean getShowReadabilityStatistics();
+
+	@ComProperty
+	void setShowReadabilityStatistics(boolean b);
+}

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComISelection.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComISelection.java
@@ -25,11 +25,23 @@ package com.sun.jna.platform.win32.COM.util.office.word;
 
 import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
 import com.sun.jna.platform.win32.COM.util.annotation.ComMethod;
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
 
 @ComInterface
 public interface ComISelection {
 
 	@ComMethod
 	void TypeText(String text);
+	
+	@ComProperty
+	Range getRange();
+	
+	//Moves the end of the selection one unit toward the end of the document.
+	@ComMethod
+	long MoveEnd();
+	
+	//Moves the start of the selection one unit toward the start of the document.
+	@ComMethod
+	long MoveStart();
 	
 }

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComITemplate.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComITemplate.java
@@ -10,4 +10,10 @@ public interface ComITemplate {
 	
 	@ComProperty(name = "Application",dispId=0x3e8)
 	ComIApplication getApplication();
+	
+	@ComProperty
+	void setSaved(boolean bSaved);
+
+	@ComProperty
+	boolean getSaved();
 }

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComITemplate.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComITemplate.java
@@ -1,0 +1,13 @@
+package com.sun.jna.platform.win32.COM.util.office.word;
+
+import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
+
+public interface ComITemplate {
+
+	@ComProperty(name = "Name", dispId = 0x0)
+	String getName();
+	
+	@ComProperty(name = "Application",dispId=0x3e8)
+	ComIApplication getApplication();
+}

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIWindow.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIWindow.java
@@ -1,0 +1,15 @@
+package com.sun.jna.platform.win32.COM.util.office.word;
+
+import com.sun.jna.platform.win32.COM.util.annotation.ComMethod;
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
+
+public interface ComIWindow {
+	
+	
+	@ComMethod(name="SetFocus",dispId=0x6d)
+	void setFocus();
+	
+	@ComProperty
+	ComIApplication getApplication();
+
+}

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIWindow.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIWindow.java
@@ -12,4 +12,9 @@ public interface ComIWindow {
 	@ComProperty
 	ComIApplication getApplication();
 
+	@ComProperty
+	WdWindowState getWindowState();
+	
+	@ComProperty
+	void setWindowState(WdWindowState windowState);
 }

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIWindows.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/ComIWindows.java
@@ -1,0 +1,10 @@
+package com.sun.jna.platform.win32.COM.util.office.word;
+
+import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
+
+public interface ComIWindows {
+	
+	@ComProperty
+	Long getCount();
+
+}

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/Range.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/Range.java
@@ -42,7 +42,7 @@ public interface Range {
      * <p>id(0x0)</p>
      */
     @ComProperty(name = "Text", dispId = 0x0)
-    void setText(String param0);
+    void setText(String text);
         
     /**
      * <p>id(0x5)</p>
@@ -153,5 +153,8 @@ public interface Range {
      */
     @ComProperty(name = "InlineShapes", dispId = 0x13f)
     InlineShapes getInlineShapes();
+
+    @ComProperty
+	void setRange(long start,long end);
 
 }

--- a/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/WdWindowState.java
+++ b/contrib/msoffice/src/com/sun/jna/platform/win32/COM/util/office/word/WdWindowState.java
@@ -1,0 +1,23 @@
+package com.sun.jna.platform.win32.COM.util.office.word;
+
+import com.sun.jna.platform.win32.COM.util.IComEnum;
+
+public enum WdWindowState implements IComEnum{
+	
+	wdWindowStateNormal(0),
+	wdWindowStateMaximize(1),
+	wdWindowStateMinimize (2),
+
+	 ;
+	
+    private WdWindowState(long value) {
+        this.value = value;
+    }
+    
+    private long value;
+
+    public long getValue() {
+        return this.value;
+    }
+
+}

--- a/contrib/msoffice/test/com/sun/jna/platform/win32/COM/util/office/word/TestWordClasses.java
+++ b/contrib/msoffice/test/com/sun/jna/platform/win32/COM/util/office/word/TestWordClasses.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.COM.Helper;
+import com.sun.jna.platform.win32.COM.office.MSWord.Selection;
 import com.sun.jna.platform.win32.COM.util.Factory;
 
 /**
@@ -80,9 +81,6 @@ public class TestWordClasses{
 		//TEST STEP 1: Create documents, save as PDF, RTF, HTML, DOC. Open 3 documents
 		testWordDocuments();
 		
-		//TEST STEP 2: Test read the Count Property of the Word.Documents object. It should be 3
-		testLongProperties();
-		
 		//TEST STEP 3: Test the Normal Template property of the Word.Application
 		testNormalTemplate();
 		
@@ -95,11 +93,11 @@ public class TestWordClasses{
 		msWord.setCaption("MSWORD1");
 		msWord.setVisible(true);
 		msWord.Activate();
-		Helper.sleep(5);
+		Helper.sleep(1);
 		msWord2.Activate();
-		Helper.sleep(5);
+		Helper.sleep(1);
 		msWord.setVisible(false);
-		Helper.sleep(5);
+		Helper.sleep(1);
 		msWord2.setVisible(false);
 	}
 	
@@ -110,10 +108,25 @@ public class TestWordClasses{
 		System.out.println("There are two different word application instances running.");
 	}
 	
+	@Test
+	public void testApplicationOptions() throws Throwable {
+		
+		//TEST SHOWREADABILITYSTATISTICS
+		boolean b = msWord.getOptions().getShowReadabilityStatistics();
+		System.out.println("MSWORD1: ShowReadabilityStatistics is:"+b);
+		msWord2.getOptions().setShowReadabilityStatistics(true);
+		b=msWord2.getOptions().getShowReadabilityStatistics();
+		System.out.println("MSWORD2: ShowReadabilityStatistics is:"+b);
+		msWord2.getOptions().setShowReadabilityStatistics(false);
+		
+	}
+	
 	
 	private void testNormalTemplate() throws Exception {
 		ComITemplate normal = msWord.getNormalTemplate();
+		normal.setSaved(true);
 		System.out.println("Word Aplication Name of Normal Template:"+normal.getName());
+		System.out.println("Normal Template Saved Property (should be true):"+normal.getSaved());
 	}
 	
 	@Test
@@ -154,6 +167,9 @@ public class TestWordClasses{
 		msWord.setVisible(true);
 		ComIDocument doc1=msWord.getDocuments().Add();
 		ComIWindow window = msWord.getActiveWindow();
+		System.out.println("Window Stat is:"+window.getWindowState());
+		window.setWindowState(WdWindowState.wdWindowStateMaximize);
+		System.out.println("Window Stat is (should be Maximized(2)):"+window.getWindowState());
 		window.setFocus();
 		doc1.Close(false);
 		msWord.setVisible(false);
@@ -169,24 +185,24 @@ public class TestWordClasses{
 
 		msWord.setVisible(true);            
                
-		msWord.getDocuments().Open(demoDocument.getAbsolutePath());
+		ComIDocument doc=msWord.getDocuments().Open(demoDocument.getAbsolutePath());
                     
         Helper.sleep(1);
                     
 		msWord.getSelection().TypeText("Hello from JNA! \n\n");
 		// wait 10sec. before closing
-		Helper.sleep(10);
+		Helper.sleep(1);
 		// save in different formats
 		// pdf format is only supported in MSWord 2007 and above
-		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.doc").getAbsolutePath(), WdSaveFormat.wdFormatDocument);
-		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.pdf").getAbsolutePath(), WdSaveFormat.wdFormatPDF);
-		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.rtf").getAbsolutePath(), WdSaveFormat.wdFormatRTF);
-		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.html").getAbsolutePath(), WdSaveFormat.wdFormatHTML);
+		doc.SaveAs(new File(Helper.tempDir, "jnatestSaveAs.doc").getAbsolutePath(), WdSaveFormat.wdFormatDocument);
+		doc.SaveAs(new File(Helper.tempDir, "jnatestSaveAs.pdf").getAbsolutePath(), WdSaveFormat.wdFormatPDF);
+		doc.SaveAs(new File(Helper.tempDir, "jnatestSaveAs.rtf").getAbsolutePath(), WdSaveFormat.wdFormatRTF);
+		doc.SaveAs(new File(Helper.tempDir, "jnatestSaveAs.html").getAbsolutePath(), WdSaveFormat.wdFormatHTML);
 		// close and don't save the changes
-		msWord.getActiveDocument().Close(false);
+		doc.Close(false);
                     
                     // Create a new document
-		msWord.getDocuments().Add();
+		doc=msWord.getDocuments().Add();
 		// msWord.openDocument(currentWorkingDir + "jnatest.doc", true);
                     msWord.getSelection().TypeText(
                         "Hello from JNA! \n Please notice that JNA can control "
@@ -194,31 +210,59 @@ public class TestWordClasses{
                         + "creating a new word document and we save it "
                         + "to the 'TEMP' directory!");
                     // save with no user prompt
-		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestNewDoc1.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
-		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestNewDoc2.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
-		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestNewDoc3.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
+        System.out.println("jnatestNewDoc1.docx Saved property is:"+msWord.getActiveDocument().getSaved());
+        doc.SaveAs(new File(Helper.tempDir, "jnatestNewDoc1.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
+		System.out.println("jnatestNewDoc1.docx Saved property is:"+msWord.getActiveDocument().getSaved());
+		doc.SaveAs(new File(Helper.tempDir, "jnatestNewDoc2.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
+		doc.SaveAs(new File(Helper.tempDir, "jnatestNewDoc3.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
 		// close and don't save the changes
-		msWord.getActiveDocument().Close(false);
+		doc.Close(false);
                     
 		// open 3 documents
-		msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc1.docx").getAbsolutePath());
+		doc=msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc1.docx").getAbsolutePath());
 		msWord.getSelection().TypeText("Hello some changes from JNA!\n");
-		msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc2.docx").getAbsolutePath());
+		ComIDocument doc2=msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc2.docx").getAbsolutePath());
 		msWord.getSelection().TypeText("Hello some changes from JNA!\n");
-		msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc3.docx").getAbsolutePath());
+		
+		ComIDocument doc3=msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc3.docx").getAbsolutePath());
 		msWord.getSelection().TypeText("Hello some changes from JNA!\n");
 		// save the document and prompt the user
 		msWord.getDocuments().Save(false, WdOriginalFormat.wdPromptUser);
 		
+		ComISelection selection=msWord.getSelection();
+		Range range=msWord.getSelection().getRange();
+		range.setText("THIS IS A TEXT");
+		selection.MoveEnd();
+		selection.MoveEnd();
+		selection.MoveEnd();
+		selection.MoveEnd();//Selection Should be:THIS
+		String text=msWord.getSelection().getRange().getText();
+		Assert.assertTrue(text.trim().equals("THIS"));
+		System.out.println("TEXT is: "+text);
+		Helper.sleep(1);
+		ComITemplate template=	msWord.getActiveDocument().getAttachedTemplate();
+		System.out.println("Template used for document:"+template.getName());
+
+		long l=msWord.getDocuments().Count();
+		Assert.assertTrue(l==3L);
+		System.out.println("Number of documents(should be 3):"+l);
+		
+		doc.Close(false);
+		doc2.Close(false);
+		doc3.Close(false);
+		
+		ComIDocuments documents=msWord.getDocuments();
+		
+		doc= documents.Add(template.getName());
+		doc.CheckGrammar();
+		doc.CheckSpelling();
+		ComITemplate used_template = doc.getAttachedTemplate();
+		Assert.assertTrue(template.equals(used_template));
+		System.out.println("Template used to create a new document:"+used_template.getName());
+		Helper.sleep(1);
+		doc.Close(false);
 	}
 	
     
-	
-	private void testLongProperties() throws Exception {
-		long l=msWord.getDocuments().Count();
-		Assert.assertTrue(l==3L);
-		System.out.println("Number of documents:"+l);
-		
-	}
    
 }

--- a/contrib/msoffice/test/com/sun/jna/platform/win32/COM/util/office/word/TestWordClasses.java
+++ b/contrib/msoffice/test/com/sun/jna/platform/win32/COM/util/office/word/TestWordClasses.java
@@ -1,0 +1,142 @@
+/* Copyright (c) 2012 Tobias Wolf, All Rights Reserved
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.  
+ */
+
+package com.sun.jna.platform.win32.COM.util.office.word;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Ole32;
+import com.sun.jna.platform.win32.COM.Helper;
+import com.sun.jna.platform.win32.COM.util.Factory;
+
+/**
+ * @author joseluisll[at]gmail[dot]com
+ * 
+ * Test to test additions to the MS Word COM classes.
+ */
+public class TestWordClasses{
+    private static final String currentWorkingDir = new File("").getAbsolutePath() + File.separator;
+
+    File demoDocument = null;
+	ComIApplication msWord = null;
+	Factory factory = null;
+	ComWord_Application msWordObject = null;
+
+	@Before
+	public void setUP() throws Exception {
+		Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
+		
+		factory=new Factory();
+		msWordObject=factory.createObject(ComWord_Application.class);
+		msWord = msWordObject.queryInterface(ComIApplication.class);
+        demoDocument = Helper.createNotExistingFile("jnatest", ".doc");
+        Helper.extractClasspathFileToReal("/com/sun/jna/platform/win32/COM/util/office/resources/jnatest.doc", demoDocument);
+
+	}
+	
+	@After
+	public void cleanUP() throws Exception {
+		
+		if (msWord != null) {
+			msWord.Quit();
+		}
+                    
+        // Release all objects acquired by the factory
+        factory.disposeAll();
+        
+        if (demoDocument != null && demoDocument.exists()) {
+            demoDocument.delete();
+        }
+		
+		Ole32.INSTANCE.CoUninitialize();
+	}
+	
+	@Test
+	public void testMSWord() throws Throwable{
+		//TEST STEP 1: Create documents, save as PDF, RTF, HTML, DOC. Open 3 documents
+		testWordDocuments();
+		
+		//TEST STEP 2: Test read the Count Property of the Word.Documents object. It should be 3
+		testLongProperties();
+		
+	}
+	
+	
+	private void testWordDocuments() throws Exception {
+		
+
+		System.out.println("Files in temp dir: " + Helper.tempDir.getAbsolutePath());
+
+		System.out.println("MSWord version: " + msWord.getVersion());
+
+		msWord.setVisible(true);            
+               
+		msWord.getDocuments().Open(demoDocument.getAbsolutePath());
+                    
+        Helper.sleep(1);
+                    
+		msWord.getSelection().TypeText("Hello from JNA! \n\n");
+		// wait 10sec. before closing
+		Helper.sleep(10);
+		// save in different formats
+		// pdf format is only supported in MSWord 2007 and above
+		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.doc").getAbsolutePath(), WdSaveFormat.wdFormatDocument);
+		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.pdf").getAbsolutePath(), WdSaveFormat.wdFormatPDF);
+		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.rtf").getAbsolutePath(), WdSaveFormat.wdFormatRTF);
+		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestSaveAs.html").getAbsolutePath(), WdSaveFormat.wdFormatHTML);
+		// close and don't save the changes
+		msWord.getActiveDocument().Close(false);
+                    
+                    // Create a new document
+		msWord.getDocuments().Add();
+		// msWord.openDocument(currentWorkingDir + "jnatest.doc", true);
+                    msWord.getSelection().TypeText(
+                        "Hello from JNA! \n Please notice that JNA can control "
+                        + "MS Word via the new COM interface! \nHere we are "
+                        + "creating a new word document and we save it "
+                        + "to the 'TEMP' directory!");
+                    // save with no user prompt
+		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestNewDoc1.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
+		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestNewDoc2.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
+		msWord.getActiveDocument().SaveAs(new File(Helper.tempDir, "jnatestNewDoc3.docx").getAbsolutePath(), WdSaveFormat.wdFormatDocumentDefault);
+		// close and don't save the changes
+		msWord.getActiveDocument().Close(false);
+                    
+		// open 3 documents
+		msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc1.docx").getAbsolutePath());
+		msWord.getSelection().TypeText("Hello some changes from JNA!\n");
+		msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc2.docx").getAbsolutePath());
+		msWord.getSelection().TypeText("Hello some changes from JNA!\n");
+		msWord.getDocuments().Open(new File(Helper.tempDir, "jnatestNewDoc3.docx").getAbsolutePath());
+		msWord.getSelection().TypeText("Hello some changes from JNA!\n");
+		// save the document and prompt the user
+		msWord.getDocuments().Save(false, WdOriginalFormat.wdPromptUser);
+		
+	}
+	
+    
+	
+	private void testLongProperties() throws Exception {
+		long l=msWord.getDocuments().Count();
+		Assert.assertTrue(l==3L);
+		System.out.println("Number of documents:"+l);
+		
+	}
+   
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
@@ -588,6 +588,19 @@ public class COMLateBindingObject extends COMBindingBaseObject {
         this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
                 propertyName, new VARIANT(value));
     }
+    
+    /**
+     * Sets the property.
+     * 
+     * @param propertyName
+     *            the property name
+     * @param value
+     *            the value
+     */
+    protected void setProperty(String propertyName, long value) {
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
+                propertyName, new VARIANT(value));
+    }
 
     /**
      * Sets the property.

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
@@ -204,6 +204,21 @@ public class COMLateBindingObject extends COMBindingBaseObject {
 
         return result.shortValue();
     }
+    
+    /**
+     * Gets the long property.
+     * 
+     * @param propertyName
+     *            the property name
+     * @return the long property
+     */
+    protected long getLongProperty(String propertyName) {
+        VARIANT.ByReference result = new VARIANT.ByReference();
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
+                this.getIDispatch(), propertyName);
+
+        return result.longValue();
+    }
 
     /**
      * Gets the string property.


### PR DESCRIPTION
There was only short, string or boolean properties. On MSWord 14 typelib properties like count are declared long. Also, there is a number of MSWord interfaces that are not present in the current implementation. I intend to add a few, together with related operations and tests.