### PR TITLE
Add RegConnectRegistry to Advapi32 mappings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Features
 * [#913](https://github.com/java-native-access/jna/issues/913): Add `@ComInterface` annotation to `com.sun.jna.platform.win32.COM.util.IConnectionPoint` to make it possible to retrieve it via `IUnknown#queryInterface` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#797](https://github.com/java-native-access/jna/issues/797): Binding `Advapi32#EnumDependendServices`, `Advapi32#EnumServicesStatusEx` and `Advapi32#QueryServiceStatus`. `W32Service#stopService` was modified to be more resilent when stopping service - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * Bind `com.sun.jna.platform.win32.Kernel32.ExpandEnvironmentStrings` and add helper method for it as `Kernel32Util#expandEnvironmentStrings` - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#935](https://github.com/java-native-access/jna/pull/935): Add RegConnectRegistry to Advapi32 mappings. - [@cxcorp](https://github.com/cxcorp).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -855,6 +855,39 @@ public interface Advapi32 extends StdCallLibrary {
                      int samDesired, HKEYByReference phkResult);
 
     /**
+     * Establishes a connection to a predefined registry key on another
+     * computer.
+     * @param lpMachineName
+     *            The name of the remote computer. The string has
+     *            the following form:<br />
+     *            <pre><code>\\computername</code></pre>
+     *            The caller must have access to the remote computer or the
+     *            function fails.<br />
+     *            If this parameter is <c>null</c>, the local computer name
+     *            is used.
+     * @param hKey
+     *            A predefined registry handle. This parameter can be one of
+     *            the following predefined keys on the remote computer.<br />
+     *            <ul>
+     *                <li>{@link WinReg#HKEY_LOCAL_MACHINE}</li>
+     *                <li>{@link WinReg#HKEY_PERFORMANCE_DATA}</li>
+     *                <li>{@link WinReg#HKEY_USERS}</li>
+     *            </ul>
+     * @param phkResult
+     *            A pointer to a variable that receives a key handle
+     *            identifying the predefined handle on the remote computer.
+     * @return If the function succeeds, the return value is
+     *         {@link WinError#ERROR_SUCCESS}.<br />
+     *         If the function fails, the return value is a nonzero error code
+     *         defined in Winerror.h. You can use the
+     *         {@link Native#getLastError} method to get a generic description
+     *         of the error.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724840.aspx">RegConnectRegistry function (Windows)</a>
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724836.aspx">Predefined Keys (Windows)</a>
+     */
+    int RegConnectRegistry(String lpMachineName, HKEY hKey, HKEYByReference phkResult);
+
+    /**
      * The RegQueryValueEx function retrieves the type and data for a specified
      * value name associated with an open registry key.
      *

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -878,8 +878,15 @@ public interface Advapi32 extends StdCallLibrary {
      *            identifying the predefined handle on the remote computer.
      * @return If the function succeeds, the return value is
      *         {@link WinError#ERROR_SUCCESS}.<br />
-     *         If the function fails, the return value is a nonzero error code
-     *         defined in Winerror.h. You can use the
+     *         If the remote computer cannot be found or if its Remote Registry
+     *         service is disabled, the function fails and returns 
+     *         {@link WinError#ERROR_BAD_NETPATH}.<br />
+     *         If attempting to use a registry handle other than one of the
+     *         three predefined handles, the function fails and returns
+     *         {@link WinError#ERROR_INVALID_HANDLE}.<br />
+     *         If access to the registry is denied, the function fails and
+     *         returns {@link WinError#ERROR_ACCESS_DENIED}. <br />
+     *         If the function fails for some other reason, you can use the
      *         {@link Native#getLastError} method to get a generic description
      *         of the error.
      * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724840.aspx">RegConnectRegistry function (Windows)</a>

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -493,6 +493,14 @@ public class Advapi32Test extends TestCase {
     	assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegCloseKey(phKey.getValue()));
     }
 
+    public void testRegConnectRegistry() {
+    	HKEYByReference phkResult = new HKEYByReference();
+    	assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegConnectRegistry(
+    			"\\\\localhost", WinReg.HKEY_LOCAL_MACHINE, phkResult));
+    	assertTrue(WinBase.INVALID_HANDLE_VALUE != phkResult.getValue());
+    	assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegCloseKey(phkResult.getValue()));
+    }
+
     public void testRegQueryValueEx() {
     	HKEYByReference phKey = new HKEYByReference();
     	assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegOpenKeyEx(

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -495,8 +495,20 @@ public class Advapi32Test extends TestCase {
 
     public void testRegConnectRegistry() {
     	HKEYByReference phkResult = new HKEYByReference();
-    	assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegConnectRegistry(
-    			"\\\\localhost", WinReg.HKEY_LOCAL_MACHINE, phkResult));
+    	int connectResult = Advapi32.INSTANCE.RegConnectRegistry(
+    			"\\\\localhost", WinReg.HKEY_LOCAL_MACHINE, phkResult);
+    
+    	if (connectResult == W32Errors.ERROR_BAD_NETPATH) {
+    		System.err.println("Failed to connect to registry with RegConnectRegistry, remote registry service is probably disabled");
+    		return;
+    	}
+    
+    	if (connectResult == W32Errors.ERROR_ACCESS_DENIED) {
+    		System.err.println("Access was denied when connecting to registry with RegConnectRegistry");
+    		return;
+    	}
+    
+    	assertEquals(W32Errors.ERROR_SUCCESS, connectResult);
     	assertTrue(WinBase.INVALID_HANDLE_VALUE != phkResult.getValue());
     	assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegCloseKey(phkResult.getValue()));
     }


### PR DESCRIPTION
Adds the [`RegConnectRegistry`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724840.aspx) function mapping to Advapi32. This function is used to connect to remote machines' registries.

I added a test case for the function, but to be completely fair, I'm not 100% sure if the `\\localhost` UNC path works. The test case could be edited to pass in `null` for the name, but then the test doesn't guarantee that the first parameter is a string.