### PR TITLE
change armSoftFloat condition in ELFAnalyser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Bug Fixes
 ---------
 * [#652](https://github.com/java-native-access/jna/issues/652): Dead Lock in class initialization - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#843](https://github.com/java-native-access/jna/pull/843): Correctly bind `com.sun.jna.platform.win32.SecBufferDesc` and add convenience binding as `com.sun.jna.platform.win32.SspiUtil.ManagedSecBufferDesc`. Bind SSPI functions `InitializeSecurityContext`, `AcceptSecurityContext`, `QueryCredentialsAttributes`, `QuerySecurityPackageInfo`, `EncryptMessage`, `DecryptMessage`, `MakeSignature`, `VerifySignature` in `com.sun.jna.platform.win32.Secur32` - [@matthiasblaesing](https://github.com/matthiasblaesing).
-
+* [#863](https://github.com/java-native-access/jna/pull/863): change armSoftFloat condition in ELFAnalyser - [@kunkun26](https://github.com/kunkun26).
 
 Breaking Changes
 ----------------

--- a/src/com/sun/jna/ELFAnalyser.java
+++ b/src/com/sun/jna/ELFAnalyser.java
@@ -133,8 +133,8 @@ class ELFAnalyser {
         
         if(arm) {
             int flags = headerData.getInt(_64Bit ? 0x30 : 0x24);
-            armSoftFloat = (flags & EF_ARM_ABI_FLOAT_SOFT) == EF_ARM_ABI_FLOAT_SOFT;
             armHardFloat = (flags & EF_ARM_ABI_FLOAT_HARD) == EF_ARM_ABI_FLOAT_HARD;
+            armSoftFloat = !armHardFloat;
         }
     }
 }


### PR DESCRIPTION
Hi, i will send PR related ELFAnalyser. Please refer to the followings. 

[ELF for the ARM Architecture](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0044f/IHI0044F_aaelf.pdf) says 

```
If both
EF_ARM_ABI_FLOAT_XXXX bits are clear, conformance to the base
procedure-call standard is implied.
```

The base standard is software-floating. But now, the condition of armSoftFloat is whether EF_ARM_ABI_FLOAT_SOFT is exists or not. So, if jna is called from a program based on JDK without both EF_ARM_ABI_FLOAT_XXXX bits (e.g Oracle Java Embedded, a homemade JDK), jna select lib for hardware-floating and do not work correctly. 

So, I changed the condition of armSoftFloat.