### PR TITLE
Add Win32 API mapping for Shlwapi PathIsUNC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Release 4.3.1 (Next release)
 Features
 --------
 * [#757](https://github.com/java-native-access/jna/issues/757): Build android archive (AAR) - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#767](https://github.com/java-native-access/jna/pull/767): Add Win32 API mapping for Shlwapi PathIsUNC - [@ivanwick](https://github.com/ivanwick).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shlwapi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shlwapi.java
@@ -55,4 +55,15 @@ public interface Shlwapi extends StdCallLibrary {
      */
 
     HRESULT StrRetToStr(PointerByReference pstr, Pointer pidl, PointerByReference ppszName);
+
+    /**
+     * Determines if a path string is a valid Universal Naming Convention (UNC) path, as opposed to
+     * a path based on a drive letter.
+     *
+     * @param path
+     *            A string containing the path to validate.
+     *
+     * @return TRUE if the string is a valid UNC path; otherwise, FALSE.
+     */
+    boolean PathIsUNC(String path);
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/ShlwapiTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/ShlwapiTest.java
@@ -1,0 +1,24 @@
+package com.sun.jna.platform.win32;
+
+import junit.framework.TestCase;
+
+public class ShlwapiTest extends TestCase {
+
+    public static void main(String[] args) {
+        junit.textui.TestRunner.run(ShlwapiTest.class);
+    }
+
+    public void testPathIsUNC() {
+        assertEquals(true, Shlwapi.INSTANCE.PathIsUNC("\\\\path1\\path2"));
+        assertEquals(true, Shlwapi.INSTANCE.PathIsUNC("\\\\path1"));
+        assertEquals(false, Shlwapi.INSTANCE.PathIsUNC("acme\\\\path4\\\\path5"));
+        assertEquals(true, Shlwapi.INSTANCE.PathIsUNC("\\\\"));
+        assertEquals(true, Shlwapi.INSTANCE.PathIsUNC("\\\\?\\UNC\\path1\\path2"));
+        assertEquals(true, Shlwapi.INSTANCE.PathIsUNC("\\\\?\\UNC\\path1"));
+        assertEquals(true, Shlwapi.INSTANCE.PathIsUNC("\\\\?\\UNC\\"));
+        assertEquals(false, Shlwapi.INSTANCE.PathIsUNC("\\path1"));
+        assertEquals(false, Shlwapi.INSTANCE.PathIsUNC("path1"));
+        assertEquals(false, Shlwapi.INSTANCE.PathIsUNC("c:\\path1"));
+        assertEquals(false, Shlwapi.INSTANCE.PathIsUNC("\\\\?\\c:\\path1"));
+    }
+}


### PR DESCRIPTION
PathIsUNC checks whether a string is a valid UNC (Universal Naming Convention) path.

Unit tests were taken from the Microsoft API docs for this function at https://msdn.microsoft.com/en-us/library/windows/desktop/bb773712(v=vs.85).aspx