### PR TITLE
Adding security functions and RtlNtStatusToDosError to NtDll

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@ Features
 * [#689](https://github.com/java-native-access/jna/pull/689): Add `GetProcAddress(HMODULE, int)` to `com.sun.jna.platform.win32.Kernel32` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#723](https://github.com/java-native-access/jna/pull/723): Added `com.sun.jna.platform.win32.Wevtapi` and `com.sun.jna.platform.win32.Winevt` - [@sakamotodesu](https://github.com/sakamotodesu).
 * [#720](https://github.com/java-native-access/jna/issues/720): Added `SetThreadExecutionState` to `com.sun.jna.platform.win32.Kernel32` - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#738](https://github.com/java-native-access/jna/pull/738): Added `GetSecurityDescriptorOwner`, `SetSecurityDescriptorOwner`, `GetSecurityDescriptorGroup`, `SetSecurityDescriptorGroup`, `GetSecurityDescriptorControl`, `SetSecurityDescriptorControl`, `GetSecurityDescriptorDacl`, `SetSecurityDescriptorDacl`, `MakeSelfRelativeSD`, `MakeAbsoluteSD`, `EqualSid`, `InitializeSecurityDescriptor`, `InitializeAcl`, `AddAce`, `AddAccessAllowedAce`, `AddAccessAllowedAceEx`, and `GetAce` to `com.sun.jna.platform.win32.Advapi32 - [@amarcionek](https://github.com/amarcionek).
+* [#738](https://github.com/java-native-access/jna/pull/738): Added `RtlNtStatusToDosError` to `com.sun.jna.platform.win32.NtDll - [@amarcionek](https://github.com/amarcionek).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -43,6 +43,7 @@ import com.sun.jna.platform.win32.WinNT.PRIVILEGE_SET;
 import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.platform.win32.WinNT.PSIDByReference;
 import com.sun.jna.platform.win32.WinNT.SECURITY_DESCRIPTOR;
+import com.sun.jna.platform.win32.WinNT.SECURITY_DESCRIPTOR_RELATIVE;
 import com.sun.jna.platform.win32.WinReg.HKEY;
 import com.sun.jna.platform.win32.WinReg.HKEYByReference;
 import com.sun.jna.platform.win32.Winsvc.ChangeServiceConfig2Info;
@@ -311,6 +312,94 @@ public interface Advapi32 extends StdCallLibrary {
      *         information, call GetLastError.
      */
     boolean InitializeSecurityDescriptor(SECURITY_DESCRIPTOR pSecurityDescriptor, int dwRevision);
+
+    /**
+     * The GetSecurityDescriptorControl function retrieves a security descriptor control and revision information.
+     * @param pSecurityDescriptor
+     *              A pointer to a SECURITY_DESCRIPTOR structure whose control and revision
+     *              information the function retrieves.
+     * @param pControl
+     *              A pointer to a SECURITY_DESCRIPTOR_CONTROL structure that receives the security descriptor's
+     *              control information.
+     * @param lpdwRevision
+     *              A pointer to a variable that receives the security descriptor's revision value.
+     *              This value is always set, even when GetSecurityDescriptorControl returns an error.
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
+     */
+    boolean GetSecurityDescriptorControl(SECURITY_DESCRIPTOR pSecurityDescriptor, IntByReference pControl, IntByReference lpdwRevision);
+
+    /**
+     * The SetSecurityDescriptorControl function sets the control bits of a security descriptor. The function can set only the control
+     * bits that relate to automatic inheritance of ACEs. To set the other control bits of a security descriptor, use the functions,
+     * such as SetSecurityDescriptorDacl, for modifying the components of a security descriptor.
+     * @param pSecurityDescriptor
+     *              A pointer to a SECURITY_DESCRIPTOR structure whose control and revision information are set.
+     * @param ControlBitsOfInterest
+     *              A SECURITY_DESCRIPTOR_CONTROL mask that indicates the control bits to set.
+     * @param ControlBitsToSet
+     *               SECURITY_DESCRIPTOR_CONTROL mask that indicates the new values for the control bits specified by the ControlBitsOfInterest mask.
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
+     */
+    boolean SetSecurityDescriptorControl(SECURITY_DESCRIPTOR pSecurityDescriptor, int ControlBitsOfInterest, int ControlBitsToSet);
+
+    /**
+     * The SetSecurityDescriptorDacl function sets information in a discretionary access control list (DACL).
+     * If a DACL is already present in the security descriptor, the DACL is replaced.
+     * @param pSecurityDescriptor
+     *              A pointer to the SECURITY_DESCRIPTOR structure to which the function adds the DACL. This
+     *              security descriptor must be in absolute format, meaning that its members must be pointers
+     *              to other structures, rather than offsets to contiguous data.
+     * @param bDaclPresent
+     *              A flag that indicates the presence of a DACL in the security descriptor. If this parameter
+     *              is TRUE, the function sets the SE_DACL_PRESENT flag in the SECURITY_DESCRIPTOR_CONTROL
+     *              structure and uses the values in the pDacl and bDaclDefaulted parameters. If this parameter
+     *              is FALSE, the function clears the SE_DACL_PRESENT flag, and pDacl and bDaclDefaulted are ignored.
+     * @param pAcl
+     *              A pointer to an ACL structure that specifies the DACL for the security descriptor. If this
+     *              parameter is NULL, a NULL DACL is assigned to the security descriptor, which allows all access
+     *              to the object. The DACL is referenced by, not copied into, the security descriptor.
+     * @param bDaclDefaulted
+     *              A flag that indicates the source of the DACL. If this flag is TRUE, the DACL has been retrieved
+     *              by some default mechanism. If FALSE, the DACL has been explicitly specified by a user. The function
+     *              stores this value in the SE_DACL_DEFAULTED flag of the SECURITY_DESCRIPTOR_CONTROL structure. If
+     *              this parameter is not specified, the SE_DACL_DEFAULTED flag is cleared.
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
+     */
+    boolean SetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, boolean bDaclPresent, ACL pDacl, boolean bDaclDefaulted);
+
+    /**
+     * The GetSecurityDescriptorDacl function retrieves a pointer to the discretionary access control list (DACL) in
+     * a specified security descriptor.
+     * @param pSecurityDescriptor
+     *              A pointer to the SECURITY_DESCRIPTOR structure that contains the DACL. The function retrieves a pointer to it.
+     * @param bDaclPresent
+     *              A pointer to a value that indicates the presence of a DACL in the specified security descriptor. If
+     *              lpbDaclPresent is TRUE, the security descriptor contains a DACL, and the remaining output parameters in this
+     *              function receive valid values. If lpbDaclPresent is FALSE, the security descriptor does not contain a DACL,
+     *              and the remaining output parameters do not receive valid values. A value of TRUE for lpbDaclPresent does not
+     *              mean that pDacl is not NULL. That is, lpbDaclPresent can be TRUE while pDacl is NULL, meaning that a NULL
+     *              DACL is in effect. A NULL DACL implicitly allows all access to an object and is not the same as an empty DACL.
+     *              An empty DACL permits no access to an object. For information about creating a proper DACL, see Creating a DACL.
+     * @param pDacl
+     *              A pointer to a pointer to an access control list (ACL). If a DACL exists, the function sets the pointer pointed
+     *              to by pDacl to the address of the security descriptor's DACL. If a DACL does not exist, no value is stored.
+     *              If the function stores a NULL value in the pointer pointed to by pDacl, the security descriptor has a NULL DACL.
+     *              A NULL DACL implicitly allows all access to an object.
+     *              If an application expects a non-NULL DACL but encounters a NULL DACL, the application should fail securely and
+     *              not allow access.
+     * @param bDaclDefaulted
+     *              A pointer to a flag set to the value of the SE_DACL_DEFAULTED flag in the SECURITY_DESCRIPTOR_CONTROL structure
+     *              if a DACL exists for the security descriptor. If this flag is TRUE, the DACL was retrieved by a default mechanism;
+     *              if FALSE, the DACL was explicitly specified by a user.
+     * @return
+     */
+    boolean GetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, BOOLByReference bDaclPresent, PointerByReference pDacl, BOOLByReference bDaclDefaulted);
 
     /**
      * The InitializeAcl function initializes a new ACL structure.
@@ -2071,6 +2160,85 @@ public interface Advapi32 extends StdCallLibrary {
      * @return If the components of the security descriptor are valid, the return value is nonzero.
      */
     boolean IsValidSecurityDescriptor(Pointer ppSecurityDescriptor);
+
+    /**
+     * A pointer to a SECURITY_DESCRIPTOR structure in absolute format. The function creates a version of this security
+     * descriptor in self-relative format without modifying the original.
+     * @param pAbsoluteSD
+     *          A pointer to a SECURITY_DESCRIPTOR structure in absolute format. The function creates a version of this
+     *          security descriptor in self-relative format without modifying the original.
+     * @param pSelfRelativeSD
+     *          A pointer to a buffer the function fills with a security descriptor in self-relative format.
+     * @param lpdwBufferLength
+     *          A pointer to a variable specifying the size of the buffer pointed to by the pSelfRelativeSD parameter.
+     *          If the buffer is not large enough for the security descriptor, the function fails and sets this variable
+     *          to the minimum required size.
+     * @return If the function succeeds, the function returns nonzero. If the function fails, it returns zero. To get
+     *         extended error information, call GetLastError. Possible return codes include, but are not limited to, the following:
+     *         ERROR_INSUFFICIENT_BUFFER - One or more of the buffers is too small.
+     */
+    boolean MakeSelfRelativeSD(SECURITY_DESCRIPTOR pAbsoluteSD,
+                               SECURITY_DESCRIPTOR_RELATIVE pSelfRelativeSD,
+                               IntByReference lpdwBufferLength);
+
+    /**
+     * The MakeAbsoluteSD function creates a security descriptor in absolute format by using a
+     * security descriptor in self-relative format as a template.
+     * @param pSelfRelativeSD
+     *              A pointer to a SECURITY_DESCRIPTOR structure in self-relative format. The function creates an
+     *              absolute-format version of this security descriptor without modifying the original security descriptor.
+     * @param pAbsoluteSD
+     *              A pointer to a buffer that the function fills with the main body of an absolute-format security
+     *              descriptor. This information is formatted as a SECURITY_DESCRIPTOR structure.
+     * @param lpdwAbsoluteSDSize
+     *              A pointer to a variable that specifies the size of the buffer pointed to by the pAbsoluteSD parameter.
+     *              If the buffer is not large enough for the security descriptor, the function fails and sets this variable
+     *              to the minimum required size.
+     * @param pDacl
+     *              A pointer to a buffer the function fills with the discretionary access control list (DACL) of the
+     *              absolute-format security descriptor. The main body of the absolute-format security descriptor references
+     *              this pointer.
+     * @param lpdwDaclSize
+     *              A pointer to a variable that specifies the size of the buffer pointed to by the pDacl parameter. If
+     *              the buffer is not large enough for the access control list (ACL), the function fails and sets this
+     *              variable to the minimum required size.
+     * @param pSacl
+     *              A pointer to a buffer the function fills with the system access control list (SACL) of the absolute-format
+     *              security descriptor. The main body of the absolute-format security descriptor references this pointer.
+     * @param lpdwSaclSize
+     *              A pointer to a variable that specifies the size of the buffer pointed to by the pSacl parameter. If the
+     *              buffer is not large enough for the ACL, the function fails and sets this variable to the minimum required
+     *              size.
+     * @param pOwner
+     *              A pointer to a buffer the function fills with the security identifier (SID) of the owner of the
+     *              absolute-format security descriptor. The main body of the absolute-format security descriptor references
+     *              this pointer.
+     * @param lpdwOwnerSize
+     *              A pointer to a variable that specifies the size of the buffer pointed to by the pOwner parameter.
+     *              If the buffer is not large enough for the SID, the function fails and sets this variable to the minimum
+     *              required size.
+     * @param pPrimaryGroup
+     *              A pointer to a buffer the function fills with the SID of the absolute-format security descriptor's
+     *              primary group. The main body of the absolute-format security descriptor references this pointer.
+     * @param lpdwPrimaryGroupSize
+     *              A pointer to a variable that specifies the size of the buffer pointed to by the pPrimaryGroup parameter.
+     *              If the buffer is not large enough for the SID, the function fails and sets this variable to the minimum
+     *              required size.
+     * @return If the function succeeds, the function returns nonzero. If the function fails, it returns zero. To get
+     *         extended error information, call GetLastError. Possible return codes include, but are not limited to, the following:
+     *         ERROR_INSUFFICIENT_BUFFER - One or more of the buffers is too small.
+     */
+    boolean MakeAbsoluteSD(SECURITY_DESCRIPTOR_RELATIVE pSelfRelativeSD,
+                           SECURITY_DESCRIPTOR pAbsoluteSD,
+                           IntByReference lpdwAbsoluteSDSize,
+                           ACL pDacl,
+                           IntByReference lpdwDaclSize,
+                           ACL pSacl,
+                           IntByReference lpdwSaclSize,
+                           PSID pOwner,
+                           IntByReference lpdwOwnerSize,
+                           PSID pPrimaryGroup,
+                           IntByReference lpdwPrimaryGroupSize);
 
     /**
      * The IsValidAcl function validates an access control list (ACL).

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -347,31 +347,85 @@ public interface Advapi32 extends StdCallLibrary {
     boolean SetSecurityDescriptorControl(SECURITY_DESCRIPTOR pSecurityDescriptor, int ControlBitsOfInterest, int ControlBitsToSet);
 
     /**
-     * The SetSecurityDescriptorDacl function sets information in a discretionary access control list (DACL).
-     * If a DACL is already present in the security descriptor, the DACL is replaced.
+     * The GetSecurityDescriptorOwner function retrieves the owner information from a security descriptor.
      * @param pSecurityDescriptor
-     *              A pointer to the SECURITY_DESCRIPTOR structure to which the function adds the DACL. This
-     *              security descriptor must be in absolute format, meaning that its members must be pointers
-     *              to other structures, rather than offsets to contiguous data.
-     * @param bDaclPresent
-     *              A flag that indicates the presence of a DACL in the security descriptor. If this parameter
-     *              is TRUE, the function sets the SE_DACL_PRESENT flag in the SECURITY_DESCRIPTOR_CONTROL
-     *              structure and uses the values in the pDacl and bDaclDefaulted parameters. If this parameter
-     *              is FALSE, the function clears the SE_DACL_PRESENT flag, and pDacl and bDaclDefaulted are ignored.
-     * @param pDacl
-     *              A pointer to an ACL structure that specifies the DACL for the security descriptor. If this
-     *              parameter is NULL, a NULL DACL is assigned to the security descriptor, which allows all access
-     *              to the object. The DACL is referenced by, not copied into, the security descriptor.
-     * @param bDaclDefaulted
-     *              A flag that indicates the source of the DACL. If this flag is TRUE, the DACL has been retrieved
-     *              by some default mechanism. If FALSE, the DACL has been explicitly specified by a user. The function
-     *              stores this value in the SE_DACL_DEFAULTED flag of the SECURITY_DESCRIPTOR_CONTROL structure. If
-     *              this parameter is not specified, the SE_DACL_DEFAULTED flag is cleared.
+     *          A pointer to a SECURITY_DESCRIPTOR structure whose owner information the function retrieves.
+     * @param pOwner
+     *          A pointer to a pointer to a security identifier (SID) that identifies the owner when the function returns.
+     *          If the security descriptor does not contain an owner, the function sets the pointer pointed to by pOwner
+     *          to NULL and ignores the remaining output parameter, lpbOwnerDefaulted. If the security descriptor contains an owner,
+     *          the function sets the pointer pointed to by pOwner to the address of the security descriptor's owner SID
+     *          and provides a valid value for the variable pointed to by lpbOwnerDefaulted.
+     * @param lpbOwnerDefaulted
+     *          A pointer to a flag that is set to the value of the SE_OWNER_DEFAULTED flag in the SECURITY_DESCRIPTOR_CONTROL
+     *          structure when the function returns. If the value stored in the variable pointed to by the pOwner parameter is
+     *          NULL, no value is set.
      * @return If the function succeeds, the return value is nonzero. If the
      *         function fails, the return value is zero. For extended error
      *         information, call GetLastError.
      */
-    boolean SetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, boolean bDaclPresent, ACL pDacl, boolean bDaclDefaulted);
+    boolean GetSecurityDescriptorOwner(SECURITY_DESCRIPTOR pSecurityDescriptor, PointerByReference pOwner, BOOLByReference lpbOwnerDefaulted);
+
+    /**
+     * The SetSecurityDescriptorOwner function sets the owner information of an absolute-format security descriptor. It replaces
+     * any owner information already present in the security descriptor.
+     * @param pSecurityDescriptor
+     *          A pointer to the SECURITY_DESCRIPTOR structure whose owner is set by this function. The function replaces any existing
+     *          owner with the new owner.
+     * @param pOwner
+     *          A pointer to a SID structure for the security descriptor's new primary owner. The SID structure is referenced by, not
+     *          copied into, the security descriptor. If this parameter is NULL, the function clears the security descriptor's owner
+     *          information. This marks the security descriptor as having no owner.
+     * @param bOwnerDefaulted
+     *          Indicates whether the owner information is derived from a default mechanism. If this value is TRUE, it is default information.
+     *          The function stores this value as the SE_OWNER_DEFAULTED flag in the SECURITY_DESCRIPTOR_CONTROL structure. If this parameter
+     *          is zero, the SE_OWNER_DEFAULTED flag is cleared.
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
+     */
+    boolean SetSecurityDescriptorOwner(SECURITY_DESCRIPTOR pSecurityDescriptor, PSID pOwner, boolean bOwnerDefaulted);
+
+    /**
+     * The GetSecurityDescriptorGroup function retrieves the primary group information from a security descriptor.
+     * @param pSecurityDescriptor
+     *          A pointer to a SECURITY_DESCRIPTOR structure whose primary group information the function retrieves.
+     * @param pGroup
+     *          A pointer to a pointer to a security identifier (SID) that identifies the primary group when the function
+     *          returns. If the security descriptor does not contain a primary group, the function sets the pointer
+     *          pointed to by pGroup to NULL and ignores the remaining output parameter, lpbGroupDefaulted. If the
+     *          security descriptor contains a primary group, the function sets the pointer pointed to by pGroup to the
+     *          address of the security descriptor's group SID and provides a valid value for the variable pointed to
+     *          by lpbGroupDefaulted.
+     * @param lpbGroupDefaulted
+     *          A pointer to a flag that is set to the value of the SE_GROUP_DEFAULTED flag in the
+     *          SECURITY_DESCRIPTOR_CONTROL structure when the function returns. If the value stored in the variable
+     *          pointed to by the pGroup parameter is NULL, no value is set.
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
+     */
+    boolean GetSecurityDescriptorGroup(SECURITY_DESCRIPTOR pSecurityDescriptor, PointerByReference pGroup, BOOLByReference lpbGroupDefaulted);
+
+    /**
+     * The SetSecurityDescriptorGroup function sets the primary group information of an absolute-format security descriptor, replacing
+     * any primary group information already present in the security descriptor.
+     * @param pSecurityDescriptor
+     *          A pointer to the SECURITY_DESCRIPTOR structure whose primary group is set by this function. The function replaces
+     *          any existing primary group with the new primary group.
+     * @param pGroup
+     *          A pointer to a SID structure for the security descriptor's new primary group. The SID structure is referenced by, not copied
+     *          into, the security descriptor. If this parameter is NULL, the function clears the security descriptor's primary group
+     *          information. This marks the security descriptor as having no primary group.
+     * @param bGroupDefaulted
+     *          Indicates whether the primary group information was derived from a default mechanism. If this value is TRUE, it is default
+     *          information, and the function stores this value as the SE_GROUP_DEFAULTED flag in the SECURITY_DESCRIPTOR_CONTROL structure.
+     *          If this parameter is zero, the SE_GROUP_DEFAULTED flag is cleared.
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
+     */
+    boolean SetSecurityDescriptorGroup(SECURITY_DESCRIPTOR pSecurityDescriptor, PSID pGroup, boolean bGroupDefaulted);
 
     /**
      * The GetSecurityDescriptorDacl function retrieves a pointer to the discretionary access control list (DACL) in
@@ -402,6 +456,33 @@ public interface Advapi32 extends StdCallLibrary {
      *         information, call GetLastError.
      */
     boolean GetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, BOOLByReference bDaclPresent, PointerByReference pDacl, BOOLByReference bDaclDefaulted);
