### PR TITLE
Enhance SSPI function converage and bugfix SecBufferDesc2 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ Features
 * [#805](https://github.com/java-native-access/jna/issues/805): Provide a way to pass JNIEnv pointer to native method and support OPTION_ALLOW_OBJECTs for direct mapping - [@ncruces](https://github.com/ncruces).
 * [#816](https://github.com/java-native-access/jna/pull/816): Support `boolean[]` in direct mapping - [@ncruces](https://github.com/ncruces).
 * [#827](https://github.com/java-native-access/jna/pull/827): Add support for linux-mips64el - [@all7](https://github.com/all7).
-* [#???](https://github.com/java-native-access/jna/pull/???): Bind SSPI functions `InitializeSecurityContext`, `AcceptSecurityContext`, `QueryCredentialsAttributes`, `QuerySecurityPackageInfo`, `EncryptMessage`, `DecryptMessage`, `MakeSignature`, `VerifySignature` in `com.sun.jna.platform.win32.Secur32`
+* [#???](https://github.com/java-native-access/jna/pull/???): Bind SSPI functions `InitializeSecurityContext`, `AcceptSecurityContext`, `QueryCredentialsAttributes`, `QuerySecurityPackageInfo`, `EncryptMessage`, `DecryptMessage`, `MakeSignature`, `VerifySignature` in `com.sun.jna.platform.win32.Secur32` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------
@@ -21,6 +21,7 @@ Bug Fixes
 * [#785](https://github.com/java-native-access/jna/issues/785): OaIdlUtil#toPrimitiveArray fails if dimension bounds are not 0-based - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#795](https://github.com/java-native-access/jna/issues/795): com.sun.jna.platform.win32.WinDef.WORDByReference holds a WORD which is defined to 16 bit on windows, so it needs to be accessed as short (getShort()). Fix suggested by  - [@kdeines](https://github.com/kdeines).
 * [#804](https://github.com/java-native-access/jna/pull/804) Main-Class in jna-platform.jar collides with java 9 module system - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#???](): Fix binding of `com.sun.jna.platform.win32.User32#MonitorFromPoint` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.4.0
 =============

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Features
 * [#805](https://github.com/java-native-access/jna/issues/805): Provide a way to pass JNIEnv pointer to native method and support OPTION_ALLOW_OBJECTs for direct mapping - [@ncruces](https://github.com/ncruces).
 * [#816](https://github.com/java-native-access/jna/pull/816): Support `boolean[]` in direct mapping - [@ncruces](https://github.com/ncruces).
 * [#827](https://github.com/java-native-access/jna/pull/827): Add support for linux-mips64el - [@all7](https://github.com/all7).
+* [#???](https://github.com/java-native-access/jna/pull/???): Bind SSPI functions `InitializeSecurityContext`, `AcceptSecurityContext`, `QueryCredentialsAttributes`, `QuerySecurityPackageInfo`, `EncryptMessage`, `DecryptMessage`, `MakeSignature`, `VerifySignature` in `com.sun.jna.platform.win32.Secur32`
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IUnknown.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IUnknown.java
@@ -32,8 +32,12 @@ import com.sun.jna.ptr.PointerByReference;
 /**
  * Wrapper class for the ITypeInfo interface
  * 
- * Method Name V-Table Offset IUnknown.QueryInterface 0 IUnknown.AddRef 4
- * IUnknown.Release 8
+ * <table>
+ * <tr><th>Method Name</th><th>V-Table Offset</th></tr>
+ * <tr><td>IUnknown.QueryInterface</td><td>0</td></tr>
+ * <tr><td>IUnknown.AddRef</td><td>4</td></tr>
+ * <tr><td>IUnknown.Release</td><td>8</td></tr>
+ * </table>
  * 
  * @author Tobias Wolf, wolf.tobias@gmx.net
  */

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
@@ -447,7 +447,7 @@ public interface Ole32 extends StdCallLibrary {
 
     /**
      * Puts an OLE compound document object into the running state.
-     * @param pUnknown [in] Pointer to the {@link IUnknown IUnknown} interface
+     * @param pUnknown [in] Pointer to the {@link com.sun.jna.platform.win32.COM.IUnknown IUnknown} interface
      *                 on the object, with which it will query for a pointer to
      *                 the IRunnableObject interface, and then call its Run method.
      * @return This function returns  on success.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
@@ -30,6 +30,7 @@ import com.sun.jna.platform.win32.Sspi.CredHandle;
 import com.sun.jna.platform.win32.Sspi.CtxtHandle;
 import com.sun.jna.platform.win32.Sspi.PSecPkgInfo;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
+import com.sun.jna.platform.win32.Sspi.SecBufferDesc2;
 import com.sun.jna.platform.win32.Sspi.TimeStamp;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.platform.win32.WinNT.LUID;
@@ -90,8 +91,8 @@ public interface Secur32 extends StdCallLibrary {
      * @param pAuthData
      *  A pointer to package-specific data. This parameter can be NULL, which indicates 
      *  that the default credentials for that package must be used. To use supplied 
-     *  credentials, pass a SEC_WINNT_AUTH_IDENTITY structure that includes those credentials 
-     *  in this parameter.
+     *  credentials, pass a {@link com.sun.jna.platform.win32.Sspi.SEC_WINNT_AUTH_IDENTITY} 
+     *  structure that includes those credentials in this parameter.
      * @param pGetKeyFn
      *  This parameter is not used and should be set to NULL. 
      * @param pvGetKeyArgument
@@ -172,7 +173,9 @@ public interface Secur32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the function returns one of the SEC_I_ success codes.
      *  If the function fails, the function returns one of the SEC_E_ error codes.
+     * @deprecated use {@link Secur32#InitializeSecurityContext(com.sun.jna.platform.win32.Sspi.CredHandle, com.sun.jna.platform.win32.Sspi.CtxtHandle, java.lang.String, int, int, int, com.sun.jna.platform.win32.Sspi.SecBufferDesc2, int, com.sun.jna.platform.win32.Sspi.CtxtHandle, com.sun.jna.platform.win32.Sspi.SecBufferDesc2, com.sun.jna.ptr.IntByReference, com.sun.jna.platform.win32.Sspi.TimeStamp) }
      */
+    @Deprecated
     int InitializeSecurityContext(CredHandle phCredential, CtxtHandle phContext,
                                          String pszTargetName, int fContextReq, int Reserved1,
                                          int TargetDataRep, SecBufferDesc pInput, int Reserved2,
@@ -246,7 +249,9 @@ public interface Secur32 extends StdCallLibrary {
      *  A pointer to a TimeStamp structure that receives the expiration time of the context. 
      * @return
      *  This function returns one of SEC_* values.
+     * @deprecated use {@link Secur32#AcceptSecurityContext(com.sun.jna.platform.win32.Sspi.CredHandle, com.sun.jna.platform.win32.Sspi.CtxtHandle, com.sun.jna.platform.win32.Sspi.SecBufferDesc, int, int, com.sun.jna.platform.win32.Sspi.CtxtHandle, com.sun.jna.platform.win32.Sspi.SecBufferDesc, com.sun.jna.ptr.IntByReference, com.sun.jna.platform.win32.Sspi.TimeStamp)}
      */
+    @Deprecated
     int AcceptSecurityContext(CredHandle phCredential, CtxtHandle phContext,
                                      SecBufferDesc pInput, int fContextReq, int TargetDataRep,
                                      CtxtHandle phNewContext, SecBufferDesc pOutput, IntByReference pfContextAttr,
@@ -340,4 +345,397 @@ public interface Secur32 extends StdCallLibrary {
      *  If the function fails, the return value is a nonzero error code.
      */
     int QueryContextAttributes(CtxtHandle phContext, int ulAttribute, Structure pBuffer);
+    
+    /**
+     * Retrieves the attributes of a credential, such as the name associated
+     * with the credential. The information is valid for any security context
+     * created with the specified credential.
+     *
+     * @param phCredential A handle of the credentials to be queried.
+     * @param ulAttribute Specifies the attribute of the context to be returned.
+     *                    This parameter can be one of the SECPKG_ATTR_* values
+     *                    defined in {@link Sspi}.
+     * @param pBuffer     A pointer to a structure that receives the attributes.
+     *                    The type of structure pointed to depends on the value
+     *                    specified in the ulAttribute parameter.
+     * @return If the function succeeds, the return value is SEC_E_OK. If the
+     *         function fails, the return value is a nonzero error code.
+     */
+    int QueryCredentialsAttributes(Sspi.CredHandle phCredential, int ulAttribute, Structure pBuffer);
+    
+    /**
+     * Retrieves information about a specified security package. This
+     * information includes the bounds on sizes of authentication information,
+     * credentials, and contexts.
+     *
+     * @param pszPackageName Name of the security package.
+     * @param ppPackageInfo  Variable that receives a pointer to a SecPkgInfo
+     *                       structure containing information about the
+     *                       specified security package.
+     * @return  If the function succeeds, the return value is SEC_E_OK.
+     * If the function fails, the return value is a nonzero error code.
+     */
+    int QuerySecurityPackageInfo(String pszPackageName, Sspi.PSecPkgInfo ppPackageInfo);
+    
+    /**
+     * EncryptMessage (Kerberos) function
+     * 
+     * <p>
+     * The EncryptMessage (Kerberos) function encrypts a message to provide
+     * privacy. EncryptMessage (Kerberos) allows an application to choose among
+     * cryptographic algorithms supported by the chosen mechanism. The
+     * EncryptMessage (Kerberos) function uses the security context referenced
+     * by the context handle. Some packages do not have messages to be encrypted
+     * or decrypted but rather provide an integrity hash that can be
+     * checked.</p>
+     *
+     * @param phContext A handle to the security context to be used to encrypt
+     *                  the message.
+     * @param fQOP      Package-specific flags that indicate the quality of
+     *                  protection. A security package can use this parameter to
+     *                  enable the selection of cryptographic algorithms. This
+     *                  parameter can be the following flag:
+     *                  {@link Sspi#SECQOP_WRAP_NO_ENCRYPT}.
+     * @param pMessage  A pointer to a SecBufferDesc structure. On input, the
+     *                  structure references one or more SecBuffer structures
+     *                  that can be of type SECBUFFER_DATA. That buffer contains
+     *                  the message to be encrypted. The message is encrypted in
+     *                  place, overwriting the original contents of the
+     *                  structure.
+     *
+     * <p>
+     * The function does not process buffers with the SECBUFFER_READONLY
+     * attribute.</p>
+     *
+     * <p>
+     * The length of the SecBuffer structure that contains the message must be
+     * no greater than cbMaximumMessage, which is obtained from the
+     * QueryContextAttributes (Kerberos) (SECPKG_ATTR_STREAM_SIZES)
+     * function.</p>
+     *
+     * <p>
+     * Applications that do not use SSL must supply a SecBuffer of type
+     * SECBUFFER_PADDING.</p>
+     * @param MessageSeqNo The sequence number that the transport application
+     *                     assigned to the message. If the transport application
+     *                     does not maintain sequence numbers, this parameter
+     *                     must be zero.
+     * @return If the function succeeds, the function returns SEC_E_OK.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa375385(v=vs.85).aspx">MSDN Entry</a>
+     */
+    int EncryptMessage(CtxtHandle phContext, int fQOP, SecBufferDesc2 pMessage, int MessageSeqNo);
+    
+    /**
+     * VerifySignature function.
+     *
+     * <p>
+     * Verifies that a message signed by using the MakeSignature function was
+     * received in the correct sequence and has not been modified.</p>
+     *
+     * <p>
+     * <strong>Warning</strong></p>
+     *
+     * <p>
+     * The VerifySignature function will fail if the message was signed using
+     * the RsaSignPssSha512 algorithm on a different version of Windows. For
+     * example, a message that was signed by calling the MakeSignature function
+     * on Windows 8 will cause the VerifySignature function on Windows 8.1 to
+     * fail.</p>
+     *
+     * @param phContext    A handle to the security context to use for the
+     *                     message.
+     * @param pMessage     Pointer to a SecBufferDesc structure that references
+     *                     a set of SecBuffer structures that contain the
+     *                     message and signature to verify. The signature is in
+     *                     a SecBuffer structure of type SECBUFFER_TOKEN.
+     * @param MessageSeqNo Specifies the sequence number expected by the
+     *                     transport application, if any. If the transport
+     *                     application does not maintain sequence numbers, this
+     *                     parameter is zero.
+     * @param pfQOP        Pointer to a ULONG variable that receives
+     *                     package-specific flags that indicate the quality of
+     *                     protection.
+     *
+     *                      <p>Some security packages ignore this parameter.</p>
+     *
+     * @return If the function verifies that the message was received in the
+     *         correct sequence and has not been modified, the return value is
+     *         SEC_E_OK.
+     *
+     * <p>
+     * If the function determines that the message is not correct according to
+     * the information in the signature, the return value can be one of the
+     * following error codes.</p>
+     * 
+     * <table>
+     * <tr><th>Return code</th><th>Description</th></tr>
+     * <tr><td>SEC_E_OUT_OF_SEQUENCE</td><td>The message was not received in the
+     * correct sequence.</td></tr>
+     * <tr><td>SEC_E_MESSAGE_ALTERED</td><td>The message has been
+     * altered.</td></tr>
+     * <tr><td>SEC_E_INVALID_HANDLE</td><td>The context handle specified by
+     * phContext is not valid.</td></tr>
+     * <tr><td>SEC_E_INVALID_TOKEN</td><td>pMessage did not contain a valid
+     * SECBUFFER_TOKEN buffer, or contained too few buffers.</td></tr>
+     * <tr><td>SEC_E_QOP_NOT_SUPPORTED</td><td>The quality of protection
+     * negotiated between the client and server did not include integrity
+     * checking.</td></tr>
+     * </table>
+     */
+    int VerifySignature(CtxtHandle phContext, SecBufferDesc2 pMessage, int MessageSeqNo, IntByReference pfQOP);
+    
+    /**
+     * MakeSignature function.
+     * 
+     * <p>
+     * The MakeSignature function generates a cryptographic checksum of the
+     * message, and also includes sequencing information to prevent message loss
+     * or insertion. MakeSignature allows the application to choose between
+     * several cryptographic algorithms, if supported by the chosen mechanism.
+     * The MakeSignature function uses the security context referenced by the
+     * context handle.</p>
+     *
+     * <p>
+     * <strong>Remarks</strong></p>
+     *
+     * <p>
+     * Remarks</p>
+     *<p>
+     * The MakeSignature function generates a signature that is based on the
+     * message and the session key for the context.</p>
+     *<p>
+     * The VerifySignature function verifies the messages signed by the
+     * MakeSignature function.</p>
+     *<p>
+     * If the transport application created the security context to support
+     * sequence detection and the caller provides a sequence number, the
+     * function includes this information in the signature. This protects
+     * against reply, insertion, and suppression of messages. The security
+     * package incorporates the sequence number passed down from the transport
+     * application.</p>
+     *
+     * @param phContext    A handle to the security context to use to sign the
+     *                     message.
+     * @param fQOP         Package-specific flags that indicate the quality of
+     *                     protection. A security package can use this parameter
+     *                     to enable the selection of cryptographic algorithms.
+     * <p>
+     * When using the Digest SSP, this parameter must be set to zero.</p>
+     *
+     * @param pMessage     A pointer to a SecBufferDesc structure. On input, the
+     *                     structure references one or more SecBuffer structures
+     *                     that contain the message to be signed. The function
+     *                     does not process buffers with the
+     *                     SECBUFFER_READONLY_WITH_CHECKSUM attribute.
+     *
+     * <p>
+     * The SecBufferDesc structure also references a SecBuffer structure of type
+     * SECBUFFER_TOKEN that receives the signature.</p>
+     * <p>
+     * When the Digest SSP is used as an HTTP authentication protocol, the
+     * buffers should be configured as follows.</p>
+     * <table>
+     * <tr><th>Buffer #/buffer type</th><th>Meaning</th></tr>
+     * <tr><td>0 / SECBUFFER_TOKEN</td><td>Empty.</td></tr>
+     * <tr><td>1 / SECBUFFER_PKG_PARAMS</td><td>Method.</td></tr>
+     * <tr><td>2 / SECBUFFER_PKG_PARAMS</td><td>URL.</td></tr>
+     * <tr><td>3 / SECBUFFER_PKG_PARAMS</td><td>HEntity. For more information,
+     * see Input Buffers for the Digest Challenge Response.</td></tr>
+     * <tr><td>4 / SECBUFFER_PADDING</td><td>Empty. Receives the
+     * signature.</td></tr>
+     * </table>
+     *<p>
+     * When the Digest SSP is used as an SASL mechanism, the buffers should be
+     * configured as follows.</p>
+     *<table>
+     * <tr><th>Buffer #/buffer type</th><th>Meaning</th></tr>
+     * <tr><td>0 / SECBUFFER_TOKEN</td><td>Empty. Receives the signature. This
+     * buffer must be large enough to hold the largest possible signature.
+     * Determine the size required by calling the QueryContextAttributes
+     * (General) function and specifying SECPKG_ATTR_SIZES. Check the returned
+     * SecPkgContext_Sizes structure member cbMaxSignature.</td></tr>
+     * <tr><td>1 / SECBUFFER_DATA</td><td>Message to be signed.</td></tr>
+     * <tr><td>2 / SECBUFFER_PADDING</td><td>Empty.</td></tr>
+     * </table>
+     * @param MessageSeqNo      *
+     *                     The sequence number that the transport application
+     *                     assigned to the message. If the transport application
+     *                     does not maintain sequence numbers, this parameter is
+     *                     zero.
+     *
+     * <p>
+     * When using the Digest SSP, this parameter must be set to zero. The Digest
+     * SSP manages sequence numbering internally.</p>
+     *
+     * @return If the function succeeds, the function returns SEC_E_OK.
+     *
+     * <p>
+     * If the function fails, it returns one of the following error codes.</p>
+     *
+     * <table>
+     * <tr><th>Return code</th><th>Description</th>
+     * <tr><td>SEC_I_RENEGOTIATE</td><td>The remote party requires a new
+     * handshake sequence or the application has just initiated a shutdown.
+     * Return to the negotiation loop and call AcceptSecurityContext (General)
+     * or InitializeSecurityContext (General) again. An empty input buffer is
+     * passed in the first call.</td></tr>
+     * <tr><td>SEC_E_INVALID_HANDLE</td><td>The context handle specified by
+     * phContext is not valid.</td></tr>
+     * <tr><td>SEC_E_INVALID_TOKEN</td><td>pMessage did not contain a valid
+     * SECBUFFER_TOKEN buffer or contained too few buffers.</td></tr>
+     * <tr><td>SEC_E_OUT_OF_SEQUENCE</td><td>The nonce count is out of
+     * sequence.</td></tr>
+     * <tr><td>SEC_E_NO_AUTHENTICATING_AUTHORITY</td><td>The security context
+     * (phContext) must be revalidated.</td></tr>
+     * <tr><td>STATUS_INVALID_PARAMETER</td><td>The nonce count is not
+     * numeric.</td></tr>
+     * <tr><td>SEC_E_QOP_NOT_SUPPORTED</td><td>The quality of protection
+     * negotiated between the client and server did not include integrity
+     * checking.</td></tr>
+     * </table>
+     */
+    int MakeSignature(CtxtHandle phContext, int fQOP, SecBufferDesc2 pMessage, int MessageSeqNo);
+    
+    /**
+     * DecryptMessage (Kerberos) function
+     *
+     * <p>
+     * The DecryptMessage (Kerberos) function decrypts a message. Some packages
+     * do not encrypt and decrypt messages but rather perform and check an
+     * integrity hash.</p>
+     *
+     * @param phContext    A handle to the security context to be used to
+     *                     encrypt the message.
+     * @param pMessage     A pointer to a SecBufferDesc structure. On input, the
+     *                     structure references one or more SecBuffer structures
+     *                     that may be of type SECBUFFER_DATA. The buffer
+     *                     contains the encrypted message. The encrypted message
+     *                     is decrypted in place, overwriting the original
+     *                     contents of its buffer.
+     * @param MessageSeqNo The sequence number expected by the transport
+     *                     application, if any. If the transport application
+     *                     does not maintain sequence numbers, this parameter
+     *                     must be set to zero.
+     * @param pfQOP        A pointer to a variable of type ULONG that receives
+     *                     package-specific flags that indicate the quality of
+     *                     protection. This parameter can be the following flag:
+     *                     {@link Sspi#SECQOP_WRAP_NO_ENCRYPT}.
+     * @return If the function verifies that the message was received in the correct sequence, the function returns SEC_E_OK.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa375385(v=vs.85).aspx">MSDN Entry</a>
+     */
+    int DecryptMessage(CtxtHandle phContext, SecBufferDesc2 pMessage, int MessageSeqNo, IntByReference pfQOP);
+    
+    /**
+     * The AcceptSecurityContext function enables the server component of a transport 
+     * application to establish a security context between the server and a remote client.
+     * The remote client uses the InitializeSecurityContext function to start the process 
+     * of establishing a security context. The server can require one or more reply tokens
+     * from the remote client to complete establishing the security context.
+     * @param phCredential
+     *  A handle to the credentials of the server. The server calls the AcquireCredentialsHandle 
+     *  function with either the SECPKG_CRED_INBOUND or SECPKG_CRED_BOTH flag set to retrieve 
+     *  this handle. 
+     * @param phContext
+     *  A pointer to a CtxtHandle structure. On the first call to AcceptSecurityContext, 
+     *  this pointer is NULL. On subsequent calls, phContext is the handle to the partially 
+     *  formed context that was returned in the phNewContext parameter by the first call. 
+     * @param pInput
+     *  A pointer to a SecBufferDesc structure generated by a client call to 
+     *  InitializeSecurityContext that contains the input buffer descriptor. 
+     * @param fContextReq
+     *  Bit flags that specify the attributes required by the server to establish the 
+     *  context. Bit flags can be combined by using bitwise-OR operations.
+     * @param TargetDataRep
+     *  The data representation, such as byte ordering, on the target. This parameter can 
+     *  be either SECURITY_NATIVE_DREP or SECURITY_NETWORK_DREP.
+     * @param phNewContext
+     *  A pointer to a CtxtHandle structure. On the first call to AcceptSecurityContext, 
+     *  this pointer receives the new context handle. On subsequent calls, phNewContext 
+     *  can be the same as the handle specified in the phContext parameter. 
+     * @param pOutput
+     *  A pointer to a SecBufferDesc structure that contains the output buffer descriptor. 
+     *  This buffer is sent to the client for input into additional calls to 
+     *  InitializeSecurityContext. An output buffer may be generated even if the function 
+     *  returns SEC_E_OK. Any buffer generated must be sent back to the client application. 
+     * @param pfContextAttr
+     *  A pointer to a variable that receives a set of bit flags that indicate the 
+     *  attributes of the established context. For a description of the various attributes, 
+     *  see Context Requirements. Flags used for this parameter are prefixed with ASC_RET, 
+     *  for example, ASC_RET_DELEGATE.
+     * @param ptsTimeStamp
+     *  A pointer to a TimeStamp structure that receives the expiration time of the context. 
+     * @return
+     *  This function returns one of SEC_* values.
+     */
+    int AcceptSecurityContext(Sspi.CredHandle phCredential, CtxtHandle phContext,
+                                     SecBufferDesc2 pInput, int fContextReq, int TargetDataRep,
+                                     CtxtHandle phNewContext, SecBufferDesc2 pOutput, IntByReference pfContextAttr,
+                                     Sspi.TimeStamp ptsTimeStamp);
+	
+    /**
+     * The InitializeSecurityContext function initiates the client side, outbound security 
+     * context from a credential handle. The function is used to build a security context 
+     * between the client application and a remote peer. InitializeSecurityContext returns 
+     * a token that the client must pass to the remote peer, which the peer in turn submits 
+     * to the local security implementation through the AcceptSecurityContext call. The 
+     * token generated should be considered opaque by all callers.
+     * 
+     * Typically, the InitializeSecurityContext function is called in a loop until a 
+     * sufficient security context is established.
+     * 
+     * @param phCredential
+     *  A handle to the credentials returned by AcquireCredentialsHandle. This handle is 
+     *  used to build the security context. The InitializeSecurityContext function requires 
+     *  at least OUTBOUND credentials. 
+     * @param phContext
+     *  A pointer to a CtxtHandle structure. On the first call to InitializeSecurityContext,
+     *  this pointer is NULL. On the second call, this parameter is a pointer to the handle 
+     *  to the partially formed context returned in the phNewContext parameter by the first 
+     *  call.
+     * @param pszTargetName
+     *  A pointer to a null-terminated string that indicates the target of the context. 
+     *  The string contents are security-package specific.
+     * @param fContextReq
+     *  Bit flags that indicate requests for the context. Not all packages can support all 
+     *  requirements. Flags used for this parameter are prefixed with ISC_REQ_, for example,
+     *  ISC_REQ_DELEGATE. 
+     * @param Reserved1
+     *  This parameter is reserved and must be set to zero.
+     * @param TargetDataRep
+     *  The data representation, such as byte ordering, on the target. This parameter can be 
+     *  either SECURITY_NATIVE_DREP or SECURITY_NETWORK_DREP.
+     * @param pInput
+     *  A pointer to a SecBufferDesc structure that contains pointers to the buffers supplied 
+     *  as input to the package. The pointer must be NULL on the first call to the function. 
+     *  On subsequent calls to the function, it is a pointer to a buffer allocated with enough 
+     *  memory to hold the token returned by the remote peer.
+     * @param Reserved2
+     *  This parameter is reserved and must be set to zero. 
+     * @param phNewContext
+     *  A pointer to a CtxtHandle structure. On the first call to InitializeSecurityContext, 
+     *  this pointer receives the new context handle. On the second call, phNewContext can be 
+     *  the same as the handle specified in the phContext parameter.
+     * @param pOutput
+     *  A pointer to a SecBufferDesc structure that contains pointers to the SecBuffer structure 
+     *  that receives the output data. If a buffer was typed as SEC_READWRITE in the input, it 
+     *  will be there on output. The system will allocate a buffer for the security token if 
+     *  requested (through ISC_REQ_ALLOCATE_MEMORY) and fill in the address in the buffer 
+     *  descriptor for the security token.
+     * @param pfContextAttr
+     *  A pointer to a variable to receive a set of bit flags that indicate the attributes of 
+     *  the established context. Flags used for this parameter are prefixed with ISC_RET, 
+     *  such as ISC_RET_DELEGATE.
+     * @param ptsExpiry
+     *  A pointer to a TimeStamp structure that receives the expiration time of the context.
+     *  It is recommended that the security package always return this value in local time. 
+     *  This parameter is optional and NULL should be passed for short-lived clients.
+     * @return
+     *  If the function succeeds, the function returns one of the SEC_I_ success codes.
+     *  If the function fails, the function returns one of the SEC_E_ error codes.
+     */
+    int InitializeSecurityContext(Sspi.CredHandle phCredential, CtxtHandle phContext,
+                                         String pszTargetName, int fContextReq, int Reserved1,
+                                         int TargetDataRep, SecBufferDesc2 pInput, int Reserved2,
+                                         CtxtHandle phNewContext, SecBufferDesc2 pOutput, IntByReference pfContextAttr,
+                                         Sspi.TimeStamp ptsExpiry);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
@@ -65,6 +65,11 @@ public interface Sspi {
      */
     int SECURITY_NATIVE_DREP = 0x10;
 
+    
+    /**
+     * Specifies network data representation.
+     */
+    int SECURITY_NETWORK_DREP = 0x00;
 
     // Flags for the fContextReq parameter of InitializeSecurityContext or AcceptSecurityContext.
 
@@ -142,15 +147,211 @@ public interface Sspi {
      */
     int SECBUFFER_TOKEN = 2;
 
-    // for ulAttribute parameter in QueryContextAttributes function
-    // (https://msdn.microsoft.com/en-us/library/windows/desktop/aa379326(v=vs.85).aspx)
+    /**
+     * The pBuffer parameter contains a pointer to a {@link SecPkgContext_Sizes}
+     * structure.
+     *
+     * <p>Queries the sizes of the structures used in the per-message functions.</p>
+     */
+    int SECPKG_ATTR_SIZES = 0;
+    /**
+     * The pBuffer parameter contains a pointer to a {@link SecPkgCredentials_Names}
+     * structure.
+     *
+     * <p>Queries the name associated with the context.</p>
+     */
+    int SECPKG_ATTR_NAMES = 1;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_Lifespan
+     * structure.
+     *
+     * <p>Queries the life span of the context.</p>
+     */
+    int SECPKG_ATTR_LIFESPAN = 2;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_DceInfo
+     * structure.
+     *
+     * <p>Queries for authorization data used by DCE services.</p>
+     */
+    int SECPKG_ATTR_DCE_INFO = 3;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_StreamSizes
+     * structure.
+     *
+     * <p>Queries the sizes of the various parts of a stream used in the
+     * per-message functions.</p>
+     * <p>This attribute is supported only by the Schannel security package.</p>
+     */
+    int SECPKG_ATTR_STREAM_SIZES = 4;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_KeyInfo
+     * structure.
+     *
+     * <p>Queries information about the keys used in a security context.</p>
+     */
+    int SECPKG_ATTR_KEY_INFO = 5;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_Authority
+     * structure.
+     *
+     * <p>Queries the name of the authenticating authority.</p>
+     */
+    int SECPKG_ATTR_AUTHORITY = 6;
+    int SECPKG_ATTR_PROTO_INFO = 7;
+    /**
+     * The pBuffer parameter contains a pointer to a
+     * SecPkgContext_PasswordExpiry structure.
+     *
+     * <p>Returns password expiration information.</p>
+     */
+    int SECPKG_ATTR_PASSWORD_EXPIRY = 8;
+    /**
+     * The pBuffer parameter contains a pointer to a
+     * {@link SecPkgContext_SessionKey} structure.
+     *
+     * Returns information about the session keys.
+     */
+    int SECPKG_ATTR_SESSION_KEY = 9;
     /**
      * The pBuffer parameter contains a pointer to a
      * {@link SecPkgContext_PackageInfo} structure.
-     * 
+     *
      * Returns information on the SSP in use.
      */
-    int SECPKG_ATTR_PACKAGE_INFO = 0x0000000A;
+    int SECPKG_ATTR_PACKAGE_INFO = 10;
+    int SECPKG_ATTR_USER_FLAGS = 11;
+    /**
+     * The pBuffer parameter contains a pointer to a
+     * {@link SecPkgContext_NegotiationInfo} structure.
+     *
+     * <p>Returns information about the security package to be used with the
+     * negotiation process and the current state of the negotiation for the use
+     * of that package.</p>
+     */
+    int SECPKG_ATTR_NEGOTIATION_INFO = 12;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_NativeNames
+     * structure.
+     *
+     * <p>Returns the principal name (CNAME) from the outbound ticket.</p>
+     */
+    int SECPKG_ATTR_NATIVE_NAMES = 13;
+    /**
+     * The pBuffer parameter contains a pointer to a {@link SecPkgContext_Flags}
+     * structure.
+     *
+     * <p>Returns information about the negotiated context flags.</p>
+     */
+    int SECPKG_ATTR_FLAGS = 14;
+    // These attributes exist only in Win XP and greater
+    int SECPKG_ATTR_USE_VALIDATED = 15;
+    int SECPKG_ATTR_CREDENTIAL_NAME = 16;
+    /**
+     * The pBuffer parameter contains a pointer to a
+     * SecPkgContext_TargetInformation structure.
+     *
+     * <p>Returns information about the name of the remote server.</p>
+     */
+    int SECPKG_ATTR_TARGET_INFORMATION = 17;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_AccessToken
+     * structure.
+     *
+     * <p>Returns a handle to the access token.</p>
+     */
+    int SECPKG_ATTR_ACCESS_TOKEN = 18;
+    // These attributes exist only in Win2K3 and greater
+    int SECPKG_ATTR_TARGET = 19;
+    int SECPKG_ATTR_AUTHENTICATION_ID = 20;
+    // These attributes exist only in Win2K3SP1 and greater
+    int SECPKG_ATTR_LOGOFF_TIME = 21;
+    //
+    // win7 or greater
+    //
+    int SECPKG_ATTR_NEGO_KEYS = 22;
+    int SECPKG_ATTR_PROMPTING_NEEDED = 24;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_Bindings
+     * structure that specifies channel binding information.
+     *
+     * <p>This value is supported only by the Schannel security package.</p>
+     *
+     * <p><strong>Windows Server 2008, Windows Vista, Windows Server 2003 and
+     * Windows XP:</strong>
+     * This value is not supported.</p>
+     */
+    int SECPKG_ATTR_UNIQUE_BINDINGS = 25;
+    /**
+     * The pBuffer parameter contains a pointer to a SecPkgContext_Bindings
+     * structure that specifies channel binding information.
+     *
+     * <p>This attribute is supported only by the Schannel security package.</p>
+     *
+     * <p><strong>Windows Server 2008, Windows Vista, Windows Server 2003 and
+     * Windows XP:</strong>
+     * This value is not supported.</p>
+     */
+    int SECPKG_ATTR_ENDPOINT_BINDINGS = 26;
+    /**
+     * The pBuffer parameter contains a pointer to a
+     * SecPkgContext_ClientSpecifiedTarget structure that represents the service
+     * principal name (SPN) of the initial target supplied by the client.
+     * 
+     * <p><strong>Windows Server 2008, Windows Vista, Windows Server 2003 and
+     * Windows XP:</strong>
+     * This value is not supported.</p>
+     */
+    int SECPKG_ATTR_CLIENT_SPECIFIED_TARGET = 27;
+
+    /**
+     * The pBuffer parameter contains a pointer to a
+     * SecPkgContext_LastClientTokenStatus structure that specifies whether the
+     * token from the most recent call to the InitializeSecurityContext function
+     * is the last token from the client.
+     *
+     * <p>This value is supported only by the Negotiate, Kerberos, and NTLM
+     * security packages.</p>
+     * 
+     * <p><strong>Windows Server 2008, Windows Vista, Windows Server 2003 and
+     * Windows XP:</strong>
+     * This value is not supported.</p>
+     */
+    int SECPKG_ATTR_LAST_CLIENT_TOKEN_STATUS = 30;
+    int SECPKG_ATTR_NEGO_PKG_INFO = 31; // contains nego info of packages
+    int SECPKG_ATTR_NEGO_STATUS = 32; // contains the last error
+    int SECPKG_ATTR_CONTEXT_DELETED = 33; // a context has been deleted
+
+    /**
+     * The pBuffer parameter contains a pointer to a
+     * SecPkgContext_SubjectAttributes structure.
+     *
+     * <p>This value returns information about the security attributes for the
+     * connection.</p>
+     *
+     * <p>This value is supported only on the CredSSP server.</p>
+     * 
+     * <p><strong>Windows Server 2008, Windows Vista, Windows Server 2003 and
+     * Windows XP:</strong>
+     * This value is not supported.</p>
+     */
+    int SECPKG_ATTR_SUBJECT_SECURITY_ATTRIBUTES = 128;
+
+    /**
+     * Negotiation has been completed.
+     */
+    int SECPKG_NEGOTIATION_COMPLETE = 0;
+    /**
+     * Negotiations not yet completed.
+     */
+    int SECPKG_NEGOTIATION_OPTIMISTIC = 1;
+    /**
+     * Negotiations in progress.
+     */
+    int SECPKG_NEGOTIATION_IN_PROGRESS = 2;
+    int SECPKG_NEGOTIATION_DIRECT = 3;
+    int SECPKG_NEGOTIATION_TRY_MULTICRED = 4;
+    
     
     // flags for SecPkgInfo fCapabilities
     // (https://msdn.microsoft.com/en-us/library/windows/desktop/aa380104(v=vs.85).aspx)
@@ -252,6 +453,22 @@ public interface Sspi {
      */
     int SECPKG_FLAG_APPCONTAINER_CHECKS = 0x00800000;
 
+    /**
+     * Returns the name of a credential in a pbuffer of type {@link SecPkgCredentials_Names}.
+     */
+    int SECPKG_CRED_ATTR_NAMES = 1;
+
+    /**
+     * Produce a header or trailer but do not encrypt the message.
+     */
+    int SECQOP_WRAP_NO_ENCRYPT = 0x80000001;
+    /**
+     * Send an Schannel alert message. In this case, the pMessage parameter must
+     * contain a standard two-byte SSL/TLS event code. This value is supported
+     * only by the Schannel SSP.
+     */
+    int SECQOP_WRAP_OOB_DATA = 0x40000000;
+    
     /**
      * Security handle.
      */
@@ -424,6 +641,13 @@ public interface Sspi {
         }
     }
 
+    /**
+     * 
+     * @deprecated use {@link SecBufferDesc2} (generic binding) and
+     * {@link ManagedSecBufferDesc} (use for SecBufferDesc managed from the
+     * java side)
+     */
+    @Deprecated
     public static class SecBufferDesc extends Structure {
         public static final List<String> FIELDS = createFieldsOrder("ulVersion", "cBuffers", "pBuffers");
         /**
@@ -476,6 +700,107 @@ public interface Sspi {
         }
     }
 
+    /**
+     * The SecBufferDesc structure describes an array of SecBuffer structures
+     * to pass from a transport application to a security package.
+     * 
+     * <p>
+     * ManagedSecBufferDesc assumes, that the size of the SecBufferDesc is known
+     * at construction time. It is assumed, that this covers all relevant
+     * use-cases.</p>
+     */
+    public static class ManagedSecBufferDesc extends SecBufferDesc2 {
+                
+        private final SecBuffer[] secBuffers;
+        
+        /**
+         * Create a new SecBufferDesc with initial data.
+         * @param type Token type.
+         * @param token Initial token data.
+         */
+        public ManagedSecBufferDesc(int type, byte[] token) {
+            secBuffers = new SecBuffer[] { new SecBuffer(type, token) };
+            pBuffers = secBuffers[0].getPointer();
+            cBuffers = secBuffers.length;
+        }
+
+        /**
+         * Create a new SecBufferDesc with one SecBuffer of a given type and size.
+         * @param type type
+         * @param tokenSize token size
+         */
+        public ManagedSecBufferDesc(int type, int tokenSize) {
+            secBuffers = new SecBuffer[] { new SecBuffer(type, tokenSize) };
+            pBuffers = secBuffers[0].getPointer();
+            cBuffers = secBuffers.length;
+        }
+        
+        public ManagedSecBufferDesc(int bufferCount) {
+            cBuffers = bufferCount;
+            secBuffers = (SecBuffer[]) new SecBuffer().toArray(bufferCount);
+            pBuffers = secBuffers[0].getPointer();
+            cBuffers = secBuffers.length;
+        }
+
+        public SecBuffer getBuffer(int idx) {
+            return secBuffers[idx];
+        }
+
+        @Override
+        public void write() {
+            for(SecBuffer sb: secBuffers)  {
+                sb.write();
+            }
+            writeField("ulVersion");
+            writeField("pBuffers");
+            writeField("cBuffers");
+        }
+
+        @Override
+        public void read() {
+            for (SecBuffer sb : secBuffers) {
+                sb.read();
+            }
+        }
+
+    }
+    
+    /**
+     * The SecBufferDesc structure describes an array of SecBuffer structures to
+     * pass from a transport application to a security package.
+     * 
+     * If the SecBufferDesc2 is managed from the java side, prefer to use 
+     * {@link ManagedSecBufferDesc}.
+     */
+    public static class SecBufferDesc2 extends Structure {
+        public static final List<String> FIELDS = createFieldsOrder("ulVersion", "cBuffers", "pBuffers");
+
+        /**
+         * Version number.
+         */
+        public int ulVersion = SECBUFFER_VERSION;
+        /**
+         * Number of buffers.
+         */
+        public int cBuffers = 1;
+        /**
+         * Pointer to array of buffers.
+         */
+        public Pointer pBuffers;
+
+        /**
+         * Create a new SecBufferDesc with one SECBUFFER_EMPTY buffer.
+         */
+        public SecBufferDesc2() {
+            super();
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+    }
+    
     /**
      * A security integer.
      */
@@ -610,4 +935,401 @@ public interface Sspi {
         }
     }
 
+    /**
+     * The SecPkgCredentials_Names structure holds the name of the user
+     * associated with a context.
+     *
+     * <p>
+     * The
+     * {@link Secur32#QueryCredentialsAttributes(com.sun.jna.platform.win32.Sspi.CredHandle, int, com.sun.jna.Structure)}
+     * function uses this structure.</p>
+     */
+    public static class SecPkgCredentials_Names extends Structure {
+
+        public static class ByReference extends SecPkgCredentials_Names implements Structure.ByReference {
+
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("sUserName");
+
+        /**
+         * Pointer to a null-terminated string containing the name of the user
+         * represented by the credential. If the security package sets the
+         * SECPKG_FLAG_ACCEPT_WIN32_NAME flag to indicate that it can process
+         * Windows names, this name can be used in other Windows calls.
+         */
+        public Pointer sUserName;
+
+        public SecPkgCredentials_Names() {
+            super(W32APITypeMapper.DEFAULT);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+
+        /**
+         * @return value of userName attribute
+         */
+        public synchronized String getUserName() {
+            if (sUserName == null) {
+                return null;
+            }
+            return Boolean.getBoolean("w32.ascii") ? sUserName.getString(0) : sUserName.getWideString(0);
+        }
+
+        /**
+         * Free native buffer
+         * 
+         * @return {@link WinError#SEC_E_OK} if ok
+         */
+        public synchronized int free() {
+            if (sUserName != null) {
+                int result = Secur32.INSTANCE.FreeContextBuffer(sUserName);
+                sUserName = null;
+                return result;
+            }
+            return WinError.SEC_E_OK;
+        }
+    }
+    
+    /**
+     * The SecPkgContext_Sizes structure indicates the sizes of important
+     * structures used in the message support functions.
+     *
+     * <p>
+     * The {@link Secur32#QueryContextAttributes(com.sun.jna.platform.win32.Sspi.CtxtHandle, int, com.sun.jna.Structure)
+     * } function uses this structure.</p>
+     */
+    public static class SecPkgContext_Sizes extends Structure {
+
+        public static class ByReference extends SecPkgContext_Sizes implements Structure.ByReference {
+
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("cbMaxToken", "cbMaxSignature", "cbBlockSize", "cbSecurityTrailer");
+
+        /**
+         * Specifies the maximum size of the security token used in the authentication exchanges.
+         */
+        public int cbMaxToken;
+        
+        /**
+         * Specifies the maximum size of the signature created by the MakeSignature function. This member must be zero if integrity services are not requested or available.
+         */
+        public int cbMaxSignature;
+        
+        /**
+         * Specifies the preferred integral size of the messages. For example, eight indicates that messages should be of size zero mod eight for optimal performance. Messages other than this block size can be padded.
+         */
+        public int cbBlockSize;
+        
+        /**
+         * Size of the security trailer to be appended to messages. This member should be zero if the relevant services are not requested or available.
+         */
+        public int cbSecurityTrailer;
+
+        public SecPkgContext_Sizes() {
+            super(W32APITypeMapper.DEFAULT);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+
+        @Override
+        public String toString() {
+            return "SecPkgContext_Sizes{" + "cbMaxToken=" + cbMaxToken +
+                    ", cbMaxSignature=" + cbMaxSignature + ", cbBlockSize=" +
+                    cbBlockSize + ", cbSecurityTrailer=" + cbSecurityTrailer +
+                    '}';
+        }
+    }
+    
+    public static class SecPkgContext_SessionKey extends Structure {
+
+        public static class ByReference extends SecPkgContext_SessionKey implements Structure.ByReference {
+
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("SessionKeyLength", "SessionKey");
+
+        /**
+         * Size, in bytes, of the session key.
+         */
+        public int SessionKeyLength;
+        
+        /**
+         * The session key for the security context.
+         */
+        public Pointer SessionKey;
+
+        public SecPkgContext_SessionKey() {
+            super(W32APITypeMapper.DEFAULT);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+
+        public byte[] getSessionKey() {
+            if(SessionKey == null) {
+                return null;
+            }
+            return SessionKey.getByteArray(0, SessionKeyLength);
+        }
+        
+        public synchronized void free() {
+            if(SessionKey != null) {
+                Secur32.INSTANCE.FreeContextBuffer(SessionKey);
+                SessionKey = null;
+            }
+        }
+    }
+    
+    public static class SecPkgContext_KeyInfo extends Structure {
+
+        public static class ByReference extends SecPkgContext_KeyInfo implements Structure.ByReference {
+
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("sSignatureAlgorithmName", "sEncryptAlgorithmName","KeySize", "SignatureAlgorithm", "EncryptAlgorithm");
+
+        /**
+         * Name, if available, of the algorithm used for generating signatures, for example "MD5" or "SHA-2".
+         */
+        public Pointer sSignatureAlgorithmName;
+        
+        /**
+         * Name, if available, of the algorithm used for encrypting messages. Reserved for future use.
+         */
+        public Pointer sEncryptAlgorithmName;
+        
+        /**
+         * Specifies the effective key length, in bits, for the session key. This is typically 40, 56, or 128 bits.
+         */
+        public int KeySize;
+        
+        /**
+         * Specifies the algorithm identifier (ALG_ID) used for generating signatures, if available.
+         */
+        public int SignatureAlgorithm;
+        
+        /**
+         * Specifies the algorithm identifier (ALG_ID) used for encrypting messages. Reserved for future use.
+         */
+        public int EncryptAlgorithm;
+
+        public SecPkgContext_KeyInfo() {
+            super(W32APITypeMapper.DEFAULT);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+
+        public synchronized String getSignatureAlgorithmName() {
+            if(sSignatureAlgorithmName == null) {
+                return null;
+            }
+            return Boolean.getBoolean("w32.ascii") ? sSignatureAlgorithmName.getString(0) : sSignatureAlgorithmName.getWideString(0);
+        }
+        
+        public synchronized String getEncryptAlgorithmName() {
+            if(sEncryptAlgorithmName == null) {
+                return null;
+            }
+            return Boolean.getBoolean("w32.ascii") ? sEncryptAlgorithmName.getString(0) : sEncryptAlgorithmName.getWideString(0);
+        }
+        
+        public synchronized void free() {
+            if(sSignatureAlgorithmName != null) {
+                Secur32.INSTANCE.FreeContextBuffer(sSignatureAlgorithmName);
+                sSignatureAlgorithmName = null;
+            }
+            if(sEncryptAlgorithmName != null) {
+                Secur32.INSTANCE.FreeContextBuffer(sEncryptAlgorithmName);
+                sEncryptAlgorithmName = null;
+            }
+        }
+    }
+    
+    public static class SecPkgContext_Lifespan extends Structure {
+
+        public static class ByReference extends SecPkgContext_Lifespan implements Structure.ByReference {
+
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("tsStart", "tsExpiry");
+
+        /**
+         * Time at which the context was established.
+         */
+        public TimeStamp tsStart;
+        
+        /**
+         * Time at which the context will expire.
+         */
+        public TimeStamp tsExpiry;
+
+        public SecPkgContext_Lifespan() {
+            super(W32APITypeMapper.DEFAULT);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+    }
+    
+    public static class SecPkgContext_NegotiationInfo extends Structure {
+
+        public static class ByReference extends SecPkgContext_NegotiationInfo implements Structure.ByReference {
+
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("PackageInfo", "NegotiationState");
+
+        /**
+         * Time at which the context was established.
+         */
+        public PSecPkgInfo PackageInfo;
+
+        /**
+         * Time at which the context will expire.
+         */
+        public int NegotiationState;
+
+        public SecPkgContext_NegotiationInfo() {
+            super(W32APITypeMapper.DEFAULT);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+        
+        public synchronized void free() {
+            if(PackageInfo != null) {
+                Secur32.INSTANCE.FreeContextBuffer(PackageInfo.pPkgInfo.getPointer());
+                PackageInfo = null;
+            }
+        }
+    }
+    
+    public static class SecPkgContext_Flags extends Structure {
+
+        public static class ByReference extends SecPkgContext_Flags implements Structure.ByReference {
+
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("Flags");
+
+        /**
+         * Flag values for the current security context. These values correspond
+         * to the flags negotiated by the InitializeSecurityContext (General)
+         * and AcceptSecurityContext (General) functions.
+         */
+        public int Flags;
+
+        public SecPkgContext_Flags() {
+            super(W32APITypeMapper.DEFAULT);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+    }
+    
+    /**
+     * Strings in structure {@link SEC_WINNT_AUTH_IDENTITY} are ANSI
+     */
+    public static final int SEC_WINNT_AUTH_IDENTITY_ANSI = 0x1;
+    /**
+     * String in structure {@link SEC_WINNT_AUTH_IDENTITY} are UNICODE
+     */
+    public static final int SEC_WINNT_AUTH_IDENTITY_UNICODE = 0x2;
+
+    
+    public static class SEC_WINNT_AUTH_IDENTITY extends Structure {
+
+        public static final List<String> FIELDS = createFieldsOrder("User", "UserLength", "Domain", "DomainLength", "Password", "PasswordLength", "Flags");
+
+        /**
+         * A string that contains the user name.
+         */
+        public String User;
+
+        /**
+         * The length, in characters, of the user string, not including the
+         * terminating null character.
+         */
+        public int UserLength;
+
+        /**
+         * A string that contains the domain name or the workgroup name.
+         */
+        public String Domain;
+
+        /**
+         * The length, in characters, of the domain string, not including the
+         * terminating null character.
+         */
+        public int DomainLength;
+
+        /**
+         * A string that contains the password of the user in the domain or
+         * workgroup. When you have finished using the password, remove the
+         * sensitive information from memory by calling SecureZeroMemory. For
+         * more information about protecting the password, see Handling
+         * Passwords.
+         */
+        public String Password;
+
+        /**
+         * The length, in characters, of the password string, not including the
+         * terminating null character.
+         */
+        public int PasswordLength;
+
+        /**
+         * This member can be one of the following values.
+         *
+         * <table>
+         * <tr><th>Value</th><th>Meaning</th></tr>
+         * <tr><td>SEC_WINNT_AUTH_IDENTITY_ANSI</td><td>The strings in this structure are in ANSI format.</td></tr>
+         * <tr><td>SEC_WINNT_AUTH_IDENTITY_UNICODE</td><td>The strings in this structure are in Unicode format.</td></tr>
+         * </table>
+         *
+         * <strong>As the string encoding is managed by JNA do not change this
+         * value!</strong>
+         */
+        public int Flags = SEC_WINNT_AUTH_IDENTITY_UNICODE;
+    
+
+        /**
+         * Create a new SecBufferDesc with one SECBUFFER_EMPTY buffer.
+         */
+        public SEC_WINNT_AUTH_IDENTITY() {
+            super(W32APITypeMapper.UNICODE);
+        }
+
+        @Override
+        public void write() {
+            UserLength = User == null ? 0 : User.length();
+            DomainLength = Domain == null ? 0 : Domain.length();
+            PasswordLength = Password == null ? 0 : Password.length();
+            super.write();
+        }
+        
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
+        }
+    }
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32.java
@@ -1731,7 +1731,7 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
      *        handle to that display monitor. If the point is not contained by a display monitor,
      *        the return value depends on the value of dwFlags.
      */
-    HMONITOR MonitorFromPoint(POINT pt, int dwFlags);
+    HMONITOR MonitorFromPoint(POINT.ByValue pt, int dwFlags);
 
     /**
      * Retrieves a handle to the display monitor that has the largest area of intersection with

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
@@ -1068,6 +1068,35 @@ public interface WinDef {
          */
         public static class ByReference extends POINT implements Structure.ByReference {
 
+            public ByReference() {
+            }
+
+            public ByReference(Pointer memory) {
+                super(memory);
+            }
+
+            public ByReference(int x, int y) {
+                super(x, y);
+            }
+
+        }
+        
+        /**
+         * The Class ByValue.
+         */
+        public static class ByValue extends POINT implements Structure.ByValue {
+
+            public ByValue() {
+            }
+
+            public ByValue(Pointer memory) {
+                super(memory);
+            }
+
+            public ByValue(int x, int y) {
+                super(x, y);
+            }
+
         }
 
         public static final List<String> FIELDS = createFieldsOrder("x", "y");

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -3528,9 +3528,9 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * construct the locale id from a language id and a sort id.
          * 
-         * @param lgid
-         * @param srtid
-         * @return 
+         * @param lgid language id
+         * @param srtid sort id
+         * @return locale id derived from ldig and srtid
          */
         public static final LCID MAKELCID(int lgid, int srtid) {
             return new LCID(_MAKELCID(lgid, srtid));
@@ -3539,10 +3539,10 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * construct the locale id from a language id, sort id, and sort version.
          * 
-         * @param lgid
-         * @param srtid
-         * @param ver
-         * @return 
+         * @param lgid locale id
+         * @param srtid sort id
+         * @param ver sort version
+         * @return locale id derviced from a language id, sort id, and sort version.
          */
         public static final LCID MAKESORTLCID(int lgid, int srtid, int ver) {
             return new LCID(_MAKELCID(lgid, srtid) | (ver << 20));
@@ -3551,8 +3551,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * extract the language id from a locale id.
          * 
-         * @param lcid
-         * @return 
+         * @param lcid locale id
+         * @return extracted language id
          */
         public static final int LANGIDFROMLCID(LCID lcid) {
             return lcid.intValue() & 0xFFFF;
@@ -3561,8 +3561,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * extract the sort id from a locale id.
          * 
-         * @param lcid
-         * @return 
+         * @param lcid locale id
+         * @return extracted sort id
          */
         public static final int SORTIDFROMLCID(LCID lcid) {
             return (lcid.intValue() >>> 16) & 0xf;
@@ -3571,8 +3571,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * extract the sort version from a locale id.
          * 
-         * @param lcid
-         * @return 
+         * @param lcid locale id
+         * @return extracted sort version
          */
         public static final int SORTVERSIONFROMLCID(LCID lcid) {
             return (lcid.intValue() >>> 20) & 0xf;
@@ -3581,9 +3581,9 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * Construct language id from a primary language id and a sublanguage id.
          * 
-         * @param p Language ID
-         * @param s Sublanguage ID
-         * @return 
+         * @param p primary language ID
+         * @param s sublanguage ID
+         * @return constructed language id
          */
         public static final int MAKELANGID(int p, int s) {
             return (s << 10) | (p & 0xFFFF);
@@ -3592,8 +3592,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * Extract primary language id from a language id.
          * 
-         * @param lgid Language ID
-         * @return 
+         * @param lgid language ID
+         * @return extracted primary language id
          */
         public static final int PRIMARYLANGID(int lgid) {
             return lgid & 0x3ff;
@@ -3602,8 +3602,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * Extract sublanguage id from a language id.
          * 
-         * @param lgid Language ID
-         * @return 
+         * @param lgid language ID
+         * @return extracted sublanguage id
          */
         public static final int SUBLANGID(int lgid) {
             return (lgid  & 0xFFFF) >>> 10;

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32ConsoleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32ConsoleTest.java
@@ -20,6 +20,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
+import org.junit.Assume;
 
 /**
  * @author lgoldstein
@@ -29,6 +30,8 @@ public class Kernel32ConsoleTest extends AbstractWin32TestSupport {
 
 	@Test
 	public void testGetConsoleDisplayMode() {
+                // If there is no console window, it can't be queried
+                Assume.assumeNotNull(INSTANCE.GetConsoleWindow());
 		IntByReference	curMode=new IntByReference();
 		assertCallSucceeded("Initial display mode value retrieval", INSTANCE.GetConsoleDisplayMode(curMode));
 	}

--- a/contrib/platform/test/com/sun/jna/platform/win32/Shell32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Shell32UtilTest.java
@@ -70,7 +70,8 @@ public class Shell32UtilTest extends TestCase {
         assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_Libraries));
         assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_RoamingAppData));
         assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProfiles));
-        assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFiles));
-        assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFilesCommon));
+        // This is unstable:
+        // assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFiles));
+        // assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFilesCommon));
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/SspiTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/SspiTest.java
@@ -1,0 +1,27 @@
+
+package com.sun.jna.platform.win32;
+
+import com.sun.jna.platform.win32.Sspi.SEC_WINNT_AUTH_IDENTITY;
+import junit.framework.TestCase;
+
+public class SspiTest extends TestCase {
+
+    public static void main(String[] args) {
+        junit.textui.TestRunner.run(SspiTest.class);
+    }
+
+    public void testSecWinntAuthIdentity() {
+        String username = "sample Username";
+        String password = ""; // empty string
+        String domain = "German Umlauts: \u00c4, \u00f6, \u00dc";
+        SEC_WINNT_AUTH_IDENTITY identity = new SEC_WINNT_AUTH_IDENTITY();
+        identity.User = username;
+        identity.Password = password;
+        identity.Domain = domain;
+        identity.write();
+        assertEquals(username.length(), identity.UserLength);
+        assertEquals(password.length(), identity.PasswordLength);
+        assertEquals(domain.length(), identity.DomainLength);
+        assertEquals(Sspi.SEC_WINNT_AUTH_IDENTITY_UNICODE, identity.Flags);
+    }
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
@@ -184,7 +184,7 @@ public class User32Test extends AbstractWin32TestSupport {
     public final void testMonitorFromPoint() {
         int dwFlags = WinUser.MONITOR_DEFAULTTOPRIMARY;
 
-        POINT pt = new POINT(0, 0);
+        POINT.ByValue pt = new POINT.ByValue(0, 0);
         assertNotNull(User32.INSTANCE.MonitorFromPoint(pt, dwFlags));
     }
 


### PR DESCRIPTION
(Re-)Bind SSPI functions:
- InitializeSecurityContext
- AcceptSecurityContext
- QueryCredentialsAttributes
- QuerySecurityPackageInfo
- EncryptMessage
- DecryptMessage
- MakeSignature
- VerifySignature

Add binding for SEC_WINNT_AUTH_IDENTITY structure.

The existing SecBufferDesc binding is deprecated, as the binding does
not correctly map the native structure. The pBuffers member is not
an array of SecBuffer.ByReference, but a pointer to an array of
SecBuffer's. This manifests when more than one buffer is specified.

The SecBufferDesc2 structure is the literal transliteration of the
native C header. In addition a ManagedSecBufferDesc was introduced, that
allows easy access to its members, as long, as the structure is managed
from the java side.

The two related commits
a) fix javadoc warnings
b) fix unittests and the binding for `com.sun.jna.platform.win32.User32#MonitorFromPoint`