### PR TITLE
Fix memory leak in COMLateBindingObject#getStringProperty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 Bug Fixes
 ---------
 * [#863](https://github.com/java-native-access/jna/pull/863): Fix ARM softfloat/hardfloat detection by modifying armSoftFloat condition in ELFAnalyser. Before this fix a softfloat binary could be misdetected as hardfloat. - [@kunkun26](https://github.com/kunkun26).
+* [#867](https://github.com/java-native-access/jna/issues/867): Fix memory leak in `COMLateBindingObject#getStringProperty` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 4.5.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
@@ -217,7 +217,11 @@ public class COMLateBindingObject extends COMBindingBaseObject {
         this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
                 this.getIDispatch(), propertyName);
 
-        return result.stringValue();
+        String res = result.stringValue();
+        
+        OleAuto.INSTANCE.VariantClear(result);
+        
+        return res;
     }
 
     /**


### PR DESCRIPTION
Variants that hold strings utilize a BSTR. BSTRs are special in the sense, that
they are allocated by SysAllocString and freed by SysFreeString and the memory
needs to be explicitly cleared.

For Variants this is handled by VariantClear. VariantClear clears the data
contained in the Variant and frees that data (not the Variant itself!). The
Variant structure is caller allocated and in JNA located in auto-allocated
memory and does not need to be explicitly freed.

This closes #867