### PR TITLE
Tighten the generic bounds for Structure#newInstance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Release 5.0.0 (Next release)
 
 Features
 --------
+* [#822](https://github.com/java-native-access/jna/issues/822): `Native#loadLibrary` requires that the interface class passed in is an instance of Library. The runtime check can be enhanced by using a constraint generic. This breaks binary compatibility (see notes below) - [@d-noll](https://github.com/d-noll).
+* [#889](https://github.com/java-native-access/jna/issues/889): The `Structure#newInstance` receive the target type as a parameter. This adds a limited generic type, so that the return type ist the target type and not a generic structure, removing the necessity to do an explizit cast  - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winevt.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winevt.java
@@ -488,7 +488,7 @@ public interface Winevt {
                     return isArray() ? field1.getPointer().getPointer(0).getWideStringArray(0, Count) : field1.getPointer().getPointer(0).getWideString(0);
                 case EvtVarTypeFileTime:
                     if (isArray()) {
-                        WinBase.FILETIME resultFirst = (WinBase.FILETIME) Structure.newInstance(WinBase.FILETIME.class, field1.getPointer().getPointer(0));
+                        WinBase.FILETIME resultFirst = Structure.newInstance(WinBase.FILETIME.class, field1.getPointer().getPointer(0));
                         resultFirst.read();
                         return resultFirst.toArray(Count);
                     } else {
@@ -498,11 +498,11 @@ public interface Winevt {
                     }
                 case EvtVarTypeSysTime:
                     if (isArray()) {
-                        WinBase.SYSTEMTIME resultFirst = (WinBase.SYSTEMTIME) Structure.newInstance(WinBase.SYSTEMTIME.class, field1.getPointer().getPointer(0));
+                        WinBase.SYSTEMTIME resultFirst = Structure.newInstance(WinBase.SYSTEMTIME.class, field1.getPointer().getPointer(0));
                         resultFirst.read();
                         return resultFirst.toArray(Count);
                     } else {
-                        WinBase.SYSTEMTIME result = (WinBase.SYSTEMTIME) Structure.newInstance(WinBase.SYSTEMTIME.class, field1.getPointer().getPointer(0));
+                        WinBase.SYSTEMTIME result = Structure.newInstance(WinBase.SYSTEMTIME.class, field1.getPointer().getPointer(0));
                         result.read();
                         return result;
                     }
@@ -531,21 +531,21 @@ public interface Winevt {
                     return null;
                 case EvtVarTypeGuid:
                     if (isArray()) {
-                        Guid.GUID resultFirst = (Guid.GUID) Structure.newInstance(Guid.GUID.class, field1.getPointer().getPointer(0));
+                        Guid.GUID resultFirst = Structure.newInstance(Guid.GUID.class, field1.getPointer().getPointer(0));
                         resultFirst.read();
                         return resultFirst.toArray(Count);
                     } else {
-                        Guid.GUID result = (Guid.GUID) Structure.newInstance(Guid.GUID.class, field1.getPointer().getPointer(0));
+                        Guid.GUID result = Structure.newInstance(Guid.GUID.class, field1.getPointer().getPointer(0));
                         result.read();
                         return result;
                     }
                 case EvtVarTypeSid:
                     if (isArray()) {
-                        WinNT.PSID resultFirst = (WinNT.PSID) Structure.newInstance(WinNT.PSID.class, field1.getPointer().getPointer(0));
+                        WinNT.PSID resultFirst = Structure.newInstance(WinNT.PSID.class, field1.getPointer().getPointer(0));
                         resultFirst.read();
                         return resultFirst.toArray(Count);
                     } else {
-                        WinNT.PSID result = (WinNT.PSID) Structure.newInstance(WinNT.PSID.class, field1.getPointer().getPointer(0));
+                        WinNT.PSID result = Structure.newInstance(WinNT.PSID.class, field1.getPointer().getPointer(0));
                         result.read();
                         return result;
                     }

--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -272,7 +272,7 @@ public class CallbackReference extends WeakReference<Callback> {
     private Class<?> getNativeType(Class<?> cls) {
         if (Structure.class.isAssignableFrom(cls)) {
             // Make sure we can instantiate an argument of this type
-            Structure.validate(cls);
+            Structure.validate((Class<? extends Structure>)cls);
             if (!Structure.ByValue.class.isAssignableFrom(cls))
                 return Pointer.class;
         } else if (NativeMapped.class.isAssignableFrom(cls)) {
@@ -580,14 +580,14 @@ public class CallbackReference extends WeakReference<Callback> {
                     // If passed by value, don't hold onto the pointer, which
                     // is only valid for the duration of the callback call
                     if (Structure.ByValue.class.isAssignableFrom(dstType)) {
-                        Structure s = Structure.newInstance(dstType);
+                        Structure s = Structure.newInstance((Class<? extends Structure>) dstType);
                         byte[] buf = new byte[s.size()];
                         ((Pointer)value).read(0, buf, 0, buf.length);
                         s.getPointer().write(0, buf, 0, buf.length);
                         s.read();
                         value = s;
                     } else {
-                        Structure s = Structure.newInstance(dstType, (Pointer)value);
+                        Structure s = Structure.newInstance((Class<? extends Structure>) dstType, (Pointer)value);
                         s.conditionalAutoRead();
                         value = s;
                     }

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -378,11 +378,11 @@ public class Function extends Pointer {
                     if (args[i] instanceof PointerArray) {
                         PointerArray array = (PointerArray)args[i];
                         if (Structure.ByReference[].class.isAssignableFrom(inArg.getClass())) {
-                            Class<?> type = inArg.getClass().getComponentType();
+                            Class<? extends Structure> type = (Class<? extends Structure>) inArg.getClass().getComponentType();
                             Structure[] ss = (Structure[])inArg;
                             for (int si=0;si < ss.length;si++) {
                                 Pointer p = array.getPointer(Native.POINTER_SIZE * si);
-                                ss[si] = Structure.updateStructureByReference(type, ss[si], p);
+                                ss[si] = Structure.updateStructureByReference((Class<Structure>)type, ss[si], p);
                             }
                         }
                     }
@@ -436,13 +436,13 @@ public class Function extends Pointer {
             if (Structure.ByValue.class.isAssignableFrom(returnType)) {
                 Structure s =
                     Native.invokeStructure(this, this.peer, callFlags, args,
-                                           Structure.newInstance(returnType));
+                                           Structure.newInstance((Class<? extends Structure>)returnType));
                 s.autoRead();
                 result = s;
             } else {
                 result = invokePointer(callFlags, args);
                 if (result != null) {
-                    Structure s = Structure.newInstance(returnType, (Pointer)result);
+                    Structure s = Structure.newInstance((Class<? extends Structure>)returnType, (Pointer)result);
                     s.conditionalAutoRead();
                     result = s;
                 }
@@ -604,7 +604,7 @@ public class Function extends Pointer {
             } else if (ss.length == 0) {
                 throw new IllegalArgumentException("Structure array must have non-zero length");
             } else if (ss[0] == null) {
-                Structure.newInstance(type).toArray(ss);
+                Structure.newInstance((Class<? extends Structure>) type).toArray(ss);
                 return ss[0].getPointer();
             } else {
                 Structure.autoWrite(ss);

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -1241,7 +1241,7 @@ public final class Native implements Version {
         }
         if (Structure.class.isAssignableFrom(type)
             && !Structure.ByReference.class.isAssignableFrom(type)) {
-            return Structure.size(type, (Structure)value);
+            return Structure.size((Class<Structure>) type, (Structure)value);
         }
         try {
             return getNativeSize(type);
@@ -1276,7 +1276,7 @@ public final class Native implements Version {
         if (cls == double.class || cls == Double.class) return 8;
         if (Structure.class.isAssignableFrom(cls)) {
             if (Structure.ByValue.class.isAssignableFrom(cls)) {
-                return Structure.size(cls);
+                return Structure.size((Class<? extends Structure>) cls);
             }
             return POINTER_SIZE;
         }

--- a/src/com/sun/jna/Pointer.java
+++ b/src/com/sun/jna/Pointer.java
@@ -363,7 +363,7 @@ public class Pointer {
         if (Structure.class.isAssignableFrom(type)) {
             Structure s = (Structure)currentValue;
             if (Structure.ByReference.class.isAssignableFrom(type)) {
-                s = Structure.updateStructureByReference(type, s, getPointer(offset));
+                s = Structure.updateStructureByReference((Class<Structure>) type, s, getPointer(offset));
             } else {
                 s.useMemory(this, (int)offset, true);
                 s.read();
@@ -488,13 +488,13 @@ public class Pointer {
             if (Structure.ByReference.class.isAssignableFrom(cls)) {
                 Pointer[] parray = getPointerArray(offset, sarray.length);
                 for (int i=0;i < sarray.length;i++) {
-                    sarray[i] = Structure.updateStructureByReference(cls, sarray[i], parray[i]);
+                    sarray[i] = Structure.updateStructureByReference((Class<Structure>) cls, sarray[i], parray[i]);
                 }
             }
             else {
                 Structure first = sarray[0];
                 if (first == null) {
-                    first = Structure.newInstance(cls, share(offset));
+                    first = Structure.newInstance((Class<Structure>) cls, share(offset));
                     first.conditionalAutoRead();
                     sarray[0] = first;
                 }
@@ -940,7 +940,7 @@ public class Pointer {
             } else {
                 Structure first = sbuf[0];
                 if (first == null) {
-                    first = Structure.newInstance(cls, share(offset));
+                    first = Structure.newInstance((Class<Structure>) cls, share(offset));
                     sbuf[0] = first;
                 } else {
                     first.useMemory(this, (int)offset, true);

--- a/test/com/sun/jna/StructureTest.java
+++ b/test/com/sun/jna/StructureTest.java
@@ -281,7 +281,7 @@ public class StructureTest extends TestCase {
     private void testStructureSize(int index) {
         try {
             SizeTest lib = Native.loadLibrary("testlib", SizeTest.class);
-            Class<?> cls = Class.forName(getClass().getName() + "$TestStructure" + index);
+            Class<? extends Structure> cls = (Class<? extends Structure>) Class.forName(getClass().getName() + "$TestStructure" + index);
             Structure s = Structure.newInstance(cls);
             assertEquals("Incorrect size for structure " + index + "=>" + s.toString(true), lib.getStructureSize(index), s.size());
         }


### PR DESCRIPTION
The signature was: `Structure newInstance(Class<?> type)` requiring
an explicit cast after the call. The the new signature introduces a 
type parameter `T` with an upper bound of `com.sun.jna.Structure`: 

```java
<T extends Structure> T newInstance(Class<T> type)
```

The companion, that takes an init pointer was also updated:

```java
<T extends Structure> T newInstance(Class<T> type, Pointer init)
```

Closes: #889