### PR TITLE
Do not change property jna.nounpack if it did have value

### DIFF
--- a/src/com/sun/jna/Platform.java
+++ b/src/com/sun/jna/Platform.java
@@ -74,7 +74,8 @@ public final class Platform {
             if ("dalvik".equals(System.getProperty("java.vm.name").toLowerCase())) {
                 osType = ANDROID;
                 // Native libraries on android must be bundled with the APK
-                System.setProperty("jna.nounpack", "true");
+                if(null == System.getProperty("jna.nounpack"))
+                    System.setProperty("jna.nounpack", "true");
             }
             else {
                 osType = LINUX;

--- a/src/com/sun/jna/Platform.java
+++ b/src/com/sun/jna/Platform.java
@@ -74,8 +74,9 @@ public final class Platform {
             if ("dalvik".equals(System.getProperty("java.vm.name").toLowerCase())) {
                 osType = ANDROID;
                 // Native libraries on android must be bundled with the APK
-                if(null == System.getProperty("jna.nounpack"))
+                if(null == System.getProperty("jna.nounpack")) {
                     System.setProperty("jna.nounpack", "true");
+				}
             }
             else {
                 osType = LINUX;


### PR DESCRIPTION
android can also run normal java application,
if always set the property true,I should do so,
```java
        try{
            Class.forName(Platform.class.getName());
        }catch(Exception ignore){
        }
        System.setProperty("jna.nounpack","false");
```
https://github.com/AoEiuV020/RunJavaOnAndroid/blob/master/jna/src/main/java/aoeiuv020/Main.java
It's stupid,
if there is a check befor set in class Platform,
I should only set the property with single line,
