### PR TITLE
OaIdlUtil#toPrimitiveArray fails if dimension bounds are not 0-based

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Features
 Bug Fixes
 ---------
 * [#776](https://github.com/java-native-access/jna/issues/776): Do not include ClassPath attribute in MANIFEST.MF of jna-platform. - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#785](https://github.com/java-native-access/jna/issues/785): OaIdlUtil#toPrimitiveArray fails if dimension bounds are not 0-based - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.4.0
 =============


### PR DESCRIPTION
The declared bounds of the SAFEARRAY can be ignored, as the SAFEARRAY
is continuous and the toPrimitiveArray maps it to a plain "zero" based
java array. The access to the SAFEARRAY does not happen through the 
accessor methods, but via direct access to the underlying memory.

Closes: #785