### PR TITLE
Main-Class in jna-platform.jar collides with java 9 module system

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Bug Fixes
 * [#776](https://github.com/java-native-access/jna/issues/776): Do not include ClassPath attribute in MANIFEST.MF of jna-platform. - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#785](https://github.com/java-native-access/jna/issues/785): OaIdlUtil#toPrimitiveArray fails if dimension bounds are not 0-based - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#795](https://github.com/java-native-access/jna/issues/795): com.sun.jna.platform.win32.WinDef.WORDByReference holds a WORD which is defined to 16 bit on windows, so it needs to be accessed as short (getShort()). Fix suggested by  - [@kdeines](https://github.com/kdeines).
+* [#804](https://github.com/java-native-access/jna/pull/804) Main-Class in jna-platform.jar collides with java 9 module system - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.4.0
 =============

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -102,7 +102,6 @@
     <target name="-pre-jar">
         <tempfile deleteonexit="true" destdir="${build.dir}" property="tmp.manifest.file"/>
         <manifest file="${tmp.manifest.file}" mode="replace">
-            <attribute name="Main-Class" value="com.sun.jna.Native"/>
             <attribute name="Manifest-Version" value="1.0"/>
             <attribute name="Implementation-Title" value="${impl.title}"/>
             <attribute name="Implementation-Vendor" value="${vendor}"/>


### PR DESCRIPTION
The java 9 module system expects the main class to reside in the same
jar, as the MANIFEST.MF. For the jna.jar the use case is valid to 
retrieve the current version of JNA, as jna.jar must be available
to run jna-platform.jar, there is no use-case to have the Main-Class
defined.

As reference the explanation from the jigsaw-dev mailing list:

http://mail.openjdk.java.net/pipermail/jigsaw-dev/2017-April/012151.html