+
+    /**
+     * The SetSecurityDescriptorDacl function sets information in a discretionary access control list (DACL).
+     * If a DACL is already present in the security descriptor, the DACL is replaced.
+     * @param pSecurityDescriptor
+     *              A pointer to the SECURITY_DESCRIPTOR structure to which the function adds the DACL. This
+     *              security descriptor must be in absolute format, meaning that its members must be pointers
+     *              to other structures, rather than offsets to contiguous data.
+     * @param bDaclPresent
+     *              A flag that indicates the presence of a DACL in the security descriptor. If this parameter
+     *              is TRUE, the function sets the SE_DACL_PRESENT flag in the SECURITY_DESCRIPTOR_CONTROL
+     *              structure and uses the values in the pDacl and bDaclDefaulted parameters. If this parameter
+     *              is FALSE, the function clears the SE_DACL_PRESENT flag, and pDacl and bDaclDefaulted are ignored.
+     * @param pDacl
+     *              A pointer to an ACL structure that specifies the DACL for the security descriptor. If this
+     *              parameter is NULL, a NULL DACL is assigned to the security descriptor, which allows all access
+     *              to the object. The DACL is referenced by, not copied into, the security descriptor.
+     * @param bDaclDefaulted
+     *              A flag that indicates the source of the DACL. If this flag is TRUE, the DACL has been retrieved
+     *              by some default mechanism. If FALSE, the DACL has been explicitly specified by a user. The function
+     *              stores this value in the SE_DACL_DEFAULTED flag of the SECURITY_DESCRIPTOR_CONTROL structure. If
+     *              this parameter is not specified, the SE_DACL_DEFAULTED flag is cleared.
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
+     */
+    boolean SetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, boolean bDaclPresent, ACL pDacl, boolean bDaclDefaulted);
 
     /**
      * The InitializeAcl function initializes a new ACL structure.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -39,6 +39,7 @@ import com.sun.jna.platform.win32.WinNT.ACL;
 import com.sun.jna.platform.win32.WinNT.GENERIC_MAPPING;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
+import com.sun.jna.platform.win32.WinNT.PACLByReference;
 import com.sun.jna.platform.win32.WinNT.PRIVILEGE_SET;
 import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.platform.win32.WinNT.PSIDByReference;
@@ -53,6 +54,7 @@ import com.sun.jna.platform.win32.Winsvc.SERVICE_STATUS_PROCESS;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.ptr.ShortByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
 
@@ -328,7 +330,7 @@ public interface Advapi32 extends StdCallLibrary {
      *         function fails, the return value is zero. For extended error
      *         information, call GetLastError.
      */
