### PR TITLE
Fix W32APIMapperTest failing on non-CP1252 encodings

### DIFF
--- a/test/com/sun/jna/win32/W32APIMapperTest.java
+++ b/test/com/sun/jna/win32/W32APIMapperTest.java
@@ -34,8 +34,13 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 
 public class W32APIMapperTest extends TestCase {
-
-    final String UNICODE = "[\u0444]";
+    // Unicode Character 'SINGLE RIGHT-POINTING ANGLE QUOTATION MARK': ›
+    //
+    // byte encoding in CP1250-CP1258 is 155
+    //
+    // The requirement is, that the encoding is present in many native windows
+    // encodings and outside the ASCII range
+    final String UNICODE = "[\u203a]";
     final String MAGIC = "magic" + UNICODE;
 
     public static void main(String[] args) {


### PR DESCRIPTION
The choosen character \u0444 (CYRILLIC SMALL LETTER EF) is not present
in all CP* charsets. This change switches to \u203a 
'SINGLE RIGHT-POINTING ANGLE QUOTATION MARK': ›, which was found to
be present in CP1250-CP1258.

Closes: #779