### PR TITLE
Add @ComInterface anntation to IConnectionPoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@ Features
 --------
 * [#903](https://github.com/java-native-access/jna/pull/903): Carry `HRESULT` in `c.s.j.p.win32.COM.COMException`, introduce `c.s.j.p.win32.COM.COMInvokeException` as subclass of `COMException` for exception as the result of a `IDispatch#Invoke`. The `EXECPINFO` is unwrapped into fields in the `COMInvokeException` and correctly freed. - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#822](https://github.com/java-native-access/jna/issues/822): `Native#loadLibrary` requires that the interface class passed in is an instance of Library. The runtime check can be enhanced by using a constraint generic. This breaks binary compatibility (see notes below) - [@d-noll](https://github.com/d-noll).
-* [#889](https://github.com/java-native-access/jna/issues/889): The `Structure#newInstance` receive the target type as a parameter. This adds a limited generic type, so that the return type ist the target type and not a generic structure, removing the necessity to do an explizit cast  - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#889](https://github.com/java-native-access/jna/issues/889): The `Structure#newInstance` receive the target type as a parameter. This adds a limited generic type, so that the return type ist the target type and not a generic structure, removing the necessity to do an explizit cast - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#913](https://github.com/java-native-access/jna/issues/913): Add `@ComInterface` annotation to `com.sun.jna.platform.win32.COM.util.IConnectionPoint` to make it possible to retrieve it via `IUnknown#queryInterface` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/IConnectionPoint.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/IConnectionPoint.java
@@ -24,7 +24,9 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.platform.win32.COM.COMException;
+import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
 
+@ComInterface(iid="{B196B284-BAB4-101A-B69C-00AA00341D07}")
 public interface IConnectionPoint {
 
 	/**

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacksObjectFactory_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacksObjectFactory_Test.java
@@ -291,4 +291,71 @@ public class ComEventCallbacksObjectFactory_Test {
                 hr = proxy.QueryInterface(new REFIID(new IID("{00000000-0000-0000-C000-000000000000}")), interfacePointer);
                 assertTrue(COMUtils.FAILED(hr));
         }
+        
+        // This tests, that the IConnectionPoint interface can be queried
+        // via queryInterface and does not require the primary interface 
+        // to extends IConnectionPoint
+        
+        @ComObject(progId="Internet.Explorer.1", clsId = "{0002DF01-0000-0000-C000-000000000046}")
+	interface ComInternetExplorerWithoutConnectionPoint extends ComIWebBrowser2WithoutConnectionPoint {
+	}
+	
+	@ComInterface(iid="{D30C1661-CDAF-11D0-8A3E-00C04FC9E26E}")
+	interface ComIWebBrowser2WithoutConnectionPoint extends IUnknown {
+		@ComProperty
+		boolean getVisible();
+		
+		@ComProperty
+		void setVisible(boolean value);
+		
+		@ComMethod
+		void Quit();
+                
+		@ComMethod
+                /**
+                 * navOpenInNewWindow = 1
+                 * navNoHistory = 2
+                 * navNoReadFromCache = 4
+                 * navNoWriteToCache = 8
+                 * navAllowAutosearch = 16
+                 * navBrowserBar = 32
+                 * navHyperlink = 64
+                 * navEnforceRestricted = 128
+                 * navNewWindowsManaged = 256
+                 * navUntrustedForDownload = 512
+                 * navTrustedForActiveX = 1024
+                 * navOpenInNewTab = 2048
+                 * navOpenInBackgroundTab = 4096
+                 * navKeepWordWheelText = 8192
+                 * navVirtualTab = 16384
+                 * navBlockRedirectsXDomain = 32768
+                 * navOpenNewForegroundTab = 65536
+                 */
+		void Navigate(String url, long flags, String targetFrameName, VARIANT postData, String headers);
+	}
+        
+	@Test
+	public void adviseNavigateComplete2WithoutConnectionPoint() throws InterruptedException {
+		ComInternetExplorerWithoutConnectionPoint ieApp = factory.createObject(ComInternetExplorerWithoutConnectionPoint.class);
+		ComIWebBrowser2WithoutConnectionPoint iWebBrowser2 = ieApp.queryInterface(ComIWebBrowser2WithoutConnectionPoint.class);
+		iWebBrowser2.setVisible(true);
+                
+                DWebBrowserEvents2_Listener listener = new DWebBrowserEvents2_Listener();
+		IComEventCallbackCookie cookie = iWebBrowser2.queryInterface(IConnectionPoint.class).advise(DWebBrowserEvents2.class, listener);
+                
+		iWebBrowser2.Navigate("https://github.com/java-native-access/jna", 0, null, null, null);
+                
+                for(int i = 0; i < 10; i++) {
+                    if(listener.navigateComplete2Called) {
+                        break;
+                    }
+                    Thread.sleep(1000);
+                }
+                
+                iWebBrowser2.Quit();
+                
+                Assert.assertTrue("NavigateComplete was not called", listener.navigateComplete2Called);
+                Assert.assertNotNull("URL passed to NavigateComplete2 was NULL", listener.navigateComplete2URL);
+                Assert.assertThat(listener.navigateComplete2URL, CoreMatchers.startsWith("https://github.com/java-native-access/jna"));
+	}
 }


### PR DESCRIPTION
With the added @ComInterface annotation the IConnectionPoint interface
can be retrieved via the IUnknown#queryInterface method.