-    boolean GetSecurityDescriptorControl(SECURITY_DESCRIPTOR pSecurityDescriptor, IntByReference pControl, IntByReference lpdwRevision);
+    boolean GetSecurityDescriptorControl(SECURITY_DESCRIPTOR pSecurityDescriptor, ShortByReference pControl, IntByReference lpdwRevision);
 
     /**
      * The SetSecurityDescriptorControl function sets the control bits of a security descriptor. The function can set only the control
@@ -344,7 +346,7 @@ public interface Advapi32 extends StdCallLibrary {
      *         function fails, the return value is zero. For extended error
      *         information, call GetLastError.
      */
-    boolean SetSecurityDescriptorControl(SECURITY_DESCRIPTOR pSecurityDescriptor, int ControlBitsOfInterest, int ControlBitsToSet);
+    boolean SetSecurityDescriptorControl(SECURITY_DESCRIPTOR pSecurityDescriptor, short ControlBitsOfInterest, short ControlBitsToSet);
 
     /**
      * The GetSecurityDescriptorOwner function retrieves the owner information from a security descriptor.
@@ -364,7 +366,7 @@ public interface Advapi32 extends StdCallLibrary {
      *         function fails, the return value is zero. For extended error
      *         information, call GetLastError.
      */
-    boolean GetSecurityDescriptorOwner(SECURITY_DESCRIPTOR pSecurityDescriptor, PointerByReference pOwner, BOOLByReference lpbOwnerDefaulted);
+    boolean GetSecurityDescriptorOwner(SECURITY_DESCRIPTOR pSecurityDescriptor, PSIDByReference pOwner, BOOLByReference lpbOwnerDefaulted);
 
     /**
      * The SetSecurityDescriptorOwner function sets the owner information of an absolute-format security descriptor. It replaces
@@ -405,7 +407,7 @@ public interface Advapi32 extends StdCallLibrary {
      *         function fails, the return value is zero. For extended error
      *         information, call GetLastError.
      */
