### PR TITLE
Add ACL constructor that tolerates files with unknown ACE types

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -2569,7 +2569,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         }
 
         public ACCESS_ACEStructure[] getACEStructures() {
-            return getACEStructures(true);
+            return getACEStructures(false);
         }
 
         public ACCESS_ACEStructure[] getACEStructures(boolean tolerateUnknownAceTypes) {


### PR DESCRIPTION
I'd like to use JNA's ACL constructor on an NTFS file that happens to contain both supported ACE types (ACCESS_ALLOWED_ACE_TYPE, ACCESS_DENIED_ACE_TYPE) as well as an unsupported type (ACCESS_ALLOWED_CALLBACK_ACE_TYPE).  The constructor throws an IllegalArgumentException.

This change preserves the same default behavior, but also allows folks to construct ACL objects against files containing unsupported/unknown ACE types.

The goal here isn't to access the unsupported type, just to get a fully-constructed ACL object so it's possible to access the supported ACCESS_ALLOWED_ACE_TYPE & ACCESS_DENIED_ACE_TYPE ACE types.