### PR TITLE
Add targetSdkVersion to AndroidManifest.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -562,6 +562,8 @@ osname=macosx;processor=x86;processor=x86-64;processor=ppc
     package="com.sun.jna"
     android:versionCode="]]>${android.versionCode}<![CDATA["
     android:versionName="]]>${jna.version}<![CDATA[" >
+
+    <uses-sdk android:targetSdkVersion="25" />
 </manifest> 
     ]]></echo>
     <zip zipfile="${build}/${aar}">


### PR DESCRIPTION
Not having a targetSdkVersion in the AndroidManifest means that the manifest merge tool will add some implicit permissions to Android apps. See [here](https://developer.android.com/studio/build/manifest-merge.html).

This is possible to override in the app, but is annoying to track down.

Also I'm pretty sure JNA by itself doesn't need these permissions, and that adding a targetSdkVersion shouldn't hurt anyone.