### PR TITLE
Direct Mapping support for OPTION_ALLOW_OBJECTS

### DIFF
--- a/native/dispatch.h
+++ b/native/dispatch.h
@@ -115,6 +115,7 @@ enum {
   CVT_TYPE_MAPPER = com_sun_jna_Native_CVT_TYPE_MAPPER,
   CVT_TYPE_MAPPER_STRING = com_sun_jna_Native_CVT_TYPE_MAPPER_STRING,
   CVT_TYPE_MAPPER_WSTRING = com_sun_jna_Native_CVT_TYPE_MAPPER_WSTRING,
+  CVT_OBJECT = com_sun_jna_Native_CVT_OBJECT,
 };
 
 /* callback behavior flags */

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -1534,8 +1534,9 @@ public final class Native implements Version {
     private static final int CVT_TYPE_MAPPER = 23;
     private static final int CVT_TYPE_MAPPER_STRING = 24;
     private static final int CVT_TYPE_MAPPER_WSTRING = 25;
+    private static final int CVT_OBJECT = 26;
 
-    private static int getConversion(Class<?> type, TypeMapper mapper) {
+    private static int getConversion(Class<?> type, TypeMapper mapper, boolean allowObjects) {
         if (type == Boolean.class) type = boolean.class;
         else if (type == Byte.class) type = byte.class;
         else if (type == Short.class) type = short.class;
@@ -1624,7 +1625,7 @@ public final class Native implements Version {
             }
             return CVT_NATIVE_MAPPED;
         }
-        return CVT_UNSUPPORTED;
+        return allowObjects ? CVT_OBJECT : CVT_UNSUPPORTED;
     }
 
     /**
@@ -1657,6 +1658,7 @@ public final class Native implements Version {
         List<Method> mlist = new ArrayList<Method>();
         Map<String, ?> options = lib.getOptions();
         TypeMapper mapper = (TypeMapper) options.get(Library.OPTION_TYPE_MAPPER);
+        boolean allowObjects = Boolean.TRUE.equals(options.get(Library.OPTION_ALLOW_OBJECTS));
         options = cacheOptions(cls, options, null);
 
         for (Method m : methods) {
@@ -1677,7 +1679,7 @@ public final class Native implements Version {
             int[] cvt = new int[ptypes.length];
             ToNativeConverter[] toNative = new ToNativeConverter[ptypes.length];
             FromNativeConverter fromNative = null;
-            int rcvt = getConversion(rclass, mapper);
+            int rcvt = getConversion(rclass, mapper, allowObjects);
             boolean throwLastError = false;
             switch (rcvt) {
                 case CVT_UNSUPPORTED:
@@ -1701,6 +1703,7 @@ public final class Native implements Version {
                     rtype = FFIType.get(NativeMappedConverter.getInstance(rclass).nativeType()).peer;
                     break;
                 case CVT_STRUCTURE:
+                case CVT_OBJECT:
                     closure_rtype = rtype = FFIType.get(Pointer.class).peer;
                     break;
                 case CVT_STRUCTURE_BYVAL:
@@ -1714,7 +1717,7 @@ public final class Native implements Version {
             for (int t=0;t < ptypes.length;t++) {
                 Class<?> type = ptypes[t];
                 sig += getSignature(type);
-                int conversionType = getConversion(type, mapper);
+                int conversionType = getConversion(type, mapper, allowObjects);
                 cvt[t] = conversionType;
                 if (conversionType == CVT_UNSUPPORTED) {
                     throw new IllegalArgumentException(type + " is not a supported argument type (in method " + method.getName() + " in " + cls + ")");

--- a/test/com/sun/jna/DirectReturnTypesTest.java
+++ b/test/com/sun/jna/DirectReturnTypesTest.java
@@ -24,6 +24,7 @@
 package com.sun.jna;
 
 import java.util.Map;
+import java.util.Collections;
 
 /** Exercise a range of native methods.
  *
@@ -96,8 +97,13 @@ public class DirectReturnTypesTest extends ReturnTypesTest {
     }
 
     public static class DirectObjectTestLibrary extends DirectTestLibrary {
-        public DirectObjectTestLibrary(Map<String, ?> options) {
-            Native.register(getClass(), NativeLibrary.getInstance("testlib", options));
+        @Override
+        public native Object returnObjectArgument(Object s);
+        @Override
+        public native TestObject returnObjectArgument(TestObject s);
+        public DirectObjectTestLibrary() {
+            Native.register(getClass(), NativeLibrary.getInstance("testlib",
+                Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, Boolean.TRUE)));
         }
     }
 
@@ -117,9 +123,13 @@ public class DirectReturnTypesTest extends ReturnTypesTest {
         return new DirectNativeMappedLibrary();
     }
 
-    // Override not-yet-supported tests
+
     @Override
-    public void testReturnObject() { }
+    public void testReturnObject() {
+        lib = new DirectObjectTestLibrary();
+    }
+
+    // Override not-yet-supported tests
     @Override
     public void testReturnPointerArray() { }
     @Override


### PR DESCRIPTION
Allows usage of direct mapping for methods with arbitrary Java types. See [`OPTION_ALLOW_OBJECTS`](https://github.com/java-native-access/jna/blob/238169d/src/com/sun/jna/Library.java#L100).

Includes basic test case (similar to those used to test `OPTION_ALLOW_OBJECTS`), but was also tested in conjunction with #805, to map [this](https://developer.android.com/ndk/reference/group___bitmap.html) Android library.