### PR TITLE
Direct Mapping for boolean arrays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 * [#783](https://github.com/java-native-access/jna/pull/783): Add Ole32 functions: `OleBuildVersion`, `OleInitialize`, `OleUninitialize`, `OleFlushClipboard`, `OleRun`, add VARIANT conversion functions to OleAuto, add default locale, LCID and LANG to WinNT - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#784](https://github.com/java-native-access/jna/issues/784): Added Solaris Kstat library - [@dbwiddis](https://github.com/dbwiddis).
 * [#805](https://github.com/java-native-access/jna/issues/805): Provide a way to pass JNIEnv pointer to native method and support OPTION_ALLOW_OBJECTs for direct mapping - [@ncruces](https://github.com/ncruces).
+* [#816](https://github.com/java-native-access/jna/pull/816): Support `boolean[]` in direct mapping - [@ncruces](https://github.com/ncruces).
 
 Bug Fixes
 ---------

--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -1849,6 +1849,7 @@ dispatch_direct(ffi_cif* cif, void* volatile resp, void** argp, void *cdata) {
    objects[i] = *(void **)args[i];                                      \
    release[i] = (void *)(*env)->Release##Type##ArrayElements;           \
    elems[i] = *(void **)args[i] = (*env)->Get##Type##ArrayElements(env, objects[i], NULL); } while(0)
+      case CVT_ARRAY_BOOLEAN: ARRAY(Boolean); break;
       case CVT_ARRAY_BYTE: ARRAY(Byte); break;
       case CVT_ARRAY_SHORT: ARRAY(Short); break;
       case CVT_ARRAY_CHAR: ARRAY(Char); break;
@@ -1968,6 +1969,7 @@ dispatch_direct(ffi_cif* cif, void* volatile resp, void** argp, void *cdata) {
         free(*(void **)args[i]);
         break;
       case CVT_BUFFER:
+      case CVT_ARRAY_BOOLEAN:
       case CVT_ARRAY_BYTE:
       case CVT_ARRAY_SHORT:
       case CVT_ARRAY_CHAR:

--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -485,7 +485,7 @@ dispatch(JNIEnv *env, void* func, jint flags, jobjectArray args,
     }
     else if ((*env)->IsInstanceOf(env, arg, classBoolean)) {
       c_args[i].i = (*env)->GetBooleanField(env, arg, FID_Boolean_value);
-      arg_types[i] = &ffi_type_sint32;
+      arg_types[i] = &ffi_type_uint32;
       arg_values[i] = &c_args[i].i;
     }
     else if ((*env)->IsInstanceOf(env, arg, classByte)) {

--- a/test/com/sun/jna/ArgumentsMarshalTest.java
+++ b/test/com/sun/jna/ArgumentsMarshalTest.java
@@ -109,6 +109,12 @@ public class ArgumentsMarshalTest extends TestCase {
         int fillFloatBuffer(float[] buf, int len, float value);
         int fillDoubleBuffer(double[] buf, int len, double value);
 
+        // boolean[] maps to jboolean* (always 8-bit), boolean mapping is 32-bit by default; use byte
+        int fillInt8Buffer(boolean[] buf, int len, byte value);
+
+        // char[] maps to jchar* (always 16-bit), char maps to wchar_t (can be 32-bit); use short
+        int fillInt16Buffer(char[] buf, int len, short value);
+
         // Nonexistent functions
         boolean returnBooleanArgument(Object arg);
 
@@ -507,11 +513,35 @@ public class ArgumentsMarshalTest extends TestCase {
         }
     }
 
+    public void testBooleanArrayArgument() {
+        boolean[] buf = new boolean[1024];
+        assertEquals("Wrong return value", buf.length,
+                     lib.fillInt8Buffer(buf, buf.length, (byte)1));
+        for (int i=0;i < buf.length;i++) {
+            assertTrue("Bad value at index " + i, buf[i]);
+        }
+        assertEquals("Wrong return value", buf.length,
+                     lib.fillInt8Buffer(buf, buf.length, (byte)0));
+        for (int i=0;i < buf.length;i++) {
+            assertFalse("Bad value at index " + i, buf[i]);
+        }
+    }
+
     public void testByteArrayArgument() {
         byte[] buf = new byte[1024];
         final byte MAGIC = (byte)0xED;
         assertEquals("Wrong return value", buf.length,
                      lib.fillInt8Buffer(buf, buf.length, MAGIC));
+        for (int i=0;i < buf.length;i++) {
+            assertEquals("Bad value at index " + i, MAGIC, buf[i]);
+        }
+    }
+
+    public void testCharArrayArgument() {
+        char[] buf = new char[1024];
+        final char MAGIC = '\uFEFF';
+        assertEquals("Wrong return value", buf.length,
+                     lib.fillInt16Buffer(buf, buf.length, (short)MAGIC));
         for (int i=0;i < buf.length;i++) {
             assertEquals("Bad value at index " + i, MAGIC, buf[i]);
         }

--- a/test/com/sun/jna/DirectArgumentsMarshalTest.java
+++ b/test/com/sun/jna/DirectArgumentsMarshalTest.java
@@ -107,6 +107,10 @@ public class DirectArgumentsMarshalTest extends ArgumentsMarshalTest {
         public native int fillFloatBuffer(float[] buf, int len, float value);
         @Override
         public native int fillDoubleBuffer(double[] buf, int len, double value);
+        @Override
+        public native int fillInt8Buffer(boolean[] buf, int len, byte value);
+        @Override
+        public native int fillInt16Buffer(char[] buf, int len, short value);
 
         // dummy to avoid causing Native.register to fail
         @Override


### PR DESCRIPTION
This is consistent with how these are handled in [interface mapping](https://github.com/java-native-access/jna/blob/b37a652c/native/dispatch.c#L581).

Also boolean is `ffi_type_uint32` everywhere in the source code, except [here](https://github.com/java-native-access/jna/commit/8f2e773a).