### PR TITLE
Fix SAFEARRAY ByReference in VARIANT

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import com.sun.jna.IntegerType;
 import com.sun.jna.Memory;
+import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -288,7 +289,7 @@ public interface OaIdl {
             return FIELDS;
         }
     }
-
+    
     /**
      * The Class DISPID.
      */
@@ -631,7 +632,7 @@ public interface OaIdl {
          * @param size array of dimension size
          * @return SAFEARRAYWrapper or {@code NULL} if creation fails.
          */
-        public static SAFEARRAY createSafeArray(int... size) {
+        public static SAFEARRAY.ByReference createSafeArray(int... size) {
             return createSafeArray(new WTypes.VARTYPE(Variant.VT_VARIANT), size);
         }
  
@@ -647,7 +648,7 @@ public interface OaIdl {
          * @param size array of dimension size
          * @return SAFEARRAYWrapper or {@code NULL} if creation fails.
          */
-        public static SAFEARRAY createSafeArray(VARTYPE vartype, int... size) {
+        public static SAFEARRAY.ByReference createSafeArray(VARTYPE vartype, int... size) {
             OaIdl.SAFEARRAYBOUND[] rgsabound = (OaIdl.SAFEARRAYBOUND[]) new OaIdl.SAFEARRAYBOUND().toArray(size.length);
             for (int i = 0; i < size.length; i++) {
                 rgsabound[i].lLbound = new WinDef.LONG(0);
@@ -1039,6 +1040,30 @@ public interface OaIdl {
          */
         public long getElemsize() {
             return OleAuto.INSTANCE.SafeArrayGetElemsize(this).longValue();
+        }
+    }
+
+    public static class SAFEARRAYByReference extends Structure implements Structure.ByReference {
+
+        public SAFEARRAYByReference() {
+        }
+
+        public SAFEARRAYByReference(Pointer p) {
+            super(p);
+            read();
+        }
+
+        public SAFEARRAYByReference(SAFEARRAY.ByReference safeArray) {
+            pSAFEARRAY = safeArray;
+        }
+
+        public static final List<String> FIELDS = createFieldsOrder("pSAFEARRAY");
+
+        public SAFEARRAY.ByReference pSAFEARRAY;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return FIELDS;
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
@@ -36,7 +36,6 @@ import com.sun.jna.platform.win32.OaIdl.VARIANT_BOOL;
 import com.sun.jna.platform.win32.OaIdl.VARIANT_BOOLByReference;
 import com.sun.jna.platform.win32.OaIdl._VARIANT_BOOLByReference;
 import com.sun.jna.platform.win32.WTypes.BSTR;
-import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.platform.win32.WTypes.VARTYPE;
 import com.sun.jna.platform.win32.WinDef.BOOL;
 import com.sun.jna.platform.win32.WinDef.BYTE;
@@ -61,6 +60,8 @@ import com.sun.jna.platform.win32.WinDef.USHORTByReference;
 import com.sun.jna.platform.win32.COM.Dispatch;
 import com.sun.jna.platform.win32.COM.IDispatch;
 import com.sun.jna.platform.win32.COM.Unknown;
+import com.sun.jna.platform.win32.OaIdl.SAFEARRAYByReference;
+import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.ptr.ByteByReference;
 import com.sun.jna.ptr.DoubleByReference;
 import com.sun.jna.ptr.FloatByReference;
@@ -186,7 +187,7 @@ public interface Variant {
 
         public VARIANT(BSTRByReference value) {
             this();
-            this.setValue(VT_BYREF | VT_BSTR, value);
+            this.setValue(VT_BSTR | VT_BYREF, value);
         }
 
         public VARIANT(VARIANT_BOOL value) {
@@ -226,7 +227,7 @@ public interface Variant {
             this();
             this.setValue(VT_UI2, new USHORT(value));
         }
-        
+
         public VARIANT(CHAR value) {
             this();
             this.setValue(Variant.VT_I1, value);
@@ -236,10 +237,15 @@ public interface Variant {
             this();
             this.setValue(VT_I2, new SHORT(value));
         }
-        
+
         public VARIANT(int value) {
             this();
             this.setValue(VT_I4, new LONG(value));
+        }
+
+        public VARIANT(IntByReference value) {
+            this();
+            this.setValue(VT_INT | VT_BYREF, value);
         }
 
         public VARIANT(long value) {
@@ -292,7 +298,12 @@ public interface Variant {
             this();
             this.setValue(array);
         }
-        
+
+        public VARIANT(SAFEARRAYByReference array) {
+            this();
+            this.setValue(array);
+        }
+
         public VARTYPE getVarType() {
             this.read();
             return _variant.vt;
@@ -305,9 +316,13 @@ public interface Variant {
         public void setValue(int vt, Object value) {
             this.setValue(new VARTYPE(vt), value);
         }
-        
+
         public void setValue(SAFEARRAY array) {
             this.setValue(array.getVarType().intValue() | VT_ARRAY, array);
+        }
+
+        public void setValue(SAFEARRAYByReference array) {
+            this.setValue(array.pSAFEARRAY.getVarType().intValue() | VT_ARRAY | VT_BYREF, array);
         }
 
         public void setValue(VARTYPE vt, Object value) {
@@ -556,7 +571,7 @@ public interface Variant {
         public byte byteValue() {
             return ((Number) this.getValue()).byteValue();
         }
-        
+
         public short shortValue() {
             return ((Number) this.getValue()).shortValue();
         }
@@ -680,13 +695,13 @@ public interface Variant {
                 // DATE * VT_BYREF|VT_DATE
                 public DATE.ByReference pdate;
                 // BSTR * VT_BYREF|VT_BSTR
-                public BSTR.ByReference pbstrVal;
+                public BSTRByReference pbstrVal;
                 // IUnknown ** VT_BYREF|VT_UNKNOWN
                 public Unknown.ByReference ppunkVal;
                 // IDispatch ** VT_BYREF|VT_DISPATCH
                 public Dispatch.ByReference ppdispVal;
                 // SAFEARRAY ** VT_BYREF|VT_ARRAY
-                public SAFEARRAY.ByReference pparray;
+                public SAFEARRAYByReference pparray;
                 // VARIANT * VT_BYREF|VT_VARIANT
                 public VARIANT.ByReference pvarVal;
                 // PVOID VT_BYREF (Generic ByRef)

--- a/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
@@ -101,10 +101,6 @@ public interface WTypes {
      * as a string containing zero characters.</p>
      */
     public static class BSTR extends PointerType {
-        public static class ByReference extends BSTR implements
-                Structure.ByReference {
-        }
-
         public BSTR() {
             super(Pointer.NULL);
         }


### PR DESCRIPTION
A SAFEARRAY byref that is wrapped in a VARIANT is a **SAFEARRAY. To
model this in JNA a pseudo structure SAFEARRAYByReference is introduced.

This approach is used, so that the referenced SAFEARRAY is read after
a native call.

To make it possible to pass a SAFEARRAYByReference and an IntByReference
through the ProxyObject helper, c.s.j.platform.win32.COM.util.Convert
is modified to reflectivly invoke a matching VARIANT constructor.

This change was manually tested with the GdPicture.NET library using
ProxyObject and COMLateBindingObject based binding.