### PR TITLE
Fix for free data handle in DdemlUtil.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Bug Fixes
 * [#754](https://github.com/java-native-access/jna/issues/754): Move MSVC build to standard stdbool.h and require Visual C++ 2015 (sizeof(bool) = 1 is now also true on MSVC build) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#399](https://github.com/java-native-access/jna/issues/399): Check native version before attempting to call into native code - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#763](https://github.com/java-native-access/jna/issues/763): Fix vararg calls without fixed parts - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#770](https://github.com/java-native-access/jna/pull/770): Fix for free data handle in DdemlUtil. - [@stolarczykt](https://github.com/stolarczykt).
 
 Release 4.3.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
@@ -2561,6 +2561,7 @@ public interface Ddeml extends StdCallLibrary {
     public int DdeGetData(HDDEDATA hData, Pointer pDst, int cbMax, int cbOff);
 
     /**
+     * Provides access to the data in the specified Dynamic Data Exchange (DDE) object.
      * An application must call the DdeUnaccessData function when it has
      * finished accessing the data in the object.
      *

--- a/contrib/platform/src/com/sun/jna/platform/win32/DdemlUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/DdemlUtil.java
@@ -731,7 +731,7 @@ public abstract class DdemlUtil {
         }
 
         public void freeDataHandle(Ddeml.HDDEDATA hData) {
-            boolean result = Ddeml.INSTANCE.DdeUnaccessData(hData);
+            boolean result = Ddeml.INSTANCE.DdeFreeDataHandle(hData);
             if(! result) {
                 throw DdemlException.create(getLastError());
             }


### PR DESCRIPTION
I found an issue that `freeDataHandle(Ddeml.HDDEDATA hData)` from `DdemlUtil` was calling incorrect method from `Ddeml` so i fixed it.