### PR TITLE
Cleanup deprecated elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,12 +16,44 @@ Bug Fixes
 
 Breaking Changes
 ----------------
-* `Pointer#SIZE` is removed. Its use is replaced by `Native#POINTER_SIZE` 
+
+* `com.sun.jna.Pointer#SIZE` is removed. Its use is replaced by `com.sun.jna.Native#POINTER_SIZE` 
   to prevent a class loading deadlock, when JNA is initialized from multiple threads
-* `SecBufferDesc` was incompatibly changed to match the correct native semantics.
-  SecBufferDesc describing more than one buffer were broken. For most usecases 
+* `com.sun.jna.Pointer#getString(long offset, boolean wide)` is removed. It was replaced by
+  `com.sun.jna.Pointer#getString(long offset)` or
+  `com.sun.jna.Pointer#getWideString(long offset)`
+* `com.sun.jna.Pointer#getStringArray(long offset, boolean wide)` is removed. It was replaced by
+  `com.sun.jna.Pointer#getStringArray(long offset)` or
+  `com.sun.jna.Pointer#getWideStringArray(long offset)`
+* `com.sun.jna.Pointer#setString(long offset, String value, boolean wide)` is removed. It was replaced by
+  `com.sun.jna.Pointer#setString(long offset, String value)` or
+  `com.sun.jna.Pointer#setWideString(long offset, String value)`
+* `com.sun.jna.Structure#setFieldOrder` is removed. It was replaced by 
+  `com.sun.jna.Structure#getFieldOrder` and threw an `java.lang.Error` on call.
+* `com.sun.jna.Native#parseVersion` was removed without replacement
+* `com.sun.jna.Native#setPreserveLastError` and `com.sun.jna.Native#getPreserveLastError`
+  were removed without replacement. They were turned into NOOPs in the past.
+* `com.sun.jna.Native#getDirectByteBuffer` was replaced by `com.sun.jna.Pointer#getByteBuffer`
+* `com.sun.jna.platform.win32.Sspi.SecBufferDesc` was incompatibly changed to 
+  match the correct native semantics. SecBufferDesc describing more than one
+  buffer were broken. For most usecases 
   `com.sun.jna.platform.win32.SspiUtil.ManagedSecBufferDesc` is the best 
   alternative.
+* `com.sun.jna.platform.win32.WinBase.FILETIME#toLong()` was replaced by
+  `com.sun.jna.platform.win32.WinBase.FILETIME#toTime()`
+* `com.sun.jna.platform.win32.Variant#COM_DAYS_ADJUSTMENT` was removed
+* `com.sun.jna.platform.win32.Variant#MICRO_SECONDS_PER_DAY` was removed
+* `com.sun.jna.platform.win32.Variant.VARIANT#toJavaDate` was removed
+* `com.sun.jna.platform.win32.Variant.VARIANT#fromJavaDate` was removed
+* `com.sun.jna.platform.win32.User32#MonitorFromPoint(Point pt, int dwFlags)`
+  was replaced by
+  `com.sun.jna.platform.win32.User32#MonitorFromPoint(Point.ByValue pt, int dwFlags)`
+* `com.sun.jna.platform.win32.OleAuto.LoadTypeLib(WString, PointerByReference)`
+  was replaced by
+  `com.sun.jna.platform.win32.OleAuto.LoadTypeLib(String, PointerByReference)`
+* `com.sun.jna.platform.win32.Kernel32Util.formatMessageFromHR(HRESULT)`
+  was replaced by
+  `com.sun.jna.platform.win32.Kernel32Util.formatMessage(HRESULT)`
 
 Release 4.5.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/TypeLibUtil.java
