### PR TITLE
Descriptive thread name for the User32Util message loop

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/User32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32Util.java
@@ -155,7 +155,12 @@ public final class User32Util {
         private volatile int nativeThreadId = 0;
         private volatile long javaThreadId = 0;
         private final List<FutureTask> workQueue = Collections.synchronizedList(new ArrayList<FutureTask>());
-        
+        private static long messageLoopId = 0;
+
+        public MessageLoopThread() {
+            setName("JNA User32 MessageLoop " + (++messageLoopId));
+        }
+
         @Override
         public void run() {
             MSG msg = new WinUser.MSG();


### PR DESCRIPTION
Hi,

I'd like to suggest the addition of an explicit thread name to the message loop in User32Util. This makes the thread clearly identifiable in debugging tools such as VisualVM or JProfiler.

Thank you