-    boolean GetSecurityDescriptorGroup(SECURITY_DESCRIPTOR pSecurityDescriptor, PointerByReference pGroup, BOOLByReference lpbGroupDefaulted);
+    boolean GetSecurityDescriptorGroup(SECURITY_DESCRIPTOR pSecurityDescriptor, PSIDByReference pGroup, BOOLByReference lpbGroupDefaulted);
 
     /**
      * The SetSecurityDescriptorGroup function sets the primary group information of an absolute-format security descriptor, replacing
@@ -455,7 +457,7 @@ public interface Advapi32 extends StdCallLibrary {
      *         function fails, the return value is zero. For extended error
      *         information, call GetLastError.
      */
-    boolean GetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, BOOLByReference bDaclPresent, PointerByReference pDacl, BOOLByReference bDaclDefaulted);
+    boolean GetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, BOOLByReference bDaclPresent, PACLByReference pDacl, BOOLByReference bDaclDefaulted);
 
     /**
      * The SetSecurityDescriptorDacl function sets information in a discretionary access control list (DACL).

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -358,7 +358,7 @@ public interface Advapi32 extends StdCallLibrary {
      *              is TRUE, the function sets the SE_DACL_PRESENT flag in the SECURITY_DESCRIPTOR_CONTROL
      *              structure and uses the values in the pDacl and bDaclDefaulted parameters. If this parameter
      *              is FALSE, the function clears the SE_DACL_PRESENT flag, and pDacl and bDaclDefaulted are ignored.
-     * @param pAcl
+     * @param pDacl
      *              A pointer to an ACL structure that specifies the DACL for the security descriptor. If this
      *              parameter is NULL, a NULL DACL is assigned to the security descriptor, which allows all access
      *              to the object. The DACL is referenced by, not copied into, the security descriptor.
@@ -397,7 +397,9 @@ public interface Advapi32 extends StdCallLibrary {
      *              A pointer to a flag set to the value of the SE_DACL_DEFAULTED flag in the SECURITY_DESCRIPTOR_CONTROL structure
      *              if a DACL exists for the security descriptor. If this flag is TRUE, the DACL was retrieved by a default mechanism;
      *              if FALSE, the DACL was explicitly specified by a user.
-     * @return
+     * @return If the function succeeds, the return value is nonzero. If the
+     *         function fails, the return value is zero. For extended error
+     *         information, call GetLastError.
      */
     boolean GetSecurityDescriptorDacl(SECURITY_DESCRIPTOR pSecurityDescriptor, BOOLByReference bDaclPresent, PointerByReference pDacl, BOOLByReference bDaclDefaulted);
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
@@ -391,7 +391,7 @@ public abstract class Advapi32Util {
 
 	/**
      * Helper function to calculate the size of an ACE for a given PSID size
-     * @param pSid the PSID
+     * @param sidLength length of the sid
      * @return size of the ACE
      */
     public static int getAceSize(int sidLength) {

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
@@ -48,9 +48,7 @@ import static com.sun.jna.platform.win32.WinNT.TOKEN_QUERY;
 import static com.sun.jna.platform.win32.WinNT.UNPROTECTED_DACL_SECURITY_INFORMATION;
 import static com.sun.jna.platform.win32.WinNT.UNPROTECTED_SACL_SECURITY_INFORMATION;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -404,18 +402,6 @@ public abstract class Advapi32Util {
     }
 
     /**
-     * Get the first 4 bytes of the PSID for a SidStart
-     * @param psid the PSID
-     * @return the SidStart
-     * @throws IOException
-     */
-    public static int getSidStart(PSID psid) throws IOException {
-        byte[] sidStart = psid.getBytes();
-        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(sidStart));
-        return dis.readInt();
-    }
-
-	/**
 	 * Get an account name from a string SID on the local machine.
 	 *
 	 * @param sidString

--- a/contrib/platform/src/com/sun/jna/platform/win32/NTStatus.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/NTStatus.java
@@ -96,5 +96,14 @@ public interface NTStatus {
     //  STATUS_ABANDONED_WAIT_63
     //
     int  STATUS_ABANDONED_WAIT_63 = 0x000000BF;
+
+    //
+    // MessageId: STATUS_INVALID_OWNER
+    //
+    // MessageText:
+    //
+    //  Indicates a particular Security ID may not be assigned as the owner of an object.
+    //
+    int  STATUS_INVALID_OWNER = 0xC000005A;
 }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/NtDll.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/NtDll.java
@@ -115,4 +115,13 @@ public interface NtDll extends StdCallLibrary {
      *  NtQuerySecurityObject returns STATUS_SUCCESS or an appropriate error status.
      */
     public int NtQuerySecurityObject(HANDLE handle, int SecurityInformation, Pointer SecurityDescriptor, int Length, IntByReference LengthNeeded);
+
+    /**
+     * Converts the specified NTSTATUS code to its equivalent system error code.
+     * @param Status [in]
+     *  The NTSTATUS code to be converted.
+     * @return The function returns the corresponding system error code. ERROR_MR_MID_NOT_FOUND is returned when the specified NTSTATUS code
+     *  does not have a corresponding system error code.
+     */
+    public int RtlNtStatusToDosError(int Status);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -2581,6 +2581,31 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         }
     }
 
