### PR TITLE
 Fix unittests (IShellFolderTest#testEnumObjects) still fails on amd64) 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Bug Fixes
 * [#785](https://github.com/java-native-access/jna/issues/785): OaIdlUtil#toPrimitiveArray fails if dimension bounds are not 0-based - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#795](https://github.com/java-native-access/jna/issues/795): com.sun.jna.platform.win32.WinDef.WORDByReference holds a WORD which is defined to 16 bit on windows, so it needs to be accessed as short (getShort()). Fix suggested by  - [@kdeines](https://github.com/kdeines).
 * [#804](https://github.com/java-native-access/jna/pull/804) Main-Class in jna-platform.jar collides with java 9 module system - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#838](https://github.com/java-native-access/jna/pull/838): Fix binding of `com.sun.jna.platform.win32.User32#MonitorFromPoint` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.4.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IUnknown.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IUnknown.java
@@ -32,8 +32,12 @@ import com.sun.jna.ptr.PointerByReference;
 /**
  * Wrapper class for the ITypeInfo interface
  * 
- * Method Name V-Table Offset IUnknown.QueryInterface 0 IUnknown.AddRef 4
- * IUnknown.Release 8
+ * <table>
+ * <tr><th>Method Name</th><th>V-Table Offset</th></tr>
+ * <tr><td>IUnknown.QueryInterface</td><td>0</td></tr>
+ * <tr><td>IUnknown.AddRef</td><td>4</td></tr>
+ * <tr><td>IUnknown.Release</td><td>8</td></tr>
+ * </table>
  * 
  * @author Tobias Wolf, wolf.tobias@gmx.net
  */

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
@@ -447,7 +447,7 @@ public interface Ole32 extends StdCallLibrary {
 
     /**
      * Puts an OLE compound document object into the running state.
-     * @param pUnknown [in] Pointer to the {@link IUnknown IUnknown} interface
+     * @param pUnknown [in] Pointer to the {@link com.sun.jna.platform.win32.COM.IUnknown IUnknown} interface
      *                 on the object, with which it will query for a pointer to
      *                 the IRunnableObject interface, and then call its Run method.
      * @return This function returns  on success.

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32.java
@@ -1730,8 +1730,25 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
      * @return If the point is contained by a display monitor, the return value is an HMONITOR
      *        handle to that display monitor. If the point is not contained by a display monitor,
      *        the return value depends on the value of dwFlags.
+     * @deprecated  Use {@link #MonitorFromPoint(com.sun.jna.platform.win32.WinDef.POINT.ByValue, int)}
      */
+    @Deprecated
     HMONITOR MonitorFromPoint(POINT pt, int dwFlags);
+    
+    /**
+     * Retrieves a handle to the display monitor that contains a specified point.
+     * @param pt A POINT structure that specifies the point of interest in virtual-screen
+     *        coordinates.
+     * @param dwFlags Determines the function's return value if the window does not intersect
+     *        any display monitor. This parameter can be one of the following values.
+     *        <ul><li>MONITOR_DEFAULTTONEAREST</li>
+     *        <li>MONITOR_DEFAULTTONULL</li>
+     *        <li>MONITOR_DEFAULTTOPRIMARY</li></ul>
+     * @return If the point is contained by a display monitor, the return value is an HMONITOR
+     *        handle to that display monitor. If the point is not contained by a display monitor,
+     *        the return value depends on the value of dwFlags.
+     */
+    HMONITOR MonitorFromPoint(POINT.ByValue pt, int dwFlags);
 
     /**
      * Retrieves a handle to the display monitor that has the largest area of intersection with

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
@@ -1068,6 +1068,35 @@ public interface WinDef {
          */
         public static class ByReference extends POINT implements Structure.ByReference {
 
+            public ByReference() {
+            }
+
+            public ByReference(Pointer memory) {
+                super(memory);
+            }
+
+            public ByReference(int x, int y) {
+                super(x, y);
+            }
+
+        }
+        
+        /**
+         * The Class ByValue.
+         */
+        public static class ByValue extends POINT implements Structure.ByValue {
+
+            public ByValue() {
+            }
+
+            public ByValue(Pointer memory) {
+                super(memory);
+            }
+
+            public ByValue(int x, int y) {
+                super(x, y);
+            }
+
         }
 
         public static final List<String> FIELDS = createFieldsOrder("x", "y");

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -3528,9 +3528,9 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * construct the locale id from a language id and a sort id.
          * 
-         * @param lgid
-         * @param srtid
-         * @return 
+         * @param lgid language id
+         * @param srtid sort id
+         * @return locale id derived from ldig and srtid
          */
         public static final LCID MAKELCID(int lgid, int srtid) {
             return new LCID(_MAKELCID(lgid, srtid));
@@ -3539,10 +3539,10 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * construct the locale id from a language id, sort id, and sort version.
          * 
-         * @param lgid
-         * @param srtid
-         * @param ver
-         * @return 
+         * @param lgid locale id
+         * @param srtid sort id
+         * @param ver sort version
+         * @return locale id derviced from a language id, sort id, and sort version.
          */
         public static final LCID MAKESORTLCID(int lgid, int srtid, int ver) {
             return new LCID(_MAKELCID(lgid, srtid) | (ver << 20));
@@ -3551,8 +3551,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * extract the language id from a locale id.
          * 
-         * @param lcid
-         * @return 
+         * @param lcid locale id
+         * @return extracted language id
          */
         public static final int LANGIDFROMLCID(LCID lcid) {
             return lcid.intValue() & 0xFFFF;
@@ -3561,8 +3561,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * extract the sort id from a locale id.
          * 
-         * @param lcid
-         * @return 
+         * @param lcid locale id
+         * @return extracted sort id
          */
         public static final int SORTIDFROMLCID(LCID lcid) {
             return (lcid.intValue() >>> 16) & 0xf;
@@ -3571,8 +3571,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * extract the sort version from a locale id.
          * 
-         * @param lcid
-         * @return 
+         * @param lcid locale id
+         * @return extracted sort version
          */
         public static final int SORTVERSIONFROMLCID(LCID lcid) {
             return (lcid.intValue() >>> 20) & 0xf;
@@ -3581,9 +3581,9 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * Construct language id from a primary language id and a sublanguage id.
          * 
-         * @param p Language ID
-         * @param s Sublanguage ID
-         * @return 
+         * @param p primary language ID
+         * @param s sublanguage ID
+         * @return constructed language id
          */
         public static final int MAKELANGID(int p, int s) {
             return (s << 10) | (p & 0xFFFF);
@@ -3592,8 +3592,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * Extract primary language id from a language id.
          * 
-         * @param lgid Language ID
-         * @return 
+         * @param lgid language ID
+         * @return extracted primary language id
          */
         public static final int PRIMARYLANGID(int lgid) {
             return lgid & 0x3ff;
@@ -3602,8 +3602,8 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * Extract sublanguage id from a language id.
          * 
-         * @param lgid Language ID
-         * @return 
+         * @param lgid language ID
+         * @return extracted sublanguage id
          */
         public static final int SUBLANGID(int lgid) {
             return (lgid  & 0xFFFF) >>> 10;

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32ConsoleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32ConsoleTest.java
@@ -20,6 +20,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
+import org.junit.Assume;
 
 /**
  * @author lgoldstein
@@ -29,6 +30,8 @@ public class Kernel32ConsoleTest extends AbstractWin32TestSupport {
 
 	@Test
 	public void testGetConsoleDisplayMode() {
+                // If there is no console window, it can't be queried
+                Assume.assumeNotNull(INSTANCE.GetConsoleWindow());
 		IntByReference	curMode=new IntByReference();
 		assertCallSucceeded("Initial display mode value retrieval", INSTANCE.GetConsoleDisplayMode(curMode));
 	}

--- a/contrib/platform/test/com/sun/jna/platform/win32/Shell32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Shell32UtilTest.java
@@ -70,7 +70,8 @@ public class Shell32UtilTest extends TestCase {
         assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_Libraries));
         assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_RoamingAppData));
         assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProfiles));
-        assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFiles));
-        assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFilesCommon));
+        // This is unstable:
+        // assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFiles));
+        // assertNotNull(Shell32Util.getKnownFolderPath(KnownFolders.FOLDERID_UserProgramFilesCommon));
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
@@ -88,6 +88,8 @@ public class User32Test extends AbstractWin32TestSupport {
             for (String name : new String[] {
                     // has 2 overloads since the original API accepts both MONITORINFO and MONITORINFOEX
                     "GetMonitorInfo"
+                    // has 2 overloads since there was a broken binding for MonitorFromPoint
+                    ,"MonitorFromPoint"
                 }) {
                 dupSet.remove(name);
             }
@@ -184,7 +186,7 @@ public class User32Test extends AbstractWin32TestSupport {
     public final void testMonitorFromPoint() {
         int dwFlags = WinUser.MONITOR_DEFAULTTOPRIMARY;
 
-        POINT pt = new POINT(0, 0);
+        POINT.ByValue pt = new POINT.ByValue(0, 0);
         assertNotNull(User32.INSTANCE.MonitorFromPoint(pt, dwFlags));
     }
 


### PR DESCRIPTION
- MonitorFromPoint takes a structure, not a reference to a structure,
  so function definition was wrong
- The last to "KnownFolters" don't resolve on Win10
- cleanup javadoc warnings