### PR TITLE
Fix calling functions with only VarArgs (without fixed parameters)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Bug Fixes
 ---------
 * [#754](https://github.com/java-native-access/jna/issues/754): Move MSVC build to standard stdbool.h and require Visual C++ 2015 (sizeof(bool) = 1 is now also true on MSVC build) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#399](https://github.com/java-native-access/jna/issues/399): Check native version before attempting to call into native code - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#763](https://github.com/java-native-access/jna/issues/763): Fix vararg calls without fixed parts - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.3.0
 =============

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -327,10 +327,11 @@ public class Function extends Pointer {
 
         TypeMapper mapper = (TypeMapper)options.get(Library.OPTION_TYPE_MAPPER);
         boolean allowObjects = Boolean.TRUE.equals(options.get(Library.OPTION_ALLOW_OBJECTS));
+        boolean isVarArgs = args.length > 0 && invokingMethod != null ? isVarArgs(invokingMethod) : false;
         int fixedArgs = args.length > 0 && invokingMethod != null ? fixedArgs(invokingMethod) : 0;
         for (int i=0; i < args.length; i++) {
             Class<?> paramType = invokingMethod != null
-                ? (fixedArgs > 0 && i >= paramTypes.length-1
+                ? (isVarArgs && i >= paramTypes.length-1
                    ? paramTypes[paramTypes.length-1].getComponentType()
                    : paramTypes[i])
                 : null;

--- a/test/com/sun/jna/VarArgsTest.java
+++ b/test/com/sun/jna/VarArgsTest.java
@@ -43,6 +43,7 @@ public class VarArgsTest extends TestCase {
         public int addVarArgs(String fmt, Number... args);
         public String returnStringVarArgs(String fmt, Object... args);
         public void modifyStructureVarArgs(String fmt, Object arg1, Object... args);
+        public String returnStringVarArgs(String... args);
     }
     TestLibrary lib;
     @Override
@@ -87,6 +88,12 @@ public class VarArgsTest extends TestCase {
         Object[] args = new Object[] { "Test" };
         assertEquals("Did not return correct string", args[0],
                      lib.returnStringVarArgs("", args));
+    }
+
+    public void testStringVarArgsFull() {
+        Object[] args = new Object[] { "Test" };
+        assertEquals("Did not return correct string", args[0],
+                     lib.returnStringVarArgs("", "Test"));
     }
 
     public void testAppendNullToVarargs() {


### PR DESCRIPTION
The change in 50eb820c129d298c26035f98e6a93aed9fc52257 introduces
the detection of the count of the fixed parameters of a VarArgs call.

The logic detecting whether this call was even a VarArgs call was
changed to be true if fixed parameter count is not null. This is
not correct, as the method call could contain only fixed parameters
or a VarArgs call could be done without fixed parameters.

Closes: #763