+    public static class PACLByReference extends ByReference {
+        public PACLByReference() {
+            this(null);
+        }
+
+        public PACLByReference(ACL h) {
+            super(Pointer.SIZE);
+            setValue(h);
+        }
+
+        public void setValue(ACL h) {
+            getPointer().setPointer(0, h != null ? h.getPointer() : null);
+        }
+
+        public ACL getValue() {
+            Pointer p = getPointer().getPointer(0);
+            if (p == null) {
+                return null;
+            }
+            else {
+                return new ACL(p);
+            }
+        }
+    }
+
     public static class SECURITY_DESCRIPTOR_RELATIVE extends Structure {
         public static class ByReference extends SECURITY_DESCRIPTOR_RELATIVE
                 implements Structure.ByReference {

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -2486,6 +2486,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         }
 
         public SECURITY_DESCRIPTOR(byte[] data) {
+            super();
             this.data = data;
             useMemory(new Memory(data.length));
         }
@@ -2521,6 +2522,12 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
 
     public static class ACL extends Structure {
         public static final List<String> FIELDS = createFieldsOrder("AclRevision", "Sbz1", "AclSize", "AceCount", "Sbz2");
+
+        /*
+         * Maximum size chosen based on technet article:
+         * https://technet.microsoft.com/en-us/library/cc781716.aspx
+         */
+        public static int MAX_ACL_SIZE = 64 * 1024;
 
         public byte AclRevision;
         public byte Sbz1;
@@ -2589,10 +2596,10 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         public int Sacl;
         public int Dacl;
 
-        private ACL DACL;
         private PSID OWNER;
         private PSID GROUP;
         private ACL SACL;
+        private ACL DACL;
 
         public SECURITY_DESCRIPTOR_RELATIVE() {
             super();
@@ -2602,6 +2609,10 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
             super(new Memory(data.length));
             getPointer().write(0, data, 0, data.length);
             setMembers();
+        }
+
+        public SECURITY_DESCRIPTOR_RELATIVE(int length) {
+            super(new Memory(length));
         }
 
         public SECURITY_DESCRIPTOR_RELATIVE(Pointer p) {

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -2778,6 +2778,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
             this.AceSize = (short) (super.fieldOffset("SidStart") + psid.getBytes().length);
             this.psid = psid;
             this.Mask = Mask;
+            this.SidStart = psid.getPointer().getByteArray(0, SidStart.length);
             this.allocateMemory(AceSize);
             write();
         }
@@ -2792,6 +2793,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
          */
         @Override
         public void write() {
+            super.write();
             int offsetOfSID = super.fieldOffset("SidStart");
             int sizeOfSID = super.AceSize - super.fieldOffset("SidStart");
             if(psid != null) {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -712,6 +712,44 @@ public class Advapi32Test extends TestCase {
         assertTrue(lpdwRevision.getValue() == WinNT.SECURITY_DESCRIPTOR_REVISION);
     }
 
+    public void testSetGetSecurityDescriptorOwner() {
+        SECURITY_DESCRIPTOR sd = new SECURITY_DESCRIPTOR(64 * 1024);
+        assertTrue(Advapi32.INSTANCE.InitializeSecurityDescriptor(sd, WinNT.SECURITY_DESCRIPTOR_REVISION));
+
+        PSID pSidPut = new PSID(WinNT.SECURITY_MAX_SID_SIZE);
+        IntByReference cbSid = new IntByReference(WinNT.SECURITY_MAX_SID_SIZE);
+        assertTrue("Failed to create well-known SID",
+                Advapi32.INSTANCE.CreateWellKnownSid(WELL_KNOWN_SID_TYPE.WinBuiltinAdministratorsSid, null, pSidPut, cbSid));
+
+        assertTrue(Advapi32.INSTANCE.SetSecurityDescriptorOwner(sd, pSidPut, true));
+
+        BOOLByReference lpbOwnerDefaulted = new BOOLByReference();
+        PointerByReference prSd = new PointerByReference(new Memory(WinNT.SECURITY_MAX_SID_SIZE));
+        assertTrue(Advapi32.INSTANCE.GetSecurityDescriptorOwner(sd, prSd, lpbOwnerDefaulted));
+
+        PSID pSidGet = new PSID(prSd.getValue());
+        assertTrue(Advapi32.INSTANCE.EqualSid(pSidPut, pSidGet));
+    }
+
+    public void testSetGetSecurityDescriptorGroup() {
+        SECURITY_DESCRIPTOR sd = new SECURITY_DESCRIPTOR(64 * 1024);
+        assertTrue(Advapi32.INSTANCE.InitializeSecurityDescriptor(sd, WinNT.SECURITY_DESCRIPTOR_REVISION));
+
+        PSID pSidPut = new PSID(WinNT.SECURITY_MAX_SID_SIZE);
+        IntByReference cbSid = new IntByReference(WinNT.SECURITY_MAX_SID_SIZE);
+        assertTrue("Failed to create well-known SID",
+                Advapi32.INSTANCE.CreateWellKnownSid(WELL_KNOWN_SID_TYPE.WinBuiltinAdministratorsSid, null, pSidPut, cbSid));
+
+        assertTrue(Advapi32.INSTANCE.SetSecurityDescriptorGroup(sd, pSidPut, true));
+
+        BOOLByReference lpbOwnerDefaulted = new BOOLByReference();
+        PointerByReference prSd = new PointerByReference(new Memory(WinNT.SECURITY_MAX_SID_SIZE));
+        assertTrue(Advapi32.INSTANCE.GetSecurityDescriptorGroup(sd, prSd, lpbOwnerDefaulted));
+
+        PSID pSidGet = new PSID(prSd.getValue());
+        assertTrue(Advapi32.INSTANCE.EqualSid(pSidPut, pSidGet));
+    }
+
     public void testSetGetSecurityDescriptorDacl() throws IOException {
         SECURITY_DESCRIPTOR sd = new SECURITY_DESCRIPTOR(64 * 1024);
         assertTrue(Advapi32.INSTANCE.InitializeSecurityDescriptor(sd, WinNT.SECURITY_DESCRIPTOR_REVISION));

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -62,6 +62,7 @@ import com.sun.jna.platform.win32.WinNT.EVENTLOGRECORD;
 import com.sun.jna.platform.win32.WinNT.GENERIC_MAPPING;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
+import com.sun.jna.platform.win32.WinNT.PACLByReference;
 import com.sun.jna.platform.win32.WinNT.PRIVILEGE_SET;
 import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.platform.win32.WinNT.PSIDByReference;
@@ -79,6 +80,7 @@ import com.sun.jna.platform.win32.Winsvc.SC_STATUS_TYPE;
 import com.sun.jna.platform.win32.Winsvc.SERVICE_STATUS_PROCESS;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.ptr.ShortByReference;
 
 import junit.framework.TestCase;
 
@@ -704,8 +706,8 @@ public class Advapi32Test extends TestCase {
     public void testSetGetSecurityDescriptorControl() {
         SECURITY_DESCRIPTOR sd = new SECURITY_DESCRIPTOR(64 * 1024);
         assertTrue(Advapi32.INSTANCE.InitializeSecurityDescriptor(sd, WinNT.SECURITY_DESCRIPTOR_REVISION));
-        assertTrue(Advapi32.INSTANCE.SetSecurityDescriptorControl(sd, WinNT.SE_DACL_PROTECTED, WinNT.SE_DACL_PROTECTED));
-        IntByReference pControl = new IntByReference();
+        assertTrue(Advapi32.INSTANCE.SetSecurityDescriptorControl(sd, (short)WinNT.SE_DACL_PROTECTED, (short)WinNT.SE_DACL_PROTECTED));
+        ShortByReference pControl = new ShortByReference();
         IntByReference lpdwRevision = new IntByReference();
         assertTrue(Advapi32.INSTANCE.GetSecurityDescriptorControl(sd, pControl, lpdwRevision));
         assertTrue(pControl.getValue() == WinNT.SE_DACL_PROTECTED);
@@ -724,10 +726,10 @@ public class Advapi32Test extends TestCase {
         assertTrue(Advapi32.INSTANCE.SetSecurityDescriptorOwner(sd, pSidPut, true));
 
         BOOLByReference lpbOwnerDefaulted = new BOOLByReference();
-        PointerByReference prSd = new PointerByReference(new Memory(WinNT.SECURITY_MAX_SID_SIZE));
+        PSIDByReference prSd = new PSIDByReference();
         assertTrue(Advapi32.INSTANCE.GetSecurityDescriptorOwner(sd, prSd, lpbOwnerDefaulted));
 
-        PSID pSidGet = new PSID(prSd.getValue());
+        PSID pSidGet = prSd.getValue();
         assertTrue(Advapi32.INSTANCE.EqualSid(pSidPut, pSidGet));
     }
 
@@ -743,10 +745,10 @@ public class Advapi32Test extends TestCase {
         assertTrue(Advapi32.INSTANCE.SetSecurityDescriptorGroup(sd, pSidPut, true));
 
         BOOLByReference lpbOwnerDefaulted = new BOOLByReference();
-        PointerByReference prSd = new PointerByReference(new Memory(WinNT.SECURITY_MAX_SID_SIZE));
+        PSIDByReference prSd = new PSIDByReference();
         assertTrue(Advapi32.INSTANCE.GetSecurityDescriptorGroup(sd, prSd, lpbOwnerDefaulted));
 
-        PSID pSidGet = new PSID(prSd.getValue());
+        PSID pSidGet = prSd.getValue();
         assertTrue(Advapi32.INSTANCE.EqualSid(pSidPut, pSidGet));
     }
 
@@ -772,9 +774,9 @@ public class Advapi32Test extends TestCase {
         assertTrue(Advapi32.INSTANCE.SetSecurityDescriptorDacl(sd, true, pAcl, false));
         BOOLByReference lpbDaclPresent  = new BOOLByReference();
         BOOLByReference lpbDaclDefaulted  = new BOOLByReference();
-        PointerByReference pDacl = new PointerByReference();
+        PACLByReference pDacl = new PACLByReference();
         assertTrue(Advapi32.INSTANCE.GetSecurityDescriptorDacl(sd, lpbDaclPresent, pDacl, lpbDaclDefaulted));
-        ACL pAclGet = new ACL(pDacl.getValue());
+        ACL pAclGet = pDacl.getValue();
         assertEquals(new BOOL(true), lpbDaclPresent.getValue());
         assertEquals(new BOOL(false), lpbDaclDefaulted.getValue());
         assertEquals(1, pAclGet.AceCount);

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -834,19 +834,15 @@ public class Advapi32Test extends TestCase {
 
         int sidLength = Advapi32.INSTANCE.GetLengthSid(pSid);
         cbAcl = Native.getNativeSize(ACL.class, null);
-        cbAcl += Native.getNativeSize(ACCESS_ALLOWED_ACE.class, null);
-        cbAcl += (sidLength - DWORD.SIZE);
+        cbAcl += Advapi32Util.getAceSize(sidLength);
         cbAcl = Advapi32Util.alignOnDWORD(cbAcl);
         pAcl = new ACL(cbAcl);
-        int cbAce = Advapi32Util.getAceSize(sidLength);
         ACCESS_ALLOWED_ACE pace = new ACCESS_ALLOWED_ACE(WinNT.STANDARD_RIGHTS_ALL,
-                Advapi32Util.getSidStart(pSid),
                 WinNT.INHERITED_ACE,
-                (short)cbAce,
                 pSid);
 
         assertTrue(Advapi32.INSTANCE.InitializeAcl(pAcl, cbAcl, WinNT.ACL_REVISION));
-        assertTrue(Advapi32.INSTANCE.AddAce(pAcl, WinNT.ACL_REVISION, WinNT.MAXDWORD, pace.getPointer(), cbAce));
+        assertTrue(Advapi32.INSTANCE.AddAce(pAcl, WinNT.ACL_REVISION, WinNT.MAXDWORD, pace.getPointer(), pace.size()));
 
         PointerByReference pAce = new PointerByReference(new Memory(16));
         assertTrue(Advapi32.INSTANCE.GetAce(pAcl, 0, pAce));
@@ -865,8 +861,7 @@ public class Advapi32Test extends TestCase {
 
         int sidLength = Advapi32.INSTANCE.GetLengthSid(pSid);
         cbAcl = Native.getNativeSize(ACL.class, null);
-        cbAcl += Native.getNativeSize(ACCESS_ALLOWED_ACE.class, null);
-        cbAcl += (sidLength - DWORD.SIZE);
+        cbAcl += Advapi32Util.getAceSize(sidLength);
         cbAcl = Advapi32Util.alignOnDWORD(cbAcl);
         pAcl = new ACL(cbAcl);
         assertTrue(Advapi32.INSTANCE.InitializeAcl(pAcl, cbAcl, WinNT.ACL_REVISION));
@@ -889,8 +884,7 @@ public class Advapi32Test extends TestCase {
 
         int sidLength = Advapi32.INSTANCE.GetLengthSid(pSid);
         cbAcl = Native.getNativeSize(ACL.class, null);
-        cbAcl += Native.getNativeSize(ACCESS_ALLOWED_ACE.class, null);
-        cbAcl += (sidLength - DWORD.SIZE);
+        cbAcl += Advapi32Util.getAceSize(sidLength);
         cbAcl = Advapi32Util.alignOnDWORD(cbAcl);
         pAcl = new ACL(cbAcl);
         assertTrue(Advapi32.INSTANCE.InitializeAcl(pAcl, cbAcl, WinNT.ACL_REVISION));

--- a/contrib/platform/test/com/sun/jna/platform/win32/NtDllTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/NtDllTest.java
@@ -105,6 +105,12 @@ public class NtDllTest extends TestCase {
         }
     }
 
+    public void testRtlNtStatusToDosError() {
+        int status = NTStatus.STATUS_INVALID_OWNER;
+        int error = NtDll.INSTANCE.RtlNtStatusToDosError(status);
+        assertEquals(W32Errors.ERROR_INVALID_OWNER, error);
+    }
+
     private File createTempFile() throws Exception {
         String filePath = System.getProperty("java.io.tmpdir") + System.nanoTime()
                 + ".text";


### PR DESCRIPTION
**Advapi32**
* GetSecurityDescriptorOwner
* SetSecurityDescriptorOwner
* GetSecurityDescriptorGroup
* SetSecurityDescriptorGroup
* GetSecurityDescriptorControl
* SetSecurityDescriptorControl
* GetSecurityDescriptorDacl
* SetSecurityDescriptorDacl
* MakeSelfRelativeSD
* MakeAbsoluteSD
* EqualSid
* InitializeSecurityDescriptor
* InitializeAcl
* AddAce
* AddAccessAllowedAce
* AddAccessAllowedAceEx
* GetAce

**NtDll**
* RtlNtStatusToDosError