@@ -106,7 +106,7 @@ public class TypeLibUtil {
     public TypeLibUtil(String file) {
         // load typelib
         PointerByReference pTypeLib = new PointerByReference();
-        HRESULT hr = OleAuto.INSTANCE.LoadTypeLib(new WString(file), pTypeLib);
+        HRESULT hr = OleAuto.INSTANCE.LoadTypeLib(file, pTypeLib);
         COMUtils.checkRC(hr);
 
         // init type lib class

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
@@ -217,16 +217,6 @@ public abstract class Kernel32Util implements WinDef {
     }
 
     /**
-     * @deprecated use {@link #formatMessage(WinNT.HRESULT)} instead.
-     * @param code error code
-     * @return formatted message
-     */
-    @Deprecated
-    public static String formatMessageFromHR(HRESULT code) {
-        return formatMessage(code.intValue());
-    }
-
-    /**
      * Format a system message from an error code.
      *
      * @param code
@@ -234,7 +224,7 @@ public abstract class Kernel32Util implements WinDef {
      * @return Formatted message.
      */
     public static String formatMessageFromLastErrorCode(int code) {
-        return formatMessageFromHR(W32Errors.HRESULT_FROM_WIN32(code));
+        return formatMessage(W32Errors.HRESULT_FROM_WIN32(code));
     }
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
@@ -29,7 +29,6 @@ import java.util.List;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.OaIdl.DISPID;
 import com.sun.jna.platform.win32.OaIdl.SAFEARRAY;
@@ -883,9 +882,6 @@ public interface OleAuto extends StdCallLibrary {
          * @return status
 	 */
 	HRESULT LoadTypeLib(String szFile, PointerByReference pptlib);
-        /** @deprecated use the String version */
-	@Deprecated
-    HRESULT LoadTypeLib(WString szFile, PointerByReference pptlib);
 
 	/**
 	 * Converts a system time to a variant representation.

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32.java
@@ -1717,23 +1717,6 @@ public interface User32 extends StdCallLibrary, WinUser, WinNT {
      *         </p>
      */
     int RegisterWindowMessage(String string);
-
-    /**
-     * Retrieves a handle to the display monitor that contains a specified point.
-     * @param pt A POINT structure that specifies the point of interest in virtual-screen
-     *        coordinates.
-     * @param dwFlags Determines the function's return value if the window does not intersect
-     *        any display monitor. This parameter can be one of the following values.
-     *        <ul><li>MONITOR_DEFAULTTONEAREST</li>
-     *        <li>MONITOR_DEFAULTTONULL</li>
-     *        <li>MONITOR_DEFAULTTOPRIMARY</li></ul>
-     * @return If the point is contained by a display monitor, the return value is an HMONITOR
-     *        handle to that display monitor. If the point is not contained by a display monitor,
-     *        the return value depends on the value of dwFlags.
-     * @deprecated  Use {@link #MonitorFromPoint(com.sun.jna.platform.win32.WinDef.POINT.ByValue, int)}
-     */
-    @Deprecated
-    HMONITOR MonitorFromPoint(POINT pt, int dwFlags);
     
     /**
      * Retrieves a handle to the display monitor that contains a specified point.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
@@ -22,7 +22,6 @@
  */
 package com.sun.jna.platform.win32;
 
-import com.sun.jna.IntegerType;
 import java.util.Date;
 import java.util.List;
 
@@ -126,14 +125,6 @@ public interface Variant {
     public static VARIANT_BOOL VARIANT_TRUE = new VARIANT_BOOL(0xFFFF);
     public static VARIANT_BOOL VARIANT_FALSE = new VARIANT_BOOL(0x0000);
 
-    @Deprecated
-    public final static long COM_DAYS_ADJUSTMENT = 25569L; // ((1969 - 1899) *
-                                                           // 365) +1 + Leap
-                                                           // years = Days 
-    @Deprecated
-    public final static long MICRO_SECONDS_PER_DAY = 86400000L; // 24L * 60L *
-                                                                // 60L * 1000L;
-    
     public static class VARIANT extends Union {
 
         public static class ByReference extends VARIANT implements
@@ -294,8 +285,7 @@ public interface Variant {
 
         public VARIANT(Date value) {
             this();
-            DATE date = this.fromJavaDate(value);
-            this.setValue(VT_DATE, date);
+            this.setValue(VT_DATE, new DATE(value));
         }
 
         public VARIANT(SAFEARRAY array) {
@@ -608,16 +598,6 @@ public interface Variant {
             } else {
                 return varDate.getAsJavaDate();
             }
-        }
-
-        @Deprecated
-        protected Date toJavaDate(DATE varDate) {
-            return varDate.getAsJavaDate();
-        }
-
-        @Deprecated
-        protected DATE fromJavaDate(Date javaDate) {
-            return new DATE(javaDate);
         }
 
         public static class _VARIANT extends Structure {

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -937,18 +937,6 @@ public interface WinBase extends WinDef, BaseTSD {
         }
 
         /**
-         * <p>Converts this filetime into a number of milliseconds which have
-         * passed since January 1, 1970 (UTC).</p>
-         * @return This filetime as a number of milliseconds which have passed
-         * since January 1, 1970 (UTC)
-         * @deprecated Replaced by {@link #toTime()}
-         */
-        @Deprecated
-        public long toLong() {
-            return toDate().getTime();
-        }
-
-        /**
          * <p>Converts the two 32-bit unsigned integer parts of this filetime
          * into a 64-bit unsigned integer representing the number of
          * 100-nanosecond intervals since January 1, 1601 (UTC).</p>

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -147,11 +147,6 @@ public final class Native implements Version {
 
     static final int MAX_ALIGNMENT;
     static final int MAX_PADDING;
-
-    @Deprecated
-    public static float parseVersion(String v) {
-        return Float.parseFloat(v.substring(0, v.lastIndexOf(".")));
-    }
     
     /**
      * Version string must have the structure <major>.<minor>.<revision>
@@ -298,21 +293,6 @@ public final class Native implements Version {
      * if this platform supports protecting memory accesses.
      */
     public static synchronized native boolean isProtected();
-
-    /** This method is obsolete.  The last error value is always preserved.
-     * @see #getLastError()
-     * @deprecated Last error is always preserved and available via {@link #getLastError()}
-     */
-    @Deprecated
-    public static void setPreserveLastError(boolean enable) { }
-
-    /** Indicates whether the system last error result is preserved
-     * after every invocation.  Always returns <code>true</code><p>
-     * @see #getLastError()
-     * @deprecated Last error is always preserved and available via {@link #getLastError()}
-     */
-    @Deprecated
-    public static boolean getPreserveLastError() { return true; }
 
     /** Utility method to get the native window ID for a Java {@link Window}
      * as a <code>long</code> value.
@@ -2189,16 +2169,10 @@ public final class Native implements Version {
     public static native void free(long ptr);
 
     /**
-     * Get a direct ByteBuffer mapped to the memory pointed to by the pointer.
-     * This method calls through to the JNA NewDirectByteBuffer method.
-     *
-     * @param addr base address of the JNA-originated memory
-     * @param length Length of ByteBuffer
-     * @return a direct ByteBuffer that accesses the memory being pointed to
-     * @deprecated Use {@link Pointer#getByteBuffer(long, long)} (since 4.3.0)
+     * @deprecated retained to keep native signature
      */
     @Deprecated
-    public static native ByteBuffer getDirectByteBuffer(long addr, long length);
+    private static native ByteBuffer getDirectByteBuffer(long addr, long length);
 
     private static final ThreadLocal<Memory> nativeThreadTerminationFlag =
         new ThreadLocal<Memory>() {

--- a/src/com/sun/jna/Pointer.java
+++ b/src/com/sun/jna/Pointer.java
@@ -653,23 +653,6 @@ public class Pointer {
         return Native.getDirectByteBuffer(this, this.peer, offset, length).order(ByteOrder.nativeOrder());
     }
 
-    /**
-     * Copy native memory to a Java String.  If <code>wide</code> is true,
-     * access the memory as an array of <code>wchar_t</code>, otherwise
-     * as an array of <code>char</code>, using the default platform encoding.
-     *
-     * @param offset byte offset from pointer to obtain the native string
-v     * @param wide whether to convert from a wide or standard C string
-     * @return the <code>String</code> value being pointed to
-     *
-     * @deprecated use {@link #getString(long,String)} or {@link
-     * #getWideString(long)} instead.
-     */
-    @Deprecated
-    public String getString(long offset, boolean wide) {
-        return wide ? getWideString(offset) : getString(offset);
-    }
-
     /** Read a wide (<code>const wchar_t *</code>) string from memory. */
     public String getWideString(long offset) {
         return Native.getWideString(this, this.peer, offset);
@@ -811,37 +794,12 @@ v     * @param wide whether to convert from a wide or standard C string
         return getStringArray(offset, length, Native.getDefaultStringEncoding());
     }
 
-    /** Returns an array of <code>String</code> based on a native array
-     * of <code>char*</code> or <code>wchar_t*</code> based on the
-     * <code>wide</code> parameter.  The array length is determined by a
-     * NULL-valued terminating element.
-     *
-     * @deprecated use {@link #getStringArray(long,String)} or {@link
-     * #getWideStringArray(long)} instead.
-     */
-    @Deprecated
-    public String[] getStringArray(long offset, boolean wide) {
-        return getStringArray(offset, -1, wide);
-    }
-
     public String[] getWideStringArray(long offset) {
         return getWideStringArray(offset, -1);
     }
 
     public String[] getWideStringArray(long offset, int length) {
         return getStringArray(offset, length, NativeString.WIDE_STRING);
-    }
-
-    /** Returns an array of <code>String</code> based on a native array
-     * of <code>char*</code> or <code>wchar_t*</code> based on the
-     * <code>wide</code> parameter, using the given array length.
-     *
-     * @deprecated use {@link #getStringArray(long,int,String)} or {@link
-     * #getWideStringArray(long,int)} instead.
-     */
-    @Deprecated
-    public String[] getStringArray(long offset, int length, boolean wide) {
-        return getStringArray(offset, length, wide ? NativeString.WIDE_STRING : Native.getDefaultStringEncoding());
     }
 
     /** Returns an array of <code>String</code> based on a native array
@@ -1143,29 +1101,6 @@ v     * @param wide whether to convert from a wide or standard C string
      */
     public void setPointer(long offset, Pointer value) {
         Native.setPointer(this, this.peer, offset, value != null ? value.peer : 0);
-    }
-
-    /**
-     * Copy string <code>value</code> to the location being pointed to.
-     *
-     * @param offset byte offset from pointer at which characters in
-     * 		     <code>value</code> must be set
-     * @param value  <code>java.lang.String</code> value to set
-     * @param wide whether to write the native string as an array of
-     * <code>wchar_t</code>.  If false, writes as a NUL-terminated array of
-     * <code>char</code> using the encoding indicated by {@link
-     * Native#getDefaultStringEncoding()}.
-     *
-     * @deprecated use {@link #setWideString(long,String)} instead.
-     */
-    @Deprecated
-    public void setString(long offset, String value, boolean wide) {
-        if (wide) {
-            setWideString(offset, value);
-        }
-        else {
-            setString(offset, value);
-        }
     }
 
     /**

--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -890,17 +890,6 @@ public abstract class Structure {
      */
     protected abstract List<String> getFieldOrder();
 
-    /**
-     * Force a compile-time error on the old method of field definition
-     * @param fields ordered array of field names
-     * @deprecated Use the required method getFieldOrder() instead to
-     * indicate the order of fields in this structure.
-     */
-    @Deprecated
-    protected final void setFieldOrder(String[] fields) {
-        throw new Error("This method is obsolete, use getFieldOrder() instead");
-    }
-
     /** Sort the structure fields according to the given array of names.
      * @param fields list of fields to be sorted
      * @param names list of names representing the desired sort order

--- a/src/com/sun/jna/overview.html
+++ b/src/com/sun/jna/overview.html
@@ -683,7 +683,12 @@ initialized unless they are selected via {@link com.sun.jna.Union#setType}.
 <a name="last-error"></a>
 <h3>Obtaining "last" error</h3>
 If a function sets the system error property
-(<code><a href="http://www.opengroup.org/onlinepubs/009695399/functions/errno.html">errno</a></code> or <code><a href="http://msdn.microsoft.com/en-us/library/ms679360(VS.85).aspx">GetLastError()</a></code>), the error code will be thrown as a {@link com.sun.jna.LastErrorException} if you declare the exception in your JNA mapping.  Alternatively, you can use {@link com.sun.jna.Native#getLastError()} to retrieve it, providing that {@link com.sun.jna.Native#setPreserveLastError(boolean)} has been called with a <code>true</code> value.  Throwing an exception is preferred since it has better performance.
+(<code><a href="http://www.opengroup.org/onlinepubs/009695399/functions/errno.html">errno</a></code> or 
+<code><a href="http://msdn.microsoft.com/en-us/library/ms679360(VS.85).aspx">GetLastError()</a></code>), 
+the error code will be thrown as a {@link com.sun.jna.LastErrorException} if you 
+declare the exception in your JNA mapping. Alternatively, you can use 
+{@link com.sun.jna.Native#getLastError()} to retrieve it. Throwing an exception
+is preferred since it has better performance.
 
 <a name="java-objects"></a>
 <h3>Arbitrary Java Object arguments/return values</h3>
@@ -743,10 +748,6 @@ and {@link com.sun.jna.Structure#writeField(String)} or {@link
 com.sun.jna.Structure#writeField(String,Object)} to synch with just the fields
 of interest. 
 <h3>Throw exceptions on last error</h3>
-To avoid the overhead of preserving the system last error information on every
-native call, invoke
-{@link com.sun.jna.Native#setPreserveLastError setPreserveLastError(false)} or
-set the System property <code>jna.preserve_last_error=false</code>.<p/>
 In those methods where you are interested in the value of errno/GetLastError(),
 declare your method to throw {@link com.sun.jna.LastErrorException}.
 </body>

--- a/test/com/sun/jna/NativeTest.java
+++ b/test/com/sun/jna/NativeTest.java
@@ -68,15 +68,6 @@ public class NativeTest extends TestCase {
             }
         }
     }
-    
-    @SuppressWarnings("deprecation")
-    public void testVersion() {
-        String[] INPUTS = { "1.0", "1.0.1", "2.1.3" };
-        float[] EXPECTED = { 1.0f, 1.0f, 2.1f };
-        for (int i=0;i < INPUTS.length;i++) {
-            assertEquals("Incorrectly parsed version", EXPECTED[i], Native.parseVersion(INPUTS[i]));
-        }
-    }
 
     public void testLongStringGeneration() {
         StringBuilder buf = new StringBuilder();


### PR DESCRIPTION
With JNA entering a new major version API breaches are possible. In the discussion around PR #839 it was made clear, that clearing up the code should be a priority. In consequence that attached changes remove all deprecated elements.

All elements have better replacements, which are document in the changelog.

There is one method, that is deprecated, but not removed:

`Native#getDirectByteBuffer`

This method was removed from the public interface (visibility changed from public to private) to retain the compatibility at the Java<->C interface. Removing the above declaration completely would require a full rebuild of all native binaries without any benefits.