### PR TITLE
Pointer documentation clarified

### DIFF
--- a/www/PointersAndArrays.md
+++ b/www/PointersAndArrays.md
@@ -10,7 +10,7 @@ Primitive array arguments (including structs) are represented by their correspon
     // Equivalent JNA mapping
     void fill_buffer(int[] buf, int len);
 
-NOTE: If the parameter is to be used by the native function outside the scope of the function call, you must use Memory or an NIO Buffer. The memory provided by a Java primitive array will only be valid for use by the native code for the duration of the function call.
+NOTE: If the parameter is to be used by the native function outside the scope of the function call, you must use Memory or an NIO direct Buffer. The memory provided by a Java primitive array will only be valid for use by the native code for the duration of the function call.
 
 Arrays of C strings (the `char* argv[]` to the C `main`, for example), may be represented by `String[]` in Java code. JNA will automatically pass an equivalent array with a `NULL` final element.
 


### PR DESCRIPTION
Am I wrong in adding this clarification? Looking at [`dispatch.c`](https://github.com/java-native-access/jna/blob/master/native/dispatch.c#L1305) it seems to me that only direct buffers can provide this guarantee. `Get##TYPE##ArrayElements` don't offer this guarantee once you do the `Release##TYPE##ArrayElements` right?