### PR TITLE
Bugfix deadlock when Pointer and Native classes are loaded from different threads in parallel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,20 @@ NOTE: as of JNA 4.0, JNA is now dual-licensed under LGPL and AL 2.0 (see LICENSE
 
 NOTE: JNI native support is typically incompatible between minor versions, and almost always incompatible between major versions.
 
+At this point development of 4.5.0 and 5.0.0 happens in parallel. All changes
+committed to 4.5.0 will be pulled into 5.0.0. 5.0.0 is used to hold API
+breaks.
+
+Release 5.0.0 (Development)
+===========================
+
+Features
+--------
+
+Bug Fixes
+---------
+* [#652](https://github.com/java-native-access/jna/issues/652): Dead Lock in class initialization - [@matthiasblaesing](https://github.com/matthiasblaesing).
+
 Release 4.5.0 (Next release)
 ============================
 

--- a/build.xml
+++ b/build.xml
@@ -49,15 +49,15 @@
   <property name="javadoc" location="${doc}/javadoc"/>
   <property name="stylesheet" location="${javadoc}/doc/css/javadoc.css"/>
   <property name="vendor" value="JNA Development Team"/>
-  <property name="year" value="2016"/>
+  <property name="year" value="2017"/>
   <property name="copyright"
             value="Copyright &amp;copy; 2007-${year} Timothy Wall. All Rights Reserved."/>
   <buildnumber/>
   
   <property name="android.versionCode" value="2"/>
   <!-- JNA library release version -->
-  <property name="jna.major" value="4"/>
-  <property name="jna.minor" value="5"/>
+  <property name="jna.major" value="5"/>
+  <property name="jna.minor" value="0"/>
   <property name="jna.revision" value="0"/>
   <property name="jna.build" value="0"/> <!--${build.number}-->
   <condition property="version.suffix" value="" else="-SNAPSHOT">

--- a/contrib/platform/src/com/sun/jna/platform/win32/BaseTSD.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/BaseTSD.java
@@ -24,6 +24,7 @@
 package com.sun.jna.platform.win32;
 
 import com.sun.jna.IntegerType;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.ByReference;
 
@@ -44,7 +45,7 @@ public interface BaseTSD {
         }
 
         public LONG_PTR(long value) {
-            super(Pointer.SIZE, value);
+            super(Native.POINTER_SIZE, value);
         }
 
         public Pointer toPointer() {
@@ -74,7 +75,7 @@ public interface BaseTSD {
         }
 
         public ULONG_PTR(long value) {
-            super(Pointer.SIZE, value, true);
+            super(Native.POINTER_SIZE, value, true);
         }
 
         public Pointer toPointer() {
@@ -90,11 +91,11 @@ public interface BaseTSD {
             this(new ULONG_PTR(0));
         }
         public ULONG_PTRByReference(ULONG_PTR value) {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
             setValue(value);
         }
         public void setValue(ULONG_PTR value) {
-            if (Pointer.SIZE == 4) {
+            if (Native.POINTER_SIZE == 4) {
                 getPointer().setInt(0, value.intValue());
             }
             else {
@@ -102,7 +103,7 @@ public interface BaseTSD {
             }
         }
         public ULONG_PTR getValue() {
-            return new ULONG_PTR(Pointer.SIZE == 4
+            return new ULONG_PTR(Native.POINTER_SIZE == 4
                                  ? getPointer().getInt(0)
                                  : getPointer().getLong(0));
         }
@@ -118,7 +119,7 @@ public interface BaseTSD {
         }
 
         public DWORD_PTR(long value) {
-            super(Pointer.SIZE, value);
+            super(Native.POINTER_SIZE, value);
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMInvoker.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMInvoker.java
@@ -24,6 +24,7 @@
 package com.sun.jna.platform.win32.COM;
 
 import com.sun.jna.Function;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 
@@ -34,7 +35,7 @@ public abstract class COMInvoker extends PointerType {
         // we take the vtable id and multiply with the pointer size (4 bytes on
         // 32bit OS)
         Function func = Function.getFunction(vptr.getPointer(vtableId
-                * Pointer.SIZE));
+                * Native.POINTER_SIZE));
         return func.invokeInt(args);
     }
 
@@ -43,7 +44,7 @@ public abstract class COMInvoker extends PointerType {
         // we take the vtable id and multiply with the pointer size (4 bytes on
         // 32bit OS)
         Function func = Function.getFunction(vptr.getPointer(vtableId
-                * Pointer.SIZE));
+                * Native.POINTER_SIZE));
         return func.invoke(returnType, args);
     }
 
@@ -52,7 +53,7 @@ public abstract class COMInvoker extends PointerType {
         // we take the vtable id and multiply with the pointer size (4 bytes on
         // 32bit OS)
         Function func = Function.getFunction(vptr.getPointer(vtableId
-                * Pointer.SIZE));
+                * Native.POINTER_SIZE));
         func.invokeVoid(args);
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
@@ -157,7 +157,7 @@ public interface WTypes {
 
     public class BSTRByReference extends ByReference {
         public BSTRByReference() {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
         }
 
         public BSTRByReference(BSTR value) {

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -50,7 +50,7 @@ public interface WinBase extends WinDef, BaseTSD {
 
     /** Constant value representing an invalid HANDLE. */
     HANDLE INVALID_HANDLE_VALUE =
-        new HANDLE(Pointer.createConstant(Pointer.SIZE == 8
+        new HANDLE(Pointer.createConstant(Native.POINTER_SIZE == 8
                                           ? -1 : 0xFFFFFFFFL));
 
     int WAIT_FAILED = 0xFFFFFFFF;

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
@@ -683,7 +683,7 @@ public interface WinDef {
          * Instantiates a new int ptr.
          */
         public INT_PTR() {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
         }
 
         /**
@@ -693,7 +693,7 @@ public interface WinDef {
          *            the value
          */
         public INT_PTR(long value) {
-            super(Pointer.SIZE, value);
+            super(Native.POINTER_SIZE, value);
         }
 
         /**
@@ -715,7 +715,7 @@ public interface WinDef {
          * Instantiates a new uint ptr.
          */
         public UINT_PTR() {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
         }
 
         /**
@@ -725,7 +725,7 @@ public interface WinDef {
          *            the value
          */
         public UINT_PTR(long value) {
-            super(Pointer.SIZE, value, true);
+            super(Native.POINTER_SIZE, value, true);
         }
 
         /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -394,7 +394,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         }
 
         public PSIDByReference(PSID h) {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
             setValue(h);
         }
 
@@ -1393,7 +1393,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         }
 
         public HANDLEByReference(HANDLE h) {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
             setValue(h);
         }
 
@@ -2605,7 +2605,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         }
 
         public PACLByReference(ACL h) {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
             setValue(h);
         }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinReg.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinReg.java
@@ -23,6 +23,7 @@
  */
 package com.sun.jna.platform.win32;
 
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.ByReference;
@@ -48,7 +49,7 @@ public interface WinReg {
         }
         
         public HKEYByReference(HKEY h) {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
             setValue(h);
         }
         

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.sun.jna.Callback;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Union;
@@ -198,9 +199,9 @@ public interface WinUser extends WinDef {
     int GWL_USERDATA = -21;
     int GWL_HWNDPARENT = -8;
 
-    int DWL_DLGPROC = Pointer.SIZE;
+    int DWL_DLGPROC = Native.POINTER_SIZE;
     int DWL_MSGRESULT = 0;
-    int DWL_USER = 2*Pointer.SIZE;
+    int DWL_USER = 2*Native.POINTER_SIZE;
 
     /* Window Styles */
 

--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -363,7 +363,7 @@ public class CallbackReference extends WeakReference<Callback> {
 
     /** Set the behavioral options for this callback. */
     private void setCallbackOptions(int options) {
-        cbstruct.setInt(Pointer.SIZE, options);
+        cbstruct.setInt(Native.POINTER_SIZE, options);
     }
 
     /** Obtain a pointer to the native glue code for this callback. */

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -381,7 +381,7 @@ public class Function extends Pointer {
                             Class<?> type = inArg.getClass().getComponentType();
                             Structure[] ss = (Structure[])inArg;
                             for (int si=0;si < ss.length;si++) {
-                                Pointer p = array.getPointer(Pointer.SIZE * si);
+                                Pointer p = array.getPointer(Native.POINTER_SIZE * si);
                                 ss[si] = Structure.updateStructureByReference(type, ss[si], p);
                             }
                         }
@@ -814,12 +814,12 @@ public class Function extends Pointer {
     private static class PointerArray extends Memory implements PostCallRead {
         private final Pointer[] original;
         public PointerArray(Pointer[] arg) {
-            super(Pointer.SIZE * (arg.length+1));
+            super(Native.POINTER_SIZE * (arg.length+1));
             this.original = arg;
             for (int i=0;i < arg.length;i++) {
-                setPointer(i*Pointer.SIZE, arg[i]);
+                setPointer(i*Native.POINTER_SIZE, arg[i]);
             }
-            setPointer(Pointer.SIZE*arg.length, null);
+            setPointer(Native.POINTER_SIZE*arg.length, null);
         }
         @Override
         public void read() {

--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -537,7 +537,7 @@ public class Memory extends Pointer {
      */
     @Override
     public Pointer getPointer(long offset) {
-        boundsCheck(offset, Pointer.SIZE);
+        boundsCheck(offset, Native.POINTER_SIZE);
         return super.getPointer(offset);
     }
 
@@ -689,7 +689,7 @@ public class Memory extends Pointer {
      */
     @Override
     public void setPointer(long offset, Pointer value) {
-        boundsCheck(offset, Pointer.SIZE);
+        boundsCheck(offset, Native.POINTER_SIZE);
         super.setPointer(offset, value);
     }
 

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -210,7 +210,7 @@ public final class Native implements Version {
         WCHAR_SIZE = sizeof(TYPE_WCHAR_T);
         SIZE_T_SIZE = sizeof(TYPE_SIZE_T);
         BOOL_SIZE = sizeof(TYPE_BOOL);
-
+        
         // Perform initialization of other JNA classes until *after*
         // initializing the above final fields
         initIDs();

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -113,8 +113,8 @@ public final class Native implements Version {
 
     // Used by tests, do not remove
     static String jnidispatchPath = null;
-    private static final Map<Class<?>, Map<String, Object>> typeOptions = new WeakHashMap<Class<?>, Map<String, Object>>();
-    private static final Map<Class<?>, Reference<?>> libraries = new WeakHashMap<Class<?>, Reference<?>>();
+    private static final Map<Class<?>, Map<String, Object>> typeOptions = Collections.synchronizedMap(new WeakHashMap<Class<?>, Map<String, Object>>());
+    private static final Map<Class<?>, Reference<?>> libraries = Collections.synchronizedMap(new WeakHashMap<Class<?>, Reference<?>>());
     private static final String _OPTION_ENCLOSING_LIBRARY = "enclosing-library";
     private static final UncaughtExceptionHandler DEFAULT_HANDLER =
         new UncaughtExceptionHandler() {
@@ -579,24 +579,22 @@ public final class Native implements Version {
      * Expects that lock on libraries is already held
      */
     private static void loadLibraryInstance(Class<?> cls) {
-        synchronized(libraries) {
-            if (cls != null && !libraries.containsKey(cls)) {
-                try {
-                    Field[] fields = cls.getFields();
-                    for (int i=0;i < fields.length;i++) {
-                        Field field = fields[i];
-                        if (field.getType() == cls
-                            && Modifier.isStatic(field.getModifiers())) {
-                            // Ensure the field gets initialized by reading it
-                            libraries.put(cls, new WeakReference<Object>(field.get(null)));
-                            break;
-                        }
+        if (cls != null && !libraries.containsKey(cls)) {
+            try {
+                Field[] fields = cls.getFields();
+                for (int i=0;i < fields.length;i++) {
+                    Field field = fields[i];
+                    if (field.getType() == cls
+                        && Modifier.isStatic(field.getModifiers())) {
+                        // Ensure the field gets initialized by reading it
+                        libraries.put(cls, new WeakReference<Object>(field.get(null)));
+                        break;
                     }
                 }
-                catch (Exception e) {
-                    throw new IllegalArgumentException("Could not access instance of "
-                                                       + cls + " (" + e + ")");
-                }
+            }
+            catch (Exception e) {
+                throw new IllegalArgumentException("Could not access instance of "
+                                                   + cls + " (" + e + ")");
             }
         }
     }
@@ -614,15 +612,13 @@ public final class Native implements Version {
         }
         // Check for direct-mapped libraries, which won't necessarily
         // implement com.sun.jna.Library.
-        synchronized(libraries) {
-            if (typeOptions.containsKey(cls)) {
-                Map<String, ?> libOptions = typeOptions.get(cls);
-                Class<?> enclosingClass = (Class<?>)libOptions.get(_OPTION_ENCLOSING_LIBRARY);
-                if (enclosingClass != null) {
-                    return enclosingClass;
-                }
-                return cls;
+        Map<String, ?> libOptions = typeOptions.get(cls);
+        if (libOptions != null) {
+            Class<?> enclosingClass = (Class<?>)libOptions.get(_OPTION_ENCLOSING_LIBRARY);
+            if (enclosingClass != null) {
+                return enclosingClass;
             }
+            return cls;
         }
         if (Library.class.isAssignableFrom(cls)) {
             return cls;
@@ -654,11 +650,9 @@ public final class Native implements Version {
     public static Map<String, Object> getLibraryOptions(Class<?> type) {
         Map<String, Object> libraryOptions;
         // cached already ?
-        synchronized(libraries) {
-            libraryOptions = typeOptions.get(type);
-            if (libraryOptions != null) {
-                return libraryOptions;
-            }
+        libraryOptions = typeOptions.get(type);
+        if (libraryOptions != null) {
+            return libraryOptions;
         }
 
         Class<?> mappingClass = findEnclosingLibraryClass(type);
@@ -668,43 +662,41 @@ public final class Native implements Version {
             mappingClass = type;
         }
 
-        synchronized(libraries) {
-            libraryOptions = typeOptions.get(mappingClass);
-            if (libraryOptions != null) {
-                typeOptions.put(type, libraryOptions);  // cache for next time
-                return libraryOptions;
-            }
-
-            try {
-                Field field = mappingClass.getField("OPTIONS");
-                field.setAccessible(true);
-                libraryOptions = (Map<String, Object>) field.get(null);
-                if (libraryOptions == null) {
-                    throw new IllegalStateException("Null options field");
-                }
-            } catch (NoSuchFieldException e) {
-                libraryOptions = Collections.<String, Object>emptyMap();
-            } catch (Exception e) {
-                throw new IllegalArgumentException("OPTIONS must be a public field of type java.util.Map (" + e + "): " + mappingClass);
-            }
-            // Make a clone of the original options
-            libraryOptions = new HashMap<String, Object>(libraryOptions);
-            if (!libraryOptions.containsKey(Library.OPTION_TYPE_MAPPER)) {
-                libraryOptions.put(Library.OPTION_TYPE_MAPPER, lookupField(mappingClass, "TYPE_MAPPER", TypeMapper.class));
-            }
-            if (!libraryOptions.containsKey(Library.OPTION_STRUCTURE_ALIGNMENT)) {
-                libraryOptions.put(Library.OPTION_STRUCTURE_ALIGNMENT, lookupField(mappingClass, "STRUCTURE_ALIGNMENT", Integer.class));
-            }
-            if (!libraryOptions.containsKey(Library.OPTION_STRING_ENCODING)) {
-                libraryOptions.put(Library.OPTION_STRING_ENCODING, lookupField(mappingClass, "STRING_ENCODING", String.class));
-            }
-            libraryOptions = cacheOptions(mappingClass, libraryOptions, null);
-            // Store the original lookup class, if different from the mapping class
-            if (type != mappingClass) {
-                typeOptions.put(type, libraryOptions);
-            }
+        libraryOptions = typeOptions.get(mappingClass);
+        if (libraryOptions != null) {
+            typeOptions.put(type, libraryOptions);  // cache for next time
             return libraryOptions;
         }
+
+        try {
+            Field field = mappingClass.getField("OPTIONS");
+            field.setAccessible(true);
+            libraryOptions = (Map<String, Object>) field.get(null);
+            if (libraryOptions == null) {
+                throw new IllegalStateException("Null options field");
+            }
+        } catch (NoSuchFieldException e) {
+            libraryOptions = Collections.<String, Object>emptyMap();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("OPTIONS must be a public field of type java.util.Map (" + e + "): " + mappingClass);
+        }
+        // Make a clone of the original options
+        libraryOptions = new HashMap<String, Object>(libraryOptions);
+        if (!libraryOptions.containsKey(Library.OPTION_TYPE_MAPPER)) {
+            libraryOptions.put(Library.OPTION_TYPE_MAPPER, lookupField(mappingClass, "TYPE_MAPPER", TypeMapper.class));
+        }
+        if (!libraryOptions.containsKey(Library.OPTION_STRUCTURE_ALIGNMENT)) {
+            libraryOptions.put(Library.OPTION_STRUCTURE_ALIGNMENT, lookupField(mappingClass, "STRUCTURE_ALIGNMENT", Integer.class));
+        }
+        if (!libraryOptions.containsKey(Library.OPTION_STRING_ENCODING)) {
+            libraryOptions.put(Library.OPTION_STRING_ENCODING, lookupField(mappingClass, "STRING_ENCODING", String.class));
+        }
+        libraryOptions = cacheOptions(mappingClass, libraryOptions, null);
+        // Store the original lookup class, if different from the mapping class
+        if (type != mappingClass) {
+            typeOptions.put(type, libraryOptions);
+        }
+        return libraryOptions;
     }
 
     private static Object lookupField(Class<?> mappingClass, String fieldName, Class<?> resultClass) {
@@ -1794,23 +1786,21 @@ public final class Native implements Version {
     private static Map<String, Object> cacheOptions(Class<?> cls, Map<String, ?> options, Object proxy) {
         Map<String, Object> libOptions = new HashMap<String, Object>(options);
         libOptions.put(_OPTION_ENCLOSING_LIBRARY, cls);
-        synchronized(libraries) {
-            typeOptions.put(cls, libOptions);
-            if (proxy != null) {
-                libraries.put(cls, new WeakReference<Object>(proxy));
-            }
+        typeOptions.put(cls, libOptions);
+        if (proxy != null) {
+            libraries.put(cls, new WeakReference<Object>(proxy));
+        }
 
-            // If it's a direct mapping, AND implements a Library interface,
-            // cache the library interface as well, so that any nested
-            // classes get the appropriate associated options
-            if (!cls.isInterface()
-                && Library.class.isAssignableFrom(cls)) {
-                Class<?> ifaces[] = cls.getInterfaces();
-                for (Class<?> ifc : ifaces) {
-                    if (Library.class.isAssignableFrom(ifc)) {
-                        cacheOptions(ifc, libOptions, proxy);
-                        break;
-                    }
+        // If it's a direct mapping, AND implements a Library interface,
+        // cache the library interface as well, so that any nested
+        // classes get the appropriate associated options
+        if (!cls.isInterface()
+            && Library.class.isAssignableFrom(cls)) {
+            Class<?> ifaces[] = cls.getInterfaces();
+            for (Class<?> ifc : ifaces) {
+                if (Library.class.isAssignableFrom(ifc)) {
+                    cacheOptions(ifc, libOptions, proxy);
+                    break;
                 }
             }
         }

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -870,7 +870,7 @@ public class NativeLibrary {
             if (Platform.isLinux() || Platform.isSolaris()
                 || Platform.isFreeBSD() || Platform.iskFreeBSD()) {
                 // Linux & FreeBSD use /usr/lib32, solaris uses /usr/lib/32
-                archPath = (Platform.isSolaris() ? "/" : "") + Pointer.SIZE * 8;
+                archPath = (Platform.isSolaris() ? "/" : "") + Native.POINTER_SIZE * 8;
             }
             String[] paths = {
                 "/usr/lib" + archPath,

--- a/src/com/sun/jna/Pointer.java
+++ b/src/com/sun/jna/Pointer.java
@@ -46,16 +46,6 @@ import java.util.List;
  */
 public class Pointer {
 
-    /** Size of a native pointer, in bytes. */
-    public static final int SIZE;
-
-    static {
-        // Force load of native library
-        if ((SIZE = Native.POINTER_SIZE) == 0) {
-            throw new Error("Native library not initialized");
-        }
-    }
-
     /** Convenience constant, same as <code>null</code>. */
     public static final Pointer NULL = null;
 
@@ -238,7 +228,7 @@ public class Pointer {
      */
     public void read(long offset, Pointer[] buf, int index, int length) {
         for (int i=0;i < length;i++) {
-            Pointer p = getPointer(offset + i*Pointer.SIZE);
+            Pointer p = getPointer(offset + i*Native.POINTER_SIZE);
             Pointer oldp = buf[i+index];
             // Avoid replacing the original pointer if it hasn't changed
             if (oldp == null || p == null || p.peer != oldp.peer) {
@@ -359,7 +349,7 @@ public class Pointer {
     */
     public void write(long bOff, Pointer[] buf, int index, int length) {
         for (int i=0;i < length;i++) {
-            setPointer(bOff + i * Pointer.SIZE, buf[index + i]);
+            setPointer(bOff + i * Native.POINTER_SIZE, buf[index + i]);
         }
     }
 
@@ -779,7 +769,7 @@ v     * @param wide whether to convert from a wide or standard C string
         Pointer p = getPointer(offset);
         while (p != null) {
             array.add(p);
-            addOffset += Pointer.SIZE;
+            addOffset += Native.POINTER_SIZE;
             p = getPointer(offset + addOffset);
         }
         return array.toArray(new Pointer[array.size()]);
@@ -875,7 +865,7 @@ v     * @param wide whether to convert from a wide or standard C string
                        ? p.getWideString(0) : p.getString(0, encoding));
                 strings.add(s);
                 if (count < length) {
-                    addOffset += SIZE;
+                    addOffset += Native.POINTER_SIZE;
                     p = getPointer(offset + addOffset);
                 }
             }
@@ -886,7 +876,7 @@ v     * @param wide whether to convert from a wide or standard C string
                     : (NativeString.WIDE_STRING.equals(encoding)
                        ? p.getWideString(0) : p.getString(0, encoding));
                 strings.add(s);
-                addOffset += SIZE;
+                addOffset += Native.POINTER_SIZE;
             }
         }
         return strings.toArray(new String[strings.size()]);

--- a/src/com/sun/jna/StringArray.java
+++ b/src/com/sun/jna/StringArray.java
@@ -53,7 +53,7 @@ public class StringArray extends Memory implements Function.PostCallRead {
         this(strings, NativeString.WIDE_STRING);
     }
     private StringArray(Object[] strings, String encoding) {
-        super((strings.length + 1) * Pointer.SIZE);
+        super((strings.length + 1) * Native.POINTER_SIZE);
         this.original = strings;
         this.encoding = encoding;
         for (int i=0;i < strings.length;i++) {
@@ -63,9 +63,9 @@ public class StringArray extends Memory implements Function.PostCallRead {
                 natives.add(ns);
                 p = ns.getPointer();
             }
-            setPointer(Pointer.SIZE * i, p);
+            setPointer(Native.POINTER_SIZE * i, p);
         }
-        setPointer(Pointer.SIZE * strings.length, null);
+        setPointer(Native.POINTER_SIZE * strings.length, null);
     }
     /** Read back from native memory. */
     @Override
@@ -73,7 +73,7 @@ public class StringArray extends Memory implements Function.PostCallRead {
         boolean returnWide = original instanceof WString[];
         boolean wide = NativeString.WIDE_STRING.equals(encoding);
         for (int si=0;si < original.length;si++) {
-            Pointer p = getPointer(si * Pointer.SIZE);
+            Pointer p = getPointer(si * Native.POINTER_SIZE);
             Object s = null;
             if (p != null) {
                 s = wide ? p.getWideString(0) : p.getString(0, encoding);

--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -1411,11 +1411,11 @@ public abstract class Structure {
                  || Callback.class.isAssignableFrom(type)
                  || WString.class == type
                  || String.class == type) {
-            alignment = Pointer.SIZE;
+            alignment = Native.POINTER_SIZE;
         }
         else if (Structure.class.isAssignableFrom(type)) {
             if (ByReference.class.isAssignableFrom(type)) {
-                alignment = Pointer.SIZE;
+                alignment = Native.POINTER_SIZE;
             }
             else {
                 if (value == null)
@@ -1968,7 +1968,7 @@ public abstract class Structure {
             return Arrays.asList(new String[] { "size", "alignment", "type", "elements" });
         }
         private void init(Pointer[] els) {
-            elements = new Memory(Pointer.SIZE * els.length);
+            elements = new Memory(Native.POINTER_SIZE * els.length);
             elements.write(0, els, 0, els.length);
             write();
         }

--- a/src/com/sun/jna/ptr/PointerByReference.java
+++ b/src/com/sun/jna/ptr/PointerByReference.java
@@ -23,6 +23,7 @@
  */
 package com.sun.jna.ptr;
 
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
 /** Represents a reference to a pointer to native data. 
@@ -36,7 +37,7 @@ public class PointerByReference extends ByReference {
     }
     
     public PointerByReference(Pointer value) {
-        super(Pointer.SIZE);
+        super(Native.POINTER_SIZE);
         setValue(value);
     }
     

--- a/src/com/sun/jna/win32/StdCallFunctionMapper.java
+++ b/src/com/sun/jna/win32/StdCallFunctionMapper.java
@@ -49,7 +49,7 @@ public class StdCallFunctionMapper implements FunctionMapper {
             cls = NativeMappedConverter.getInstance(cls).nativeType();
         }
         if (cls.isArray()) {
-            return Pointer.SIZE;
+            return Native.POINTER_SIZE;
         }
         try {
             return Native.getNativeSize(cls);

--- a/test/com/sun/jna/HeadlessLoadLibraryTest.java
+++ b/test/com/sun/jna/HeadlessLoadLibraryTest.java
@@ -28,7 +28,7 @@ public class HeadlessLoadLibraryTest extends TestCase {
     
     public void testLoadWhenHeadless() {
         System.setProperty("java.awt.headless", "true");
-        assertTrue("Pointer size must not be zero", Pointer.SIZE > 0);
+        assertTrue("Pointer size must not be zero", Native.POINTER_SIZE > 0);
     }
     
     public static void main(String[] args) {

--- a/test/com/sun/jna/LibraryLoadTest.java
+++ b/test/com/sun/jna/LibraryLoadTest.java
@@ -47,7 +47,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
     }
 
     public void testLoadJNALibrary() {
-        assertTrue("Pointer size should never be zero", Pointer.SIZE > 0);
+        assertTrue("Pointer size should never be zero", Native.POINTER_SIZE > 0);
     }
 
     public void testLoadJAWT() {
@@ -65,7 +65,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
 
         if (GraphicsEnvironment.isHeadless()) return;
 
-        if (Pointer.SIZE > 0) {
+        if (Native.POINTER_SIZE > 0) {
             Toolkit.getDefaultToolkit();
         }
     }

--- a/test/com/sun/jna/PointerTest.java
+++ b/test/com/sun/jna/PointerTest.java
@@ -88,7 +88,7 @@ public class PointerTest extends TestCase {
     }
 
     public void testSetNativeMapped() {
-        Pointer p = new Memory(Pointer.SIZE);
+        Pointer p = new Memory(Native.POINTER_SIZE);
         TestPointerType tp = new TestPointerType(p);
 
         p.setValue(0, tp, tp.getClass());
@@ -97,7 +97,7 @@ public class PointerTest extends TestCase {
     }
 
     public void testGetNativeMapped() {
-        Pointer p = new Memory(Pointer.SIZE);
+        Pointer p = new Memory(Native.POINTER_SIZE);
         p.setPointer(0, null);
         Object o = p.getValue(0, TestPointerType.class, null);
         assertNull("Wrong empty value: " + o, o);
@@ -107,14 +107,14 @@ public class PointerTest extends TestCase {
     }
 
     public void testGetStringArray() {
-        Pointer p = new Memory(Pointer.SIZE*3);
+        Pointer p = new Memory(Native.POINTER_SIZE*3);
         final String VALUE1 = getName() + UNICODE;
         final String VALUE2 = getName() + "2" + UNICODE;
         final String ENCODING = "utf8";
 
         p.setPointer(0, new NativeString(VALUE1, ENCODING).getPointer());
-        p.setPointer(Pointer.SIZE, new NativeString(VALUE2, ENCODING).getPointer());
-        p.setPointer(Pointer.SIZE*2, null);
+        p.setPointer(Native.POINTER_SIZE, new NativeString(VALUE2, ENCODING).getPointer());
+        p.setPointer(Native.POINTER_SIZE*2, null);
 
         assertEquals("Wrong null-terminated String array",
                      Arrays.asList(new String[] { VALUE1, VALUE2 }),
@@ -129,13 +129,13 @@ public class PointerTest extends TestCase {
     }
 
     public void testGetWideStringArray() {
-        Pointer p = new Memory(Pointer.SIZE*3);
+        Pointer p = new Memory(Native.POINTER_SIZE*3);
         final String VALUE1 = getName() + UNICODE;
         final String VALUE2 = getName() + "2" + UNICODE;
 
         p.setPointer(0, new NativeString(VALUE1, true).getPointer());
-        p.setPointer(Pointer.SIZE, new NativeString(VALUE2, true).getPointer());
-        p.setPointer(Pointer.SIZE*2, null);
+        p.setPointer(Native.POINTER_SIZE, new NativeString(VALUE2, true).getPointer());
+        p.setPointer(Native.POINTER_SIZE*2, null);
 
         assertEquals("Wrong null-terminated String array",
                      Arrays.asList(new String[] { VALUE1, VALUE2 }),
@@ -150,7 +150,7 @@ public class PointerTest extends TestCase {
     }
 
     public void testReadPointerArray() {
-        Pointer mem = new Memory(Pointer.SIZE * 2);
+        Pointer mem = new Memory(Native.POINTER_SIZE * 2);
         Pointer[] p = new Pointer[2];
         String VALUE1 = getName();
 
@@ -166,7 +166,7 @@ public class PointerTest extends TestCase {
         assertSame("Pointer object not preserved[1]", orig[1], p[1]);
 
         mem.setPointer(0, null);
-        mem.setPointer(Pointer.SIZE, new Memory(1024));
+        mem.setPointer(Native.POINTER_SIZE, new Memory(1024));
         mem.read(0, p, 0, p.length);
         assertNull("Pointer element not updated[0]", p[0]);
         assertNotSame("Pointer element not updated[1]", orig[1], p[1]);
@@ -181,7 +181,7 @@ public class PointerTest extends TestCase {
     }
 
     public void testReadStringArrayNULLElement() {
-        Memory m = new Memory(Pointer.SIZE);
+        Memory m = new Memory(Native.POINTER_SIZE);
         m.clear();
         String[] arr = m.getStringArray(0, 1);
         assertEquals("Wrong array size", 1, arr.length);

--- a/test/com/sun/jna/StructureBufferFieldTest.java
+++ b/test/com/sun/jna/StructureBufferFieldTest.java
@@ -74,7 +74,7 @@ public class StructureBufferFieldTest extends TestCase {
     public void testBufferFieldReadChanged() {
         if (!Platform.HAS_BUFFERS) return;
         BufferStructure bs = new BufferStructure();
-        if (Pointer.SIZE == 4) {
+        if (Native.POINTER_SIZE == 4) {
             bs.getPointer().setInt(0, 0x1);
         }
         else {

--- a/test/com/sun/jna/StructureTest.java
+++ b/test/com/sun/jna/StructureTest.java
@@ -945,7 +945,7 @@ public class StructureTest extends TestCase {
     public void testPointerArrayField() {
         ArrayOfPointerStructure s = new ArrayOfPointerStructure();
         int size = s.size();
-        assertEquals("Wrong size", ArrayOfPointerStructure.SIZE * Pointer.SIZE, size);
+        assertEquals("Wrong size", ArrayOfPointerStructure.SIZE * Native.POINTER_SIZE, size);
         s.array[0] = s.getPointer();
         s.write();
         s.array[0] = null;
@@ -992,7 +992,7 @@ public class StructureTest extends TestCase {
     }
     public void testStructureByReferenceField() {
         StructureWithPointers s = new StructureWithPointers();
-        assertEquals("Wrong size for structure with structure references", Pointer.SIZE * 2, s.size());
+        assertEquals("Wrong size for structure with structure references", Native.POINTER_SIZE * 2, s.size());
         assertNull("Initial refs should be null", s.s1);
     }
 
@@ -1060,14 +1060,14 @@ public class StructureTest extends TestCase {
         m2.setString(0, WVALUE);
 
         s.getPointer().setPointer(0, m);
-        s.getPointer().setPointer(Pointer.SIZE, m2);
+        s.getPointer().setPointer(Native.POINTER_SIZE, m2);
         s.read();
         assertEquals("Wrong String field value", VALUE, s.s);
         assertEquals("Wrong WString field value", WVALUE, s.ws);
 
         s.write();
         assertEquals("String field should not be overwritten: " + s, m, s.getPointer().getPointer(0));
-        assertEquals("WString field should not be overwritten: " + s, m2, s.getPointer().getPointer(Pointer.SIZE));
+        assertEquals("WString field should not be overwritten: " + s, m2, s.getPointer().getPointer(Native.POINTER_SIZE));
     }
 
     // Ensure string cacheing doesn't interfere with wrapped structure writes.
@@ -1148,7 +1148,7 @@ public class StructureTest extends TestCase {
             }
         }
         TestStructure s = new TestStructure();
-        assertEquals("Wrong structure size", 2*Pointer.SIZE, s.size());
+        assertEquals("Wrong structure size", 2*Native.POINTER_SIZE, s.size());
 
         PublicTestStructure.ByReference ref = new PublicTestStructure.ByReference();
         ref.x = 42;
@@ -1256,9 +1256,9 @@ public class StructureTest extends TestCase {
                      inner, els.getPointer(0));
         assertEquals("Wrong type information for integer field",
                      Structure.getTypeInfo(Integer.valueOf(0)),
-                     els.getPointer(Pointer.SIZE));
+                     els.getPointer(Native.POINTER_SIZE));
         assertNull("Type element list should be null-terminated",
-                   els.getPointer(Pointer.SIZE*2));
+                   els.getPointer(Native.POINTER_SIZE*2));
     }
 
     public void testInnerArrayTypeInfo() {

--- a/test/com/sun/jna/UnionTest.java
+++ b/test/com/sun/jna/UnionTest.java
@@ -92,7 +92,7 @@ public class UnionTest extends TestCase {
 
     public void testFieldOffsets() {
         StructUnion u = new StructUnion();
-        assertEquals("Wrong union size: " + u, Pointer.SIZE, u.size());
+        assertEquals("Wrong union size: " + u, Native.POINTER_SIZE, u.size());
         u.setType(u.testStruct.getClass());
         u.write();
         assertEquals("Wrong struct member base address",
@@ -132,7 +132,7 @@ public class UnionTest extends TestCase {
         final int VALUE = 0x12345678;
         // write an instance of a direct union class to memory
         StructUnion u = new StructUnion();
-        assertEquals("Wrong union size: " + u, Pointer.SIZE, u.size());
+        assertEquals("Wrong union size: " + u, Native.POINTER_SIZE, u.size());
         IntStructure intStruct = new IntStructure();
         intStruct.value = VALUE;
         u.setTypedValue(intStruct);
@@ -158,7 +158,7 @@ public class UnionTest extends TestCase {
 
     public void testReadTypedUnion() {
         StructUnion u = new StructUnion();
-        assertEquals("Wrong union size: " + u, Pointer.SIZE, u.size());
+        assertEquals("Wrong union size: " + u, Native.POINTER_SIZE, u.size());
         final int VALUE = 0x12345678;
         u.getPointer().setInt(0, VALUE);
         assertEquals("int structure not read properly", VALUE, ((IntStructure) u.getTypedValue(IntStructure.class)).value);

--- a/test/com/sun/jna/VMCrashProtectionTest.java
+++ b/test/com/sun/jna/VMCrashProtectionTest.java
@@ -40,8 +40,8 @@ public class VMCrashProtectionTest extends TestCase {
         if (!Native.isProtected())
             return;
         
-        Memory m = new Memory(Pointer.SIZE);
-        if (Pointer.SIZE == 4)
+        Memory m = new Memory(Native.POINTER_SIZE);
+        if (Native.POINTER_SIZE == 4)
             m.setInt(0, 1);
         else
             m.setLong(0, 1);

--- a/test/com/sun/jna/win32/W32APIMapperTest.java
+++ b/test/com/sun/jna/win32/W32APIMapperTest.java
@@ -96,10 +96,10 @@ public class W32APIMapperTest extends TestCase {
 
     public void testInvalidHandleValue() {
         String EXPECTED = "@0xffffffff";
-        if (Pointer.SIZE == 8) {
+        if (Native.POINTER_SIZE == 8) {
             EXPECTED += "ffffffff";
         }
-        Pointer p = Pointer.createConstant(Pointer.SIZE == 8 ? -1 : 0xFFFFFFFFL);
+        Pointer p = Pointer.createConstant(Native.POINTER_SIZE == 8 ? -1 : 0xFFFFFFFFL);
         assertTrue("Wrong value: " + p, p.toString().endsWith(EXPECTED));
 
     }
@@ -133,41 +133,41 @@ public class W32APIMapperTest extends TestCase {
     public void testUnicodeStructureSize() {
         UnicodeLibrary.TestStructure s = new UnicodeLibrary.TestStructure();
         assertEquals("Wrong structure size",
-                     Pointer.SIZE*2+8, s.size());
+                     Native.POINTER_SIZE*2+8, s.size());
     }
 
     public void testASCIIStructureSize() {
         ASCIILibrary.TestStructure s = new ASCIILibrary.TestStructure();
         assertEquals("Wrong structure size",
-                     Pointer.SIZE*2+8, s.size());
+                     Native.POINTER_SIZE*2+8, s.size());
     }
 
     public void testUnicodeStructureWriteBoolean() {
         UnicodeLibrary.TestStructure s = new UnicodeLibrary.TestStructure();
         s.bool2 = true;
         s.write();
-        assertEquals("Wrong value written for FALSE", 0, s.getPointer().getInt(Pointer.SIZE*2));
-        assertEquals("Wrong value written for TRUE", 1, s.getPointer().getInt(Pointer.SIZE*2+4));
+        assertEquals("Wrong value written for FALSE", 0, s.getPointer().getInt(Native.POINTER_SIZE*2));
+        assertEquals("Wrong value written for TRUE", 1, s.getPointer().getInt(Native.POINTER_SIZE*2+4));
     }
     public void testASCIIStructureWriteBoolean() {
         ASCIILibrary.TestStructure s = new ASCIILibrary.TestStructure();
         s.bool2 = true;
         s.write();
-        assertEquals("Wrong value written for FALSE", 0, s.getPointer().getInt(Pointer.SIZE*2));
-        assertEquals("Wrong value written for TRUE", 1, s.getPointer().getInt(Pointer.SIZE*2+4));
+        assertEquals("Wrong value written for FALSE", 0, s.getPointer().getInt(Native.POINTER_SIZE*2));
+        assertEquals("Wrong value written for TRUE", 1, s.getPointer().getInt(Native.POINTER_SIZE*2+4));
     }
     public void testUnicodeStructureReadBoolean() {
         UnicodeLibrary.TestStructure s = new UnicodeLibrary.TestStructure();
-        s.getPointer().setInt(Pointer.SIZE*2, 1);
-        s.getPointer().setInt(Pointer.SIZE*2+4, 0);
+        s.getPointer().setInt(Native.POINTER_SIZE*2, 1);
+        s.getPointer().setInt(Native.POINTER_SIZE*2+4, 0);
         s.read();
         assertTrue("Wrong value read for TRUE", s.bool);
         assertFalse("Wrong value read for FALSE", s.bool2);
     }
     public void testASCIIStructureReadBoolean() {
         ASCIILibrary.TestStructure s = new ASCIILibrary.TestStructure();
-        s.getPointer().setInt(Pointer.SIZE*2, 1);
-        s.getPointer().setInt(Pointer.SIZE*2+4, 0);
+        s.getPointer().setInt(Native.POINTER_SIZE*2, 1);
+        s.getPointer().setInt(Native.POINTER_SIZE*2+4, 0);
         s.read();
         assertTrue("Wrong value read for TRUE", s.bool);
         assertFalse("Wrong value read for FALSE", s.bool2);
@@ -178,7 +178,7 @@ public class W32APIMapperTest extends TestCase {
         s.string2 = MAGIC;
         s.write();
         assertEquals("Improper null write", null, s.getPointer().getPointer(0));
-        assertEquals("Improper string write", MAGIC, s.getPointer().getPointer(Pointer.SIZE).getWideString(0));
+        assertEquals("Improper string write", MAGIC, s.getPointer().getPointer(Native.POINTER_SIZE).getWideString(0));
     }
     public void testASCIIStructureWriteString() {
         ASCIILibrary.TestStructure s = new ASCIILibrary.TestStructure();
@@ -186,7 +186,7 @@ public class W32APIMapperTest extends TestCase {
         s.string2 = MAGIC;
         s.write();
         assertEquals("Improper null write", null, s.getPointer().getPointer(0));
-        assertEquals("Improper string write", MAGIC, s.getPointer().getPointer(Pointer.SIZE).getString(0));
+        assertEquals("Improper string write", MAGIC, s.getPointer().getPointer(Native.POINTER_SIZE).getString(0));
     }
     public void testUnicodeStructureReadString() {
         UnicodeLibrary.TestStructure s = new UnicodeLibrary.TestStructure();


### PR DESCRIPTION
There are two vectors addressed:

- Pointer and Native classes are prone to deadlocks when loaded from different Threads. The cycle can be broken by removing the Pointer#SIZE attribute and instead using the Native#POINTER_SIZE value. From the commit message:

> Remove Pointer#SIZE replaced by Native#POINTER_SIZE to prevent classloading deadlock
> 
> If Pointer and Native class are concurrently initialized, a deadlock
> results:
> 
> - The static initializer block of Pointer uses Native#POINTER_SIZE
>   to initialize its SIZE value
> - The Native#initIDs method loads the Pointer class via JNI to find
>   its ClassID and MethodIDs
> 
> Both threads enter the initialization lock for their corresponding class
> for initialization to succeed both classes also need an initialized
> version of the counter part. Thus each thread needed to acquire the
> others initialization lock.

- The synchronized blocks in Native, that synchronize on Native#library are to broad and prone to deadlocks, as further class loading is triggered. From the commit message:
>  Use a synchronizedMap for typeOptions and libraries instead of seperate lock
> 
> The currently used lock is to broad and can cause a deadlock when
> loadLibrary is called from different threads, that need
> recursive initialization of dependend classes.
> 
> The codepaths that hold the libraries lock to prevent duplicate
> execution of initialization code. The lock can be dropped in favor
> of a Collections#synchronizedMap construct, that only protects the
> Map structure.
> 
> In detail:
> 
> - loadLibraryInstance: The lock on libraries prevents a duplicate put of
>   WeakReference to the static singleton instance of the library.
>   This is uncritical, as the References are equal from the outside view.
> 
>   The library won't be initialized twice, as the JLS defines, that
>   class initialization must happend under a lock.
> 
>   The codepath can be entered multiple times without negative consequences.
> 
> - findEnclosingLibrary: The lock on libraries prevents recursive calls
>   to Native#findEnclosingLibrary and CallbackReference#findCallbackClass.
> 
>   These paths have no side effects apart from caching, so can be
>   entered multiple times.
> 
> - getLibraryOptions: The lock on libraries prevents building the library
>   options map multiple times. As there are no side effects, locking is
>   not necessary.
> 
> - cacheOptions: The lock on libraries prevents multiple puts of the
>   options map into the typeOptions and libraries maps.
>   As there are no side effects, locking is not necessary.


This causes an API break, removing the Pointer#SIZE member.