### PR TITLE
Improve speed of GDIUtils.getScreenshot by ~30%

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features
 --------
 * [#757](https://github.com/java-native-access/jna/issues/757): Build android archive (AAR) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#767](https://github.com/java-native-access/jna/pull/767): Add Win32 API mapping for Shlwapi PathIsUNC - [@ivanwick](https://github.com/ivanwick).
+* [#772](https://github.com/java-native-access/jna/pull/772): Improved speed of GDIUtil.getScreenshot() by ~30% - [@sommd](https://github.com/sommd).
 
 Bug Fixes
 ---------


### PR DESCRIPTION
Instead of using setRGB on a newly created BufferedImage, create a from the pixel buffer and create the BufferedImage from that.

This is the same way that java.awt.Robot does it.