### PR TITLE
Add SuppressWarnings unused and other code cleanup

### DIFF
--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -101,7 +101,8 @@ public class CallbackReference extends WeakReference<Callback> {
     }
 
     /* Called from native code to initialize a callback thread. */
-    private static ThreadGroup initializeThread(Callback cb, AttachOptions args) {
+    @SuppressWarnings("unused")
+	private static ThreadGroup initializeThread(Callback cb, AttachOptions args) {
         CallbackThreadInitializer init = null;
         if (cb instanceof DefaultCallbackProxy) {
             cb = ((DefaultCallbackProxy)cb).getCallback();

--- a/src/com/sun/jna/ELFAnalyser.java
+++ b/src/com/sun/jna/ELFAnalyser.java
@@ -26,7 +26,6 @@ class ELFAnalyser {
      * e_flags mask if executable file conforms to software floating-point
      * procedure-call standard (arm ABI version 5)
      */
-    private static final int EF_ARM_ABI_FLOAT_SOFT = 0x00000200;
     private static final int EI_DATA_BIG_ENDIAN = 2;
     private static final int E_MACHINE_ARM = 0x28;
     private static final int EI_CLASS_64BIT = 2;
@@ -116,6 +115,7 @@ class ELFAnalyser {
             }
         }
         if (!ELF) {
+        	raf.close();
             return;
         }
         raf.seek(4);
@@ -136,5 +136,7 @@ class ELFAnalyser {
             armHardFloat = (flags & EF_ARM_ABI_FLOAT_HARD) == EF_ARM_ABI_FLOAT_HARD;
             armSoftFloat = !armHardFloat;
         }
+
+    	raf.close();
     }
 }

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -270,7 +270,7 @@ public class Function extends Pointer {
         this.functionName = functionAddress.toString();
         this.callFlags = callFlags;
         this.peer = functionAddress.peer;
-        this.options = Collections.EMPTY_MAP;
+        this.options = Collections.emptyMap();
         this.encoding = encoding != null
             ? encoding : Native.getDefaultStringEncoding();
     }

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -651,7 +651,8 @@ public final class Native implements Version {
      * @param type The type class
      * @return The options map
      */
-    public static Map<String, Object> getLibraryOptions(Class<?> type) {
+    @SuppressWarnings("unchecked")
+	public static Map<String, Object> getLibraryOptions(Class<?> type) {
         Map<String, Object> libraryOptions;
         // cached already ?
         synchronized(libraries) {
@@ -2242,7 +2243,6 @@ public final class Native implements Version {
             // state every time.  Clear the termination flag, since it's not
             // needed when the native thread is detached normally.
             nativeThreads.remove(thread);
-            Pointer p = nativeThreadTerminationFlag.get();
             setDetachState(true, 0);
         }
         else {

--- a/src/com/sun/jna/NativeString.java
+++ b/src/com/sun/jna/NativeString.java
@@ -31,7 +31,7 @@ import java.nio.CharBuffer;
  * @author  Todd Fast, todd.fast@sun.com
  * @author twall@users.sf.net
  */
-class NativeString implements CharSequence, Comparable {
+class NativeString implements CharSequence, Comparable<Object> {
 
     static final String WIDE_STRING = "--WIDE-STRING--";
 

--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -149,7 +149,8 @@ public abstract class Structure {
     private final Map<String, Object> nativeStrings = new HashMap<String, Object>();
     private TypeMapper typeMapper;
     // This field is accessed by native code
-    private long typeInfo;
+    @SuppressWarnings("unused")
+	private long typeInfo;
 
     private boolean autoRead = true;
     private boolean autoWrite = true;
@@ -1356,7 +1357,8 @@ public abstract class Structure {
         return value;
     }
 
-    private int addPadding(int calculatedSize) {
+    @SuppressWarnings("unused")
+	private int addPadding(int calculatedSize) {
         return addPadding(calculatedSize, structAlignment);
     }
 
@@ -1586,8 +1588,10 @@ public abstract class Structure {
     public Structure[] toArray(int size) {
         return toArray((Structure[])Array.newInstance(getClass(), size));
     }
-
-    private Class<?> baseClass() {
+    
+    //Native usage
+    @SuppressWarnings("unused")
+	private Class<?> baseClass() {
         if ((this instanceof Structure.ByReference
              || this instanceof Structure.ByValue)
             && Structure.class.isAssignableFrom(getClass().getSuperclass())) {
@@ -1755,7 +1759,8 @@ public abstract class Structure {
      * #newInstance(Class,Pointer)}, except that it additionally calls
      * {@link #conditionalAutoRead()}.
      */
-    private static Structure newInstance(Class<?> type, long init) {
+    @SuppressWarnings("unused")
+	private static Structure newInstance(Class<?> type, long init) {
         try {
             Structure s = newInstance(type, init == 0 ? PLACEHOLDER_MEMORY : new Pointer(init));
             if (init != 0) {
@@ -1879,11 +1884,12 @@ public abstract class Structure {
         // Native.initIDs initializes these fields to their appropriate
         // pointer values.  These are in a separate class from FFIType so that
         // they may be initialized prior to loading the FFIType class
+        @SuppressWarnings("unused")
         private static class FFITypes {
             private static Pointer ffi_type_void;
             private static Pointer ffi_type_float;
             private static Pointer ffi_type_double;
-            private static Pointer ffi_type_longdouble;
+			private static Pointer ffi_type_longdouble;
             private static Pointer ffi_type_uint8;
             private static Pointer ffi_type_sint8;
             private static Pointer ffi_type_uint16;

--- a/src/com/sun/jna/WString.java
+++ b/src/com/sun/jna/WString.java
@@ -26,7 +26,7 @@ package com.sun.jna;
 /** Simple wrapper class to identify a wide string argument or return type.
  * @author twall@users.sf.net
  */
-public final class WString implements CharSequence, Comparable {
+public final class WString implements CharSequence, Comparable<Object> {
     private String string;
     public WString(String s){
         if (s == null) {

--- a/src/com/sun/jna/WeakMemoryHolder.java
+++ b/src/com/sun/jna/WeakMemoryHolder.java
@@ -47,7 +47,7 @@ public class WeakMemoryHolder {
     }
     
     public synchronized void clean() {
-        for(Reference ref = referenceQueue.poll(); ref != null; ref = referenceQueue.poll()) {
+        for(Reference<?> ref = referenceQueue.poll(); ref != null; ref = referenceQueue.poll()) {
             backingMap.remove(ref);
         }
     }


### PR DESCRIPTION
Fixes RandomAccessFile raf not being closed in ELFAnalyzer. Also removes the now unused field EF_ARM_ABI_FLOAT_SOFT from the same class. Other minor code cleanups, adding SuppressWarning unused's where native code calls occur (feel free to remove anything with that in it, I saw nothing in the contributing file that would suggest the use or refute it).