### PR TITLE
com.sun.jna.platform.win32.WinDef.WORDByReference holds a WORD (16bit)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Bug Fixes
 ---------
 * [#776](https://github.com/java-native-access/jna/issues/776): Do not include ClassPath attribute in MANIFEST.MF of jna-platform. - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#785](https://github.com/java-native-access/jna/issues/785): OaIdlUtil#toPrimitiveArray fails if dimension bounds are not 0-based - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#795](https://github.com/java-native-access/jna/issues/795): com.sun.jna.platform.win32.WinDef.WORDByReference holds a WORD which is defined to 16 bit on windows, so it needs to be accessed as short (getShort()). Fix suggested by  - [@kdeines](https://github.com/kdeines).
 
 Release 4.4.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
@@ -115,7 +115,7 @@ public interface WinDef {
          * @return the value
          */
         public WORD getValue() {
-            return new WORD(getPointer().getInt(0));
+            return new WORD(getPointer().getShort(0));
         }
     }
 


### PR DESCRIPTION
WORD is defined to hold 16 bit on windows, so it needs to be accessed 
as short (getShort()).

Closes: #795