### PR TITLE
Changing Class<T> to Class<T extends Library> for Native.loadLibrary

### DIFF
--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -503,7 +503,7 @@ public final class Native implements Version {
      * @throws UnsatisfiedLinkError if the library cannot be found or
      * dependent libraries are missing.
      */
-    public static <T> T loadLibrary(Class<T> interfaceClass) {
+    public static <T extends Library> T loadLibrary(Class<T> interfaceClass) {
         return loadLibrary(null, interfaceClass);
     }
 
@@ -522,7 +522,7 @@ public final class Native implements Version {
      * dependent libraries are missing.
      * @see #loadLibrary(String, Class, Map)
      */
-    public static <T> T loadLibrary(Class<T> interfaceClass, Map<String, ?> options) {
+    public static <T extends Library> T loadLibrary(Class<T> interfaceClass, Map<String, ?> options) {
         return loadLibrary(null, interfaceClass, options);
     }
 
@@ -540,7 +540,7 @@ public final class Native implements Version {
      * dependent libraries are missing.
      * @see #loadLibrary(String, Class, Map)
      */
-    public static <T> T loadLibrary(String name, Class<T> interfaceClass) {
+    public static <T extends Library> T loadLibrary(String name, Class<T> interfaceClass) {
         return loadLibrary(name, interfaceClass, Collections.<String, Object>emptyMap());
     }
 
@@ -560,8 +560,9 @@ public final class Native implements Version {
      * @throws UnsatisfiedLinkError if the library cannot be found or
      * dependent libraries are missing.
      */
-    public static <T> T loadLibrary(String name, Class<T> interfaceClass, Map<String, ?> options) {
+    public static <T extends Library> T loadLibrary(String name, Class<T> interfaceClass, Map<String, ?> options) {
         if (!Library.class.isAssignableFrom(interfaceClass)) {
+            // Maybe still possible if the caller is not using generics?
             throw new IllegalArgumentException("Interface (" + interfaceClass.getSimpleName() + ")"
                     + " of library=" + name + " does not extend " + Library.class.getSimpleName());
         }

--- a/test/com/sun/jna/NativeTest.java
+++ b/test/com/sun/jna/NativeTest.java
@@ -61,7 +61,7 @@ public class NativeTest extends TestCase {
                 Method m = Native.class.getMethod("loadLibrary", paramTypes);
                 Class<?> returnType = m.getReturnType();
                 signature.append(Native.getSignature(returnType));
-                assertSame("Mismatched return type for signature=" + signature, Object.class, returnType);
+                assertSame("Mismatched return type for signature=" + signature, Library.class, returnType);
 //                System.out.println("===>" + m.getName() + ": " + signature);
             } catch(NoSuchMethodError err) {
                 fail("No method for signature=" + signature);


### PR DESCRIPTION
It was possible to pass a non-library class into this method and get a runtime exception, when the same check can be done at compile-time, so this fix changes it to be done at compile-time.

After erasure, with this change the return type changes from `Object` to `Library`. So as far as backwards compatibility:

1. If you were assigning the result to `Object`, that will still work
2. If you were passing something that wasn't a `Class<? extends Library>`, your code will now not compile, instead of failing at runtime.
3. I can't remember the rules for binary compatibility.

Fixes #822.