### PR TITLE
Call `Native.toString()` in `#getFileName()` & `#getAlternateFileName()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,7 @@ Bug Fixes
 * [#669](https://github.com/java-native-access/jna/pull/669): Ensure XSI-compliant strerror_r is used, to prevent corrupted error messages on linux - [@DavidKeller](https://github.com/DavidKeller).
 * [#697](https://github.com/java-native-access/jna/issues/697): Ensure disposed memory is removed from Memory#allocatedMemory map - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#731](https://github.com/java-native-access/jna/issues/731): Require mingw-w64 instead of mingw as the alternative to the MSVC build - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#747](https://github.com/java-native-access/jna/issues/747): - Call `Native.toString()` in `#getFileName()` and `#getAlternateFileName()` in `c.s.j.p.win32.WinBase` instead of custom NUL terminator logic - [@jhult](https://github.com/jhult).
 
 Release 4.2.1
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -817,16 +817,14 @@ public interface WinBase extends WinDef, BaseTSD {
          * @return String containing the file name
          */
         public String getFileName() {
-            String actualFileName = new String(cFileName);
-            return actualFileName.substring(0, actualFileName.indexOf('\0'));
+            return Native.toString(cFileName);
         }
 
         /**
          * @return String containing the alternate file name
          */
         public String getAlternateFileName() {
-            String actualAlternateFileName = new String(cAlternateFileName);
-            return actualAlternateFileName.substring(0, actualAlternateFileName.indexOf('\0'));
+            return Native.toString(cAlternateFileName);
         }
     }
 


### PR DESCRIPTION
The custom logic which I removed, did not account for a missing NUL terminator. Plus, it is better to use logic already in the code base (e.g. `Native.toString()`).