### PR TITLE
Add annotations for Java 10+ javac -h for native headers

### DIFF
--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -60,17 +60,23 @@ public class Function extends Pointer {
     }
 
     /** Maximum number of arguments supported by a JNA function call. */
+    @java.lang.annotation.Native
     public static final int MAX_NARGS = 256;
 
     /** Standard C calling convention. */
+    @java.lang.annotation.Native
     public static final int C_CONVENTION = 0;
     /** First alternate convention (currently used only for w32 stdcall). */
+    @java.lang.annotation.Native
     public static final int ALT_CONVENTION = 0x3F;
 
+    @java.lang.annotation.Native
     private static final int MASK_CC = 0x3F;
     /** Whether to throw an exception if last error is non-zero after call. */
+    @java.lang.annotation.Native
     public static final int THROW_LAST_ERROR = 0x40;
     /** Mask for number of fixed args (1-3) for varargs calls. */
+    @java.lang.annotation.Native
     public static final int USE_VARARGS = 0x180;
 
     static final Integer INTEGER_TRUE = Integer.valueOf(-1);


### PR DESCRIPTION
Initial modifications for Java 10+ ```javac -h``` since ```javah``` was removed starting with Java 10 now released per issue #902. I am good with the annotations. I am NOT ok with the FIXME code in there. That was the ONLY way I could find to generate the header files for those classes. I had to introduce a variable in both classes and interfaces, so I could add the annotations. I do not like adding unused variables....

However that did generate the header files for the methods exactly as javah did before. The exception is the interfaces. Since I could not make those variables private, those variables show up in the header files, unlike javah. With these modifications, if you do ```javah``` with < 10, and then do ```javac -h``` with 9, 10, or 11. The output is the same except the following. A and B are folders, ```javah``` is outputted to A, ```javac -h``` from 11 in B. You can see the only difference is the header files for interfaces due to unused variable being public.
```diff
$ diff -Naur a b
diff -Naur a/com_sun_jna_Function_PostCallRead.h b/com_sun_jna_Function_PostCallRead.h
--- a/com_sun_jna_Function_PostCallRead.h       2018-03-21 19:04:13.921572141 -0400
+++ b/com_sun_jna_Function_PostCallRead.h       2018-03-21 20:04:13.605134889 -0400
@@ -7,6 +7,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#undef com_sun_jna_Function_PostCallRead_UNUSED
+#define com_sun_jna_Function_PostCallRead_UNUSED 0L
 #ifdef __cplusplus
 }
 #endif
diff -Naur a/com_sun_jna_Native_ffi_callback.h b/com_sun_jna_Native_ffi_callback.h
--- a/com_sun_jna_Native_ffi_callback.h 2018-03-21 19:04:15.531624426 -0400
+++ b/com_sun_jna_Native_ffi_callback.h 2018-03-21 20:04:14.325158271 -0400
@@ -7,6 +7,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#undef com_sun_jna_Native_ffi_callback_UNUSED
+#define com_sun_jna_Native_ffi_callback_UNUSED 0L
 #ifdef __cplusplus
 }
 #endif
```

Now if the header files for the interfaces are not needed. Then it is a bit better. Still have unused private variables. Seems no other means to mark the class for native generation. Maybe a bug to be fixed in java 11? Likely to late for Java 10. Seems like interfaces and classes need to be able to be marked as Native via annotation or modifier/keyword.

Seems like there should be a better way. ```javah``` removal seems premature with ```javac -h``` not having full replacement abilities.
 - unable to generate native headers for classes without global variables to annotate with ```@java.lang.annotation.Native```
 - unable to generate native headers for interfaces in classes without adding a global public variable to annotate with ```@java.lang.annotation.Native```