### PR TITLE
Document synchronization requirement for KstatCtl

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/unix/solaris/LibKstat.java
+++ b/contrib/platform/src/com/sun/jna/platform/unix/solaris/LibKstat.java
@@ -367,6 +367,10 @@ public interface LibKstat extends Library {
         }
     }
 
+    /**
+     * A kstat control structure. Only one thread may actively use a KstatCtl
+     * value at any time. Synchronization is left to the application.
+     */
     class KstatCtl extends Structure {
 
         public int kc_chain_id; // current kstat chain ID


### PR DESCRIPTION
Adding a javadoc to note the mapping to `kstat_ctl_t` is not thread safe.  See https://github.com/oshi/oshi/issues/493 for background.