### PR TITLE
COM Call through the `com.sun.jna.platform.win32.COM.util.Factory` lo…

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Factory.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Factory.java
@@ -177,10 +177,12 @@ public class Factory extends ObjectFactory {
         } catch (ExecutionException ex) {
             Throwable cause = ex.getCause();
             if (cause instanceof RuntimeException) {
+                appendStacktrace(ex, cause);
                 throw (RuntimeException) cause;
             } else if (cause instanceof InvocationTargetException) {
                 cause = ((InvocationTargetException) cause).getTargetException();
                 if (cause instanceof RuntimeException) {
+                    appendStacktrace(ex, cause);
                     throw (RuntimeException) cause;
                 }
             }
@@ -188,6 +190,19 @@ public class Factory extends ObjectFactory {
         }
     }
 
+    /**
+     * Append the stack trace available via caughtException to the stack trace
+     * of toBeThrown. The combined stack trace is reassigned to toBeThrown
+     */
+    private static void appendStacktrace(Exception caughtException, Throwable toBeThrown) {
+        StackTraceElement[] upperTrace = caughtException.getStackTrace();
+        StackTraceElement[] lowerTrace = toBeThrown.getStackTrace();
+        StackTraceElement[] trace = new StackTraceElement[upperTrace.length + lowerTrace.length];
+        System.arraycopy(upperTrace, 0, trace, lowerTrace.length, upperTrace.length);
+        System.arraycopy(lowerTrace, 0, trace, 0, lowerTrace.length);
+        toBeThrown.setStackTrace(trace);
+    }
+    
     public ComThread getComThread() {
         return comThread;
     }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ProxyObjectFactory_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ProxyObjectFactory_Test.java
@@ -154,8 +154,17 @@ public class ProxyObjectFactory_Test {
             assertNotNull("fetchObject on a non-running Object must raise an exception", exceptionRaised);
             assertEquals("Unexpected error code", exceptionRaised.getHresult().intValue(), WinError.MK_E_UNAVAILABLE);
             assertTrue("Error code not matched", exceptionRaised.matchesErrorCode(WinError.MK_E_UNAVAILABLE));
+            boolean callingMethodPartOfStackTrace = false;
+            for(StackTraceElement ste: exceptionRaised.getStackTrace()) {
+                if("testFetchNotExistingObject".equals(ste.getMethodName())
+                        && getClass().getName().equals(ste.getClassName())) {
+                    callingMethodPartOfStackTrace = true;
+                    break;
+                }
+            }
+            assertTrue("The calling method must be part of the reported stack trace", callingMethodPartOfStackTrace);
         }
-
+        
 	@Test
 	public void equals() {
 		MsWordApp comObj1 = this.factory.createObject(MsWordApp.class);

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ProxyObjectObjectFactory_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ProxyObjectObjectFactory_Test.java
@@ -158,6 +158,15 @@ public class ProxyObjectObjectFactory_Test {
             assertNotNull("fetchObject on a non-running Object must raise an exception", exceptionRaised);
             assertEquals("Unexpected error code", exceptionRaised.getHresult().intValue(), WinError.MK_E_UNAVAILABLE);
             assertTrue("Error code not matched", exceptionRaised.matchesErrorCode(WinError.MK_E_UNAVAILABLE));
+            boolean callingMethodPartOfStackTrace = false;
+            for(StackTraceElement ste: exceptionRaised.getStackTrace()) {
+                if("testFetchNotExistingObject".equals(ste.getMethodName())
+                        && getClass().getName().equals(ste.getClassName())) {
+                    callingMethodPartOfStackTrace = true;
+                    break;
+                }
+            }
+            assertTrue("The calling method must be part of the reported stack trace", callingMethodPartOfStackTrace);
         }
 
 	@Test


### PR DESCRIPTION
…ose stack trace information

The execution of business method invoked via 
com.sun.jna.platform.win32.COM.util.Factory is dispatched into a
different thread, that has COM initialized. If the execution of one
of these methods raises an Exception, the exception is unwrapped as
far as possible. This in turn looses the call information on the call
site.

This is corrected here by concatenating the two stacktraces. While
not strictly correct, it results in stack traces, that give enough
information to trace them back to their origin.

Closes: #948 