### PR TITLE
Restore compatibility of Native#loadLibrary, deprecate for Native#load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Features
 --------
 * [#915](https://github.com/java-native-access/jna/pull/915): Adding interfaces to call to Cryptui and Crypt32 windows libraries and adding related structures to Wincrypt. - [@rosh89](https://github.com/rosh89).
 * [#903](https://github.com/java-native-access/jna/pull/903): Carry `HRESULT` in `c.s.j.p.win32.COM.COMException`, introduce `c.s.j.p.win32.COM.COMInvokeException` as subclass of `COMException` for exception as the result of a `IDispatch#Invoke`. The `EXECPINFO` is unwrapped into fields in the `COMInvokeException` and correctly freed. - [@matthiasblaesing](https://github.com/matthiasblaesing).
-* [#822](https://github.com/java-native-access/jna/issues/822): `Native#loadLibrary` requires that the interface class passed in is an instance of Library. The runtime check can be enhanced by using a constraint generic. This breaks binary compatibility (see notes below) - [@d-noll](https://github.com/d-noll).
+* [#822](https://github.com/java-native-access/jna/issues/822): `Native#loadLibrary` requires that the interface class passed in is an instance of Library. The runtime check can be enhanced by using a constraint generic. This breaks binary compatibility (see notes below) - [@d-noll](https://github.com/d-noll).<br /><br />In a followup, the original `loadLibrary` methods were deprecated and `Native#load` methods were introduced, that hold the new generic definitions. So this change is now binary compatible.
 * [#889](https://github.com/java-native-access/jna/issues/889): The `Structure#newInstance` receive the target type as a parameter. This adds a limited generic type, so that the return type ist the target type and not a generic structure, removing the necessity to do an explizit cast - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#913](https://github.com/java-native-access/jna/issues/913): Add `@ComInterface` annotation to `com.sun.jna.platform.win32.COM.util.IConnectionPoint` to make it possible to retrieve it via `IUnknown#queryInterface` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#797](https://github.com/java-native-access/jna/issues/797): Binding `Advapi32#EnumDependendServices`, `Advapi32#EnumServicesStatusEx` and `Advapi32#QueryServiceStatus`. `W32Service#stopService` was modified to be more resilent when stopping service - [@matthiasblaesing](https://github.com/matthiasblaesing).
@@ -66,10 +66,6 @@ Breaking Changes
 * `com.sun.jna.Native#setPreserveLastError` and `com.sun.jna.Native#getPreserveLastError`
   were removed without replacement. They were turned into NOOPs in the past.
 * `com.sun.jna.Native#getDirectByteBuffer` was replaced by `com.sun.jna.Pointer#getByteBuffer`
-* `com.sun.jna.Native#loadLibrary` methods return a `T` instance and expect
-  a `Class<T>` as parameter. `T` was unconstraint and was modified to
-  extend `com.sun.jna.Library`. This change is source compatible, but not
-  binary compatbile, so bindings need to be recompiled.
 * the parameters of the methods `gethostname`, `sethostname`, `getdomainname` 
    and `setdomainname` in the interface `com.sun.jna.platform.unix.LibCAPI`
   were changed from `(char[] name, int len)` to `(byte[] name, int len)`

--- a/contrib/platform/src/com/sun/jna/platform/mac/Carbon.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/Carbon.java
@@ -40,7 +40,7 @@ import com.sun.jna.ptr.PointerByReference;
  * Date: 7/25/11
  */
 public interface Carbon extends Library {
-    Carbon INSTANCE = Native.loadLibrary("Carbon", Carbon.class);
+    Carbon INSTANCE = Native.load("Carbon", Carbon.class);
 
     int cmdKey = 0x0100;
     int shiftKey = 0x0200;

--- a/contrib/platform/src/com/sun/jna/platform/mac/MacFileUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/MacFileUtils.java
@@ -42,7 +42,7 @@ public class MacFileUtils extends FileUtils {
 
     public interface FileManager extends Library {
 
-        FileManager INSTANCE = Native.loadLibrary("CoreServices", FileManager.class);
+        FileManager INSTANCE = Native.load("CoreServices", FileManager.class);
 
         int kFSFileOperationDefaultOptions = 0;
         int kFSFileOperationsOverwrite = 0x01;

--- a/contrib/platform/src/com/sun/jna/platform/mac/SystemB.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/SystemB.java
@@ -40,7 +40,7 @@ import com.sun.jna.ptr.PointerByReference;
  */
 public interface SystemB extends Library {
 
-    SystemB INSTANCE = Native.loadLibrary("System", SystemB.class);
+    SystemB INSTANCE = Native.load("System", SystemB.class);
 
     // host_statistics()
     int HOST_LOAD_INFO = 1;// System loading stats

--- a/contrib/platform/src/com/sun/jna/platform/mac/XAttr.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/XAttr.java
@@ -34,7 +34,7 @@ import com.sun.jna.Pointer;
 interface XAttr extends Library {
 
 	// load from current image
-	XAttr INSTANCE = Native.loadLibrary(null, XAttr.class);
+	XAttr INSTANCE = Native.load(null, XAttr.class);
 
 	// see /usr/include/sys/xattr.h
 	int XATTR_NOFOLLOW = 0x0001;

--- a/contrib/platform/src/com/sun/jna/platform/unix/LibC.java
+++ b/contrib/platform/src/com/sun/jna/platform/unix/LibC.java
@@ -32,5 +32,5 @@ import com.sun.jna.Native;
  */
 public interface LibC extends LibCAPI, Library {
     String NAME = "c";
-    LibC INSTANCE = Native.loadLibrary(NAME, LibC.class);
+    LibC INSTANCE = Native.load(NAME, LibC.class);
 }

--- a/contrib/platform/src/com/sun/jna/platform/unix/X11.java
+++ b/contrib/platform/src/com/sun/jna/platform/unix/X11.java
@@ -289,7 +289,7 @@ public interface X11 extends Library {
 
     /** Definition (incomplete) of the Xext library. */
     interface Xext extends Library {
-        Xext INSTANCE = Native.loadLibrary("Xext", Xext.class);
+        Xext INSTANCE = Native.load("Xext", Xext.class);
         // Shape Kinds
         int ShapeBounding = 0;
         int ShapeClip = 1;
@@ -307,7 +307,7 @@ public interface X11 extends Library {
 
     /** Definition (incomplete) of the Xrender library. */
     interface Xrender extends Library {
-        Xrender INSTANCE = Native.loadLibrary("Xrender", Xrender.class);
+        Xrender INSTANCE = Native.load("Xrender", Xrender.class);
 
         class XRenderDirectFormat extends Structure {
             public static final List<String> FIELDS = createFieldsOrder("red", "redMask", "green", "greenMask", "blue", "blueMask", "alpha", "alphaMask");
@@ -355,7 +355,7 @@ public interface X11 extends Library {
     /** Definition of the Xevie library. */
     interface Xevie extends Library {
         /** Instance of Xevie. Note: This extension has been removed from xorg/xserver on Oct 22, 2008 because it is broken and maintainerless. */
-        Xevie INSTANCE = Native.loadLibrary("Xevie", Xevie.class);
+        Xevie INSTANCE = Native.load("Xevie", Xevie.class);
         int XEVIE_UNMODIFIED = 0;
         int XEVIE_MODIFIED   = 1;
         // Bool XevieQueryVersion (Display* display, int* major_version, int* minor_version);
@@ -372,7 +372,7 @@ public interface X11 extends Library {
 
     /** Definition of the XTest library. */
     interface XTest extends Library {
-        XTest INSTANCE = Native.loadLibrary("Xtst", XTest.class);///usr/lib/libxcb-xtest.so.0
+        XTest INSTANCE = Native.load("Xtst", XTest.class);///usr/lib/libxcb-xtest.so.0
         boolean XTestQueryExtension(Display display, IntByReference event_basep, IntByReference error_basep, IntByReference majorp, IntByReference minorp);
         boolean XTestCompareCursorWithWindow(Display display, Window window, Cursor cursor);
         boolean XTestCompareCurrentCursorWithWindow(Display display, Window window);
@@ -414,7 +414,7 @@ public interface X11 extends Library {
         }
     }
 
-    X11 INSTANCE = Native.loadLibrary("X11", X11.class);
+    X11 INSTANCE = Native.load("X11", X11.class);
 
     /*
       typedef struct {

--- a/contrib/platform/src/com/sun/jna/platform/unix/solaris/LibKstat.java
+++ b/contrib/platform/src/com/sun/jna/platform/unix/solaris/LibKstat.java
@@ -40,7 +40,7 @@ import com.sun.jna.Union;
  */
 public interface LibKstat extends Library {
 
-    LibKstat INSTANCE = Native.loadLibrary("kstat", LibKstat.class);
+    LibKstat INSTANCE = Native.load("kstat", LibKstat.class);
 
     /*
      * Kstat Data Types

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -67,7 +67,7 @@ import com.sun.jna.win32.W32APIOptions;
  * @author dblock[at]dblock.org
  */
 public interface Advapi32 extends StdCallLibrary {
-    Advapi32 INSTANCE = Native.loadLibrary("Advapi32", Advapi32.class, W32APIOptions.DEFAULT_OPTIONS);
+    Advapi32 INSTANCE = Native.load("Advapi32", Advapi32.class, W32APIOptions.DEFAULT_OPTIONS);
 
     int MAX_KEY_LENGTH = 255;
     int MAX_VALUE_NAME = 16383;

--- a/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
@@ -41,7 +41,7 @@ import com.sun.jna.platform.win32.WTypes.LPSTR;
  */
 public interface Crypt32 extends StdCallLibrary {
 
-	Crypt32 INSTANCE = Native.loadLibrary("Crypt32", Crypt32.class, W32APIOptions.DEFAULT_OPTIONS);
+	Crypt32 INSTANCE = Native.load("Crypt32", Crypt32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * The CryptProtectData function performs encryption on the data in a DATA_BLOB

--- a/contrib/platform/src/com/sun/jna/platform/win32/Cryptui.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Cryptui.java
@@ -37,7 +37,7 @@ import com.sun.jna.platform.win32.WinCrypt.*;
  */
 public interface Cryptui extends StdCallLibrary {
 
-	Cryptui INSTANCE = (Cryptui) Native.loadLibrary("Cryptui", Cryptui.class, W32APIOptions.UNICODE_OPTIONS);
+	Cryptui INSTANCE = (Cryptui) Native.load("Cryptui", Cryptui.class, W32APIOptions.UNICODE_OPTIONS);
 
 	/**
 	 * The CryptUIDlgSelectCertificateFromStore function displays a dialog box that

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
@@ -54,7 +54,7 @@ import com.sun.jna.win32.W32APITypeMapper;
  */
 public interface Ddeml extends StdCallLibrary {
 
-    Ddeml INSTANCE = Native.loadLibrary("user32", Ddeml.class, W32APIOptions.DEFAULT_OPTIONS);
+    Ddeml INSTANCE = Native.load("user32", Ddeml.class, W32APIOptions.DEFAULT_OPTIONS);
     
     public class HCONVLIST extends PointerType {
     };

--- a/contrib/platform/src/com/sun/jna/platform/win32/Dxva2.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Dxva2.java
@@ -66,7 +66,7 @@ public interface Dxva2 extends StdCallLibrary, PhysicalMonitorEnumerationAPI, Hi
     /**
      * The only instance of the library
      */
-    Dxva2 INSTANCE = Native.loadLibrary("Dxva2", Dxva2.class, DXVA_OPTIONS);
+    Dxva2 INSTANCE = Native.load("Dxva2", Dxva2.class, DXVA_OPTIONS);
 
 
     /******************************************************************************

--- a/contrib/platform/src/com/sun/jna/platform/win32/GDI32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/GDI32.java
@@ -50,7 +50,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface GDI32 extends StdCallLibrary {
 
-    GDI32 INSTANCE = Native.loadLibrary("gdi32", GDI32.class, W32APIOptions.DEFAULT_OPTIONS);
+    GDI32 INSTANCE = Native.load("gdi32", GDI32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * Used with BitBlt. Copies the source rectangle directly to the destination

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -39,7 +39,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
 
     /** The instance. */
-    Kernel32 INSTANCE = Native.loadLibrary("kernel32", Kernel32.class, W32APIOptions.DEFAULT_OPTIONS);
+    Kernel32 INSTANCE = Native.load("kernel32", Kernel32.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * <strong>LOAD_LIBRARY_AS_DATAFILE</strong> <br>

--- a/contrib/platform/src/com/sun/jna/platform/win32/Mpr.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Mpr.java
@@ -42,7 +42,7 @@ import com.sun.jna.win32.W32APIOptions;
 
 public interface Mpr extends StdCallLibrary {
 
-    Mpr INSTANCE = Native.loadLibrary("Mpr", Mpr.class, W32APIOptions.DEFAULT_OPTIONS);
+    Mpr INSTANCE = Native.load("Mpr", Mpr.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The WNetOpenEnum function starts an enumeration of network resources or

--- a/contrib/platform/src/com/sun/jna/platform/win32/Msi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Msi.java
@@ -32,7 +32,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Msi extends StdCallLibrary {
 
-    Msi INSTANCE = Native.loadLibrary("msi", Msi.class, W32APIOptions.DEFAULT_OPTIONS);
+    Msi INSTANCE = Native.load("msi", Msi.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The component being requested is disabled on the computer.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Netapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Netapi32.java
@@ -40,7 +40,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Netapi32 extends StdCallLibrary {
 	
-	Netapi32 INSTANCE = Native.loadLibrary("Netapi32", Netapi32.class, W32APIOptions.DEFAULT_OPTIONS);
+	Netapi32 INSTANCE = Native.load("Netapi32", Netapi32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * Retrieves join status information for the specified computer.

--- a/contrib/platform/src/com/sun/jna/platform/win32/NtDll.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/NtDll.java
@@ -37,7 +37,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface NtDll extends StdCallLibrary {
 	
-	NtDll INSTANCE = Native.loadLibrary("NtDll", NtDll.class, W32APIOptions.DEFAULT_OPTIONS);
+	NtDll INSTANCE = Native.load("NtDll", NtDll.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * The ZwQueryKey routine provides information about the class of a registry key, 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
@@ -44,7 +44,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface Ole32 extends StdCallLibrary {
 
     /** The instance. */
-    Ole32 INSTANCE = Native.loadLibrary("Ole32", Ole32.class, W32APIOptions.DEFAULT_OPTIONS);
+    Ole32 INSTANCE = Native.load("Ole32", Ole32.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Creates a GUID, a unique 128-bit integer used for CLSIDs and interface

--- a/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
@@ -56,7 +56,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface OleAuto extends StdCallLibrary {
 	/** The instance. */
-	OleAuto INSTANCE = Native.loadLibrary("OleAut32", OleAuto.class, W32APIOptions.DEFAULT_OPTIONS);
+	OleAuto INSTANCE = Native.load("OleAut32", OleAuto.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/* Flags for IDispatch::Invoke */
 	/** The Constant DISPATCH_METHOD. */

--- a/contrib/platform/src/com/sun/jna/platform/win32/OpenGL32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OpenGL32.java
@@ -32,7 +32,7 @@ import com.sun.jna.win32.StdCallLibrary;
  * opengl32.dll Interface.
  */
 public interface OpenGL32 extends StdCallLibrary {
-    OpenGL32 INSTANCE = Native.loadLibrary("opengl32", OpenGL32.class);
+    OpenGL32 INSTANCE = Native.load("opengl32", OpenGL32.class);
 
     /**
      * The glGetString function returns a string describing the current OpenGL connection.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Pdh.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Pdh.java
@@ -42,7 +42,7 @@ import com.sun.jna.win32.W32APIOptions;
  * @see <A HREF="https://msdn.microsoft.com/en-us/library/windows/desktop/aa373083(v=vs.85).aspx">Performance Counters</A>
  */
 public interface Pdh extends StdCallLibrary {
-    Pdh INSTANCE = Native.loadLibrary("Pdh", Pdh.class, W32APIOptions.DEFAULT_OPTIONS);
+    Pdh INSTANCE = Native.load("Pdh", Pdh.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /** Maximum counter name length. */
     int PDH_MAX_COUNTER_NAME = 1024;

--- a/contrib/platform/src/com/sun/jna/platform/win32/Psapi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Psapi.java
@@ -44,7 +44,7 @@ import com.sun.jna.win32.W32APIOptions;
  * @author Andreas "PAX" L&uuml;ck, onkelpax-git[at]yahoo.de
  */
 public interface Psapi extends StdCallLibrary {
-    Psapi INSTANCE = Native.loadLibrary("psapi", Psapi.class, W32APIOptions.DEFAULT_OPTIONS);
+    Psapi INSTANCE = Native.load("psapi", Psapi.class, W32APIOptions.DEFAULT_OPTIONS);
     
     /**
      * Retrieves the fully qualified path for the file containing the specified

--- a/contrib/platform/src/com/sun/jna/platform/win32/Rasapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Rasapi32.java
@@ -44,7 +44,7 @@ import com.sun.jna.win32.W32APIOptions;
  * Rasapi32.dll Interface.
  */
 public interface Rasapi32 extends StdCallLibrary {
-	Rasapi32 INSTANCE = Native.loadLibrary("Rasapi32", Rasapi32.class, W32APIOptions.DEFAULT_OPTIONS);
+	Rasapi32 INSTANCE = Native.load("Rasapi32", Rasapi32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	/**
 	 * The RasDial function establishes a RAS connection between a RAS client and a RAS server.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
@@ -42,7 +42,7 @@ import com.sun.jna.win32.W32APIOptions;
  * @author dblock[at]dblock.org
  */
 public interface Secur32 extends StdCallLibrary {
-    Secur32 INSTANCE = Native.loadLibrary("Secur32", Secur32.class, W32APIOptions.DEFAULT_OPTIONS);
+    Secur32 INSTANCE = Native.load("Secur32", Secur32.class, W32APIOptions.DEFAULT_OPTIONS);
 	
     /**
      * Specifies a format for a directory service object name.

--- a/contrib/platform/src/com/sun/jna/platform/win32/SetupApi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/SetupApi.java
@@ -40,7 +40,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface SetupApi extends StdCallLibrary {
 
-    SetupApi INSTANCE = Native.loadLibrary("setupapi", SetupApi.class, W32APIOptions.DEFAULT_OPTIONS);
+    SetupApi INSTANCE = Native.load("setupapi", SetupApi.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * The GUID_DEVINTERFACE_DISK device interface class is defined for hard disk storage devices.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shell32.java
@@ -42,7 +42,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Shell32 extends ShellAPI, StdCallLibrary {
     /** The instance **/
-    Shell32 INSTANCE = Native.loadLibrary("shell32", Shell32.class, W32APIOptions.DEFAULT_OPTIONS);
+    Shell32 INSTANCE = Native.load("shell32", Shell32.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * No dialog box confirming the deletion of the objects will be displayed.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Shlwapi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Shlwapi.java
@@ -35,7 +35,7 @@ import com.sun.jna.win32.W32APIOptions;
 import com.sun.jna.platform.win32.WinNT.*;
 
 public interface Shlwapi extends StdCallLibrary {
-    Shlwapi INSTANCE = Native.loadLibrary("Shlwapi", Shlwapi.class, W32APIOptions.DEFAULT_OPTIONS);
+    Shlwapi INSTANCE = Native.load("Shlwapi", Shlwapi.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Takes an STRRET structure returned by IShellFolder::GetDisplayNameOf and returns a pointer

--- a/contrib/platform/src/com/sun/jna/platform/win32/User32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/User32.java
@@ -45,7 +45,7 @@ import com.sun.jna.win32.W32APIOptions;
 public interface User32 extends StdCallLibrary, WinUser, WinNT {
 
     /** The instance. */
-    User32 INSTANCE = Native.loadLibrary("user32", User32.class, W32APIOptions.DEFAULT_OPTIONS);
+    User32 INSTANCE = Native.load("user32", User32.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Handle for message-only window.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Version.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Version.java
@@ -33,7 +33,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Version extends StdCallLibrary {
 
-    Version INSTANCE = Native.loadLibrary("version", Version.class, W32APIOptions.DEFAULT_OPTIONS);
+    Version INSTANCE = Native.load("version", Version.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Determines whether the operating system can retrieve version information for a specified file. If version

--- a/contrib/platform/src/com/sun/jna/platform/win32/Wevtapi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Wevtapi.java
@@ -38,7 +38,7 @@ import com.sun.jna.win32.W32APIOptions;
  * @author Minoru Sakamoto
  */
 public interface Wevtapi extends StdCallLibrary {
-    Wevtapi INSTANCE = (Wevtapi) Native.loadLibrary("wevtapi", Wevtapi.class, W32APIOptions.UNICODE_OPTIONS);
+    Wevtapi INSTANCE = (Wevtapi) Native.load("wevtapi", Wevtapi.class, W32APIOptions.UNICODE_OPTIONS);
 
     /**
      * Establishes a connection to a remote computer that you can use when calling the other Windows Event Log functions.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Wininet.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Wininet.java
@@ -41,7 +41,7 @@ public interface Wininet extends StdCallLibrary {
     /**
      * A usable instance of this interface
      */
-    Wininet INSTANCE = Native.loadLibrary("wininet", Wininet.class, W32APIOptions.DEFAULT_OPTIONS);
+    Wininet INSTANCE = Native.load("wininet", Wininet.class, W32APIOptions.DEFAULT_OPTIONS);
 
     /**
      * Normal cache entry; can be deleted to recover space for new entries.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winsock2.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winsock2.java
@@ -29,7 +29,7 @@ import com.sun.jna.win32.W32APIOptions;
 
 public interface Winsock2 extends Library {
 
-    Winsock2 INSTANCE = (Winsock2) Native.loadLibrary("ws2_32", Winsock2.class, W32APIOptions.ASCII_OPTIONS);
+    Winsock2 INSTANCE = (Winsock2) Native.load("ws2_32", Winsock2.class, W32APIOptions.ASCII_OPTIONS);
 
     /**
      * The gethostname function retrieves the standard host name for the local

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winspool.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winspool.java
@@ -47,7 +47,7 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface Winspool extends StdCallLibrary {
 
-    Winspool INSTANCE = Native.loadLibrary("Winspool.drv", Winspool.class, W32APIOptions.DEFAULT_OPTIONS);
+    Winspool INSTANCE = Native.load("Winspool.drv", Winspool.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	public static final int CCHDEVICENAME = 32;
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Wtsapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Wtsapi32.java
@@ -30,7 +30,7 @@ import com.sun.jna.win32.W32APIOptions;
 
 public interface Wtsapi32 extends StdCallLibrary {
 
-	Wtsapi32 INSTANCE = Native.loadLibrary("Wtsapi32", Wtsapi32.class, W32APIOptions.DEFAULT_OPTIONS);
+	Wtsapi32 INSTANCE = Native.load("Wtsapi32", Wtsapi32.class, W32APIOptions.DEFAULT_OPTIONS);
 
 	int NOTIFY_FOR_ALL_SESSIONS = 1;
 

--- a/contrib/platform/src/com/sun/jna/platform/wince/CoreDLL.java
+++ b/contrib/platform/src/com/sun/jna/platform/wince/CoreDLL.java
@@ -33,6 +33,6 @@ import com.sun.jna.win32.W32APIOptions;
  */
 public interface CoreDLL extends WinNT, Library {
 
-    CoreDLL INSTANCE = Native.loadLibrary("coredll", CoreDLL.class, W32APIOptions.UNICODE_OPTIONS);
+    CoreDLL INSTANCE = Native.load("coredll", CoreDLL.class, W32APIOptions.UNICODE_OPTIONS);
 
 }

--- a/src/com/sun/jna/FunctionMapper.java
+++ b/src/com/sun/jna/FunctionMapper.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Method;
 
 /** Provides mapping of Java method names to native function names.  
  * An instance of this interface may be provided to 
- * {@link Native#loadLibrary(String, Class, java.util.Map)} as an entry in
+ * {@link Native#load(String, Class, java.util.Map)} as an entry in
  * the options map with key {@link Library#OPTION_FUNCTION_MAPPER}.
  * <p>
  * There are several circumstances where this option might prove useful.

--- a/src/com/sun/jna/InvocationMapper.java
+++ b/src/com/sun/jna/InvocationMapper.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Method;
 
 /** Provide a method for overriding how a given function is invoked.
  * An instance of this interface may be provided to 
- * {@link Native#loadLibrary(String, Class, java.util.Map)} as an entry in
+ * {@link Native#load(String, Class, java.util.Map)} as an entry in
  * the options map with key {@link Library#OPTION_INVOCATION_MAPPER}.<p>
  * This is useful for implementing inlined functions, or functions which
  * are actually C preprocessor macros.  Given a native library and JNA

--- a/src/com/sun/jna/Library.java
+++ b/src/com/sun/jna/Library.java
@@ -33,14 +33,14 @@ import java.util.WeakHashMap;
  * Define an instance of your library like this:
  * <pre><code>
  * MyNativeLibrary INSTANCE = (MyNativeLibrary)
- *     Native.loadLibrary("mylib", MyNativeLibrary.class);
+ *     Native.load("mylib", MyNativeLibrary.class);
  * </code></pre>
  * <p>
  * By convention, method names are identical to the native names, although you
  * can map java names to different native names by providing a
  * {@link FunctionMapper} as a value for key {@link #OPTION_FUNCTION_MAPPER}
  * in the options map passed to the
- * {@link Native#loadLibrary(String, Class, Map)} call.
+ * {@link Native#load(String, Class, Map)} call.
  * <p>
  * Although the names for structures and structure fields may be chosen
  * arbitrarily, they should correspond as closely as possible to the native
@@ -56,10 +56,10 @@ import java.util.WeakHashMap;
  * <b>Optional fields</b><br>
  * Interface options will be automatically propagated to structures defined
  * within the library provided a call to
- * {@link Native#loadLibrary(String,Class,Map)} is made prior to instantiating
+ * {@link Native#load(String,Class,Map)} is made prior to instantiating
  * any of those structures.  One common way of ensuring this is to declare
  * an <b>INSTANCE</b> field in the interface which holds the
- * <code>loadLibrary</code> result.
+ * <code>load</code> result.
  * <p>
  * <b>OPTIONS</b> (an instance of {@link Map}),
  * <b>TYPE_MAPPER</b> (an instance of {@link TypeMapper}),

--- a/src/com/sun/jna/overview.html
+++ b/src/com/sun/jna/overview.html
@@ -91,7 +91,7 @@ following:<br>
 <blockquote><code><pre>
 // Alternative 1: interface-mapped class, dynamically load the C library
 public interface CLibrary extends Library {
-    CLibrary INSTANCE = (CLibrary)Native.loadLibrary("c", CLibrary.class);
+    CLibrary INSTANCE = (CLibrary)Native.load("c", CLibrary.class);
 }
 
 // Alternative 2: direct-mapped class (uses a concrete class rather than an
@@ -104,7 +104,7 @@ public class CLibrary {
 }
 </pre></code></blockquote>
 The <code>String</code> passed to the
-{@link com.sun.jna.Native#loadLibrary(String,Class)}
+{@link com.sun.jna.Native#load(String,Class)}
 (or {@link com.sun.jna.NativeLibrary#getInstance(String)}) method
 is the undecorated name of the shared library file.  Here are some examples of
 library name mappings.<p>  
@@ -153,7 +153,7 @@ public class CLibrary {
 }
 </pre></code></blockquote>
 
-If you prefer to rename the Java methods to conform to Java coding conventions, then you can provide an entry ({@link com.sun.jna.Library#OPTION_FUNCTION_MAPPER}/{@link com.sun.jna.FunctionMapper}) in the options {@link java.util.Map} passed to {@link com.sun.jna.Native#loadLibrary(String,Class,java.util.Map) Native.loadLibrary()} which maps the Java names to the native names.  While this keeps your Java code a little cleaner, the additional mapping of names may make it a little less obvious the native functions being called.<p>
+If you prefer to rename the Java methods to conform to Java coding conventions, then you can provide an entry ({@link com.sun.jna.Library#OPTION_FUNCTION_MAPPER}/{@link com.sun.jna.FunctionMapper}) in the options {@link java.util.Map} passed to {@link com.sun.jna.Native#load(String,Class,java.util.Map) Native.load()} which maps the Java names to the native names.  While this keeps your Java code a little cleaner, the additional mapping of names may make it a little less obvious the native functions being called.<p>
 An instance of the {@link com.sun.jna.Function} class is obtained through the {@link com.sun.jna.NativeLibrary} instance corresponding to the containing native library.  This {@link com.sun.jna.Function} instance handles argument marshalling and delegation to the native function. 
 
 <p>

--- a/test/com/sun/jna/AnnotatedLibraryTest.java
+++ b/test/com/sun/jna/AnnotatedLibraryTest.java
@@ -90,7 +90,7 @@ public class AnnotatedLibraryTest extends TestCase {
         });
 
         AnnotationTestLibrary lib =
-                Native.loadLibrary("testlib", AnnotationTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+                Native.load("testlib", AnnotationTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert integer return to boolean TRUE", true,
                      lib.returnInt32Argument(true));
         assertTrue("Failed to get annotation from ParameterContext", hasAnnotation[0]);

--- a/test/com/sun/jna/ArgumentsMarshalNullableTest.java
+++ b/test/com/sun/jna/ArgumentsMarshalNullableTest.java
@@ -179,7 +179,7 @@ public class ArgumentsMarshalNullableTest extends TestCase {
     TestLibrary lib;
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class,
+        lib = Native.load("testlib", TestLibrary.class,
                 Collections.singletonMap(Library.OPTION_TYPE_MAPPER, new TypeMapper() {
                     public FromNativeConverter getFromNativeConverter(Class<?> javaType) {
                         if(javaType == Int32.class) {

--- a/test/com/sun/jna/ArgumentsMarshalTest.java
+++ b/test/com/sun/jna/ArgumentsMarshalTest.java
@@ -158,7 +158,7 @@ public class ArgumentsMarshalTest extends TestCase {
     TestLibrary lib;
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.load("testlib", TestLibrary.class);
     }
 
     @Override
@@ -310,7 +310,7 @@ public class ArgumentsMarshalTest extends TestCase {
         }
     }
     protected NativeMappedLibrary loadNativeMappedLibrary() {
-        return Native.loadLibrary("testlib", NativeMappedLibrary.class);
+        return Native.load("testlib", NativeMappedLibrary.class);
     }
     public void testNativeMappedArgument() {
         NativeMappedLibrary lib = loadNativeMappedLibrary();

--- a/test/com/sun/jna/ArgumentsWrappersMarshalTest.java
+++ b/test/com/sun/jna/ArgumentsWrappersMarshalTest.java
@@ -47,7 +47,7 @@ public class ArgumentsWrappersMarshalTest extends TestCase {
     TestLibrary lib;
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.load("testlib", TestLibrary.class);
     }
 
     @Override

--- a/test/com/sun/jna/BufferArgumentsMarshalTest.java
+++ b/test/com/sun/jna/BufferArgumentsMarshalTest.java
@@ -60,7 +60,7 @@ public class BufferArgumentsMarshalTest extends TestCase {
     TestLibrary lib;
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.load("testlib", TestLibrary.class);
     }
 
     @Override

--- a/test/com/sun/jna/ByReferenceArgumentsTest.java
+++ b/test/com/sun/jna/ByReferenceArgumentsTest.java
@@ -54,7 +54,7 @@ public class ByReferenceArgumentsTest extends TestCase {
     TestLibrary lib;
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.load("testlib", TestLibrary.class);
     }
 
     @Override

--- a/test/com/sun/jna/CallbacksTest.java
+++ b/test/com/sun/jna/CallbacksTest.java
@@ -230,7 +230,7 @@ public class CallbacksTest extends TestCase implements Paths {
 
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.load("testlib", TestLibrary.class);
     }
 
     @Override
@@ -1108,7 +1108,7 @@ public class CallbacksTest extends TestCase implements Paths {
     }
 
     protected CallbackTestLibrary loadCallbackTestLibrary() {
-        return Native.loadLibrary("testlib", CallbackTestLibrary.class, CallbackTestLibrary._OPTIONS);
+        return Native.load("testlib", CallbackTestLibrary.class, CallbackTestLibrary._OPTIONS);
     }
 
     /** This test is here instead of NativeTest in order to facilitate running
@@ -1524,7 +1524,7 @@ public class CallbacksTest extends TestCase implements Paths {
     }
 
     public void testCallingConventionFromInterface() {
-        TaggedCallingConventionTestLibrary lib = Native.loadLibrary("testlib", TaggedCallingConventionTestLibrary.class);
+        TaggedCallingConventionTestLibrary lib = Native.load("testlib", TaggedCallingConventionTestLibrary.class);
         TaggedCallingConventionTestLibrary.TestCallbackTagged cb = new TaggedCallingConventionTestLibrary.TestCallbackTagged() {
             @Override
             public void invoke() { }
@@ -1548,7 +1548,7 @@ public class CallbacksTest extends TestCase implements Paths {
 
     public void testCallingConventionFromOptions() {
         OptionCallingConventionTestLibrary lib =
-                Native.loadLibrary("testlib", OptionCallingConventionTestLibrary.class, Collections.singletonMap(Library.OPTION_CALLING_CONVENTION, Function.ALT_CONVENTION));
+                Native.load("testlib", OptionCallingConventionTestLibrary.class, Collections.singletonMap(Library.OPTION_CALLING_CONVENTION, Function.ALT_CONVENTION));
         assertNotNull("Library not loaded", lib);
         OptionCallingConventionTestLibrary.TestCallback cb = new OptionCallingConventionTestLibrary.TestCallback() {
             @Override

--- a/test/com/sun/jna/LastErrorTest.java
+++ b/test/com/sun/jna/LastErrorTest.java
@@ -66,7 +66,7 @@ public class LastErrorTest extends TestCase {
     }
 
     public void testLastErrorPerThreadStorage() throws Exception {
-        final TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
+        final TestLibrary lib = Native.load("testlib", TestLibrary.class);
         final int NTHREADS = 100;
         final int[] errors = new int[NTHREADS];
         List<Thread> threads = new ArrayList<Thread>(NTHREADS);
@@ -101,7 +101,7 @@ public class LastErrorTest extends TestCase {
 
     private final int ERROR = Platform.isWindows() ? 1 : -1;
     public void testThrowLastError() {
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, OPTIONS);
+        TestLibrary lib = Native.load("testlib", TestLibrary.class, OPTIONS);
 
         lib.noThrowLastError(ERROR);
         assertEquals("Last error not preserved", ERROR, Native.getLastError());

--- a/test/com/sun/jna/LibraryLoadTest.java
+++ b/test/com/sun/jna/LibraryLoadTest.java
@@ -124,15 +124,15 @@ public class LibraryLoadTest extends TestCase implements Paths {
     }
 
     private Object load() {
-        return Native.loadLibrary(Platform.C_LIBRARY_NAME, CLibrary.class);
+        return Native.load(Platform.C_LIBRARY_NAME, CLibrary.class);
     }
 
     public void testLoadProcess() {
-        Native.loadLibrary(CLibrary.class);
+        Native.load(CLibrary.class);
     }
 
     public void testLoadProcessWithOptions() {
-        Native.loadLibrary(CLibrary.class, Collections.EMPTY_MAP);
+        Native.load(CLibrary.class, Collections.EMPTY_MAP);
     }
 
     public void testLoadCLibrary() {
@@ -266,7 +266,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
     // dependent libraries in the same directory as the original
     public void testLoadDependentLibraryWithAlteredSearchPath() {
         try {
-            TestLib2 lib = Native.loadLibrary("testlib2", TestLib2.class);
+            TestLib2 lib = Native.load("testlib2", TestLib2.class);
             lib.dependentReturnFalse();
         }
         catch(UnsatisfiedLinkError e) {
@@ -282,7 +282,7 @@ public class LibraryLoadTest extends TestCase implements Paths {
     public void testLoadProperCLibraryVersion() {
         if (Platform.isWindows()) return;
 
-        CLibrary lib = Native.loadLibrary("c", CLibrary.class);
+        CLibrary lib = Native.load("c", CLibrary.class);
         assertNotNull("Couldn't get current user",
                       lib.getpwuid(lib.geteuid()));
     }

--- a/test/com/sun/jna/NativeLibraryTest.java
+++ b/test/com/sun/jna/NativeLibraryTest.java
@@ -87,7 +87,7 @@ public class NativeLibraryTest extends TestCase {
         // occasionally get the same library handle back on subsequent dlopen
         Thread.sleep(2);
 
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.load("testlib", TestLibrary.class);
         assertEquals("Library should be newly loaded after explicit dispose of all native libraries",
                      1, lib.callCount());
         if (lib.callCount() <= 1) {
@@ -96,28 +96,28 @@ public class NativeLibraryTest extends TestCase {
     }
 
     public void testUseSingleLibraryInstance() {
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.load("testlib", TestLibrary.class);
         int count = lib.callCount();
-        TestLibrary lib2 = Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib2 = Native.load("testlib", TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Interfaces should share a library instance",
                      count + 1, count2);
     }
 
     public void testAliasLibraryFilename() {
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.load("testlib", TestLibrary.class);
         int count = lib.callCount();
         NativeLibrary nl = NativeLibrary.getInstance("testlib");
-        TestLibrary lib2 = Native.loadLibrary(nl.getFile().getName(), TestLibrary.class);
+        TestLibrary lib2 = Native.load(nl.getFile().getName(), TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Simple filename load not aliased", count + 1, count2);
     }
 
     public void testAliasLibraryFullPath() {
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib = Native.load("testlib", TestLibrary.class);
         int count = lib.callCount();
         NativeLibrary nl = NativeLibrary.getInstance("testlib");
-        TestLibrary lib2 = Native.loadLibrary(nl.getFile().getAbsolutePath(), TestLibrary.class);
+        TestLibrary lib2 = Native.load(nl.getFile().getAbsolutePath(), TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Full pathname load not aliased", count + 1, count2);
     }
@@ -135,9 +135,9 @@ public class NativeLibraryTest extends TestCase {
                 fail("Timed out waiting for library to be GC'd");
             }
         }
-        TestLibrary lib = Native.loadLibrary(file.getAbsolutePath(), TestLibrary.class);
+        TestLibrary lib = Native.load(file.getAbsolutePath(), TestLibrary.class);
         int count = lib.callCount();
-        TestLibrary lib2 = Native.loadLibrary("testlib", TestLibrary.class);
+        TestLibrary lib2 = Native.load("testlib", TestLibrary.class);
         int count2 = lib2.callCount();
         assertEquals("Simple library name not aliased", count + 1, count2);
     }
@@ -272,7 +272,7 @@ public class NativeLibraryTest extends TestCase {
     }
 
     public void testLoadLibraryWithOptions() {
-        Native.loadLibrary("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_OPEN_FLAGS, Integer.valueOf(-1)));
+        Native.load("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_OPEN_FLAGS, Integer.valueOf(-1)));
     }
 
     public interface Kernel32 {

--- a/test/com/sun/jna/NativeTest.java
+++ b/test/com/sun/jna/NativeTest.java
@@ -58,7 +58,7 @@ public class NativeTest extends TestCase {
             signature.append(')');
 
             try {
-                Method m = Native.class.getMethod("loadLibrary", paramTypes);
+                Method m = Native.class.getMethod("load", paramTypes);
                 Class<?> returnType = m.getReturnType();
                 signature.append(Native.getSignature(returnType));
                 assertSame("Mismatched return type for signature=" + signature, Library.class, returnType);
@@ -189,7 +189,7 @@ public class NativeTest extends TestCase {
     public void testSynchronizedAccess() throws Exception {
         final boolean[] lockHeld = { false };
         final NativeLibrary nlib = NativeLibrary.getInstance("testlib", TestLib.class.getClassLoader());
-        final TestLib lib = Native.loadLibrary("testlib", TestLib.class);
+        final TestLib lib = Native.load("testlib", TestLib.class);
         final TestLib synchlib = (TestLib)Native.synchronizedLibrary(lib);
         final TestLib.VoidCallback cb = new TestLib.VoidCallback() {
             @Override
@@ -258,7 +258,7 @@ public class NativeTest extends TestCase {
                 put(OPTION_STRING_ENCODING, TEST_ENCODING);
             }
         };
-        TestInterfaceWithInstance ARBITRARY = Native.loadLibrary("testlib", TestInterfaceWithInstance.class, TEST_OPTS);
+        TestInterfaceWithInstance ARBITRARY = Native.load("testlib", TestInterfaceWithInstance.class, TEST_OPTS);
         abstract class TestStructure extends Structure {}
     }
     public void testOptionsInferenceFromInstanceField() {
@@ -355,7 +355,7 @@ public class NativeTest extends TestCase {
     public interface OptionsSubclass extends OptionsBase, Library {
         TypeMapper _MAPPER = new DefaultTypeMapper();
         Map<String, ?> _OPTIONS = Collections.singletonMap(Library.OPTION_TYPE_MAPPER, _MAPPER);
-        OptionsSubclass INSTANCE = Native.loadLibrary("testlib", OptionsSubclass.class, _OPTIONS);
+        OptionsSubclass INSTANCE = Native.load("testlib", OptionsSubclass.class, _OPTIONS);
     }
     public void testStructureOptionsInference() {
         Structure s = new OptionsBase.TypeMappedStructure();

--- a/test/com/sun/jna/PerformanceTest.java
+++ b/test/com/sun/jna/PerformanceTest.java
@@ -130,7 +130,7 @@ public class PerformanceTest extends TestCase implements Paths {
         Pointer pb = Native.getDirectBufferPointer(b);
 
         String mname = Platform.MATH_LIBRARY_NAME;
-        MathInterface mlib = Native.loadLibrary(mname, MathInterface.class);
+        MathInterface mlib = Native.load(mname, MathInterface.class);
         Function f = NativeLibrary.getInstance(mname).getFunction("cos");
 
         ///////////////////////////////////////////
@@ -222,7 +222,7 @@ public class PerformanceTest extends TestCase implements Paths {
                 }
             });
         }
-        CInterface clib = Native.loadLibrary(cname, CInterface.class, options);
+        CInterface clib = Native.load(cname, CInterface.class, options);
 
         ///////////////////////////////////////////
         // getpid
@@ -477,7 +477,7 @@ public class PerformanceTest extends TestCase implements Paths {
 
         ///////////////////////////////////////////
         // Callbacks
-        TestInterface tlib = Native.loadLibrary("testlib", TestInterface.class);
+        TestInterface tlib = Native.load("testlib", TestInterface.class);
         start = System.currentTimeMillis();
         TestInterface.Int32Callback cb = new TestInterface.Int32Callback() {
             @Override

--- a/test/com/sun/jna/ReturnTypesTest.java
+++ b/test/com/sun/jna/ReturnTypesTest.java
@@ -138,10 +138,10 @@ public class ReturnTypesTest extends TestCase {
 
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
-        libSupportingObject = Native.loadLibrary("testlib", TestLibrary.class,
+        lib = Native.load("testlib", TestLibrary.class);
+        libSupportingObject = Native.load("testlib", TestLibrary.class,
                 Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, Boolean.TRUE));
-        libNativeMapped = Native.loadLibrary("testlib", NativeMappedLibrary.class);
+        libNativeMapped = Native.load("testlib", NativeMappedLibrary.class);
     }
 
     @Override

--- a/test/com/sun/jna/StructureByValueTest.java
+++ b/test/com/sun/jna/StructureByValueTest.java
@@ -59,7 +59,7 @@ public class StructureByValueTest extends TestCase {
 
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.load("testlib", TestLibrary.class);
     }
 
     @Override

--- a/test/com/sun/jna/StructureTest.java
+++ b/test/com/sun/jna/StructureTest.java
@@ -327,7 +327,7 @@ public class StructureTest extends TestCase {
     }
     private void testStructureSize(String prefix, int index) {
         try {
-            SizeTest lib = Native.loadLibrary("testlib", SizeTest.class);
+            SizeTest lib = Native.load("testlib", SizeTest.class);
             Class<? extends Structure> cls = (Class<? extends Structure>) Class.forName(getClass().getName() + "$" + prefix + "TestStructure" + index);
             Structure s = Structure.newInstance(cls);
             assertEquals("Incorrect size for structure " + index + "=>" + s.toString(true), lib.getStructureSize(index), s.size());
@@ -385,7 +385,7 @@ public class StructureTest extends TestCase {
         testAlignStruct("", index);
     }
     private void testAlignStruct(String prefix,int index) {
-        AlignmentTest lib = Native.loadLibrary("testlib", AlignmentTest.class);
+        AlignmentTest lib = Native.load("testlib", AlignmentTest.class);
         try {
             IntByReference offset = new IntByReference();
             LongByReference value = new LongByReference();

--- a/test/com/sun/jna/TypeMapperTest.java
+++ b/test/com/sun/jna/TypeMapperTest.java
@@ -55,7 +55,7 @@ public class TypeMapperTest extends TestCase {
                 return Integer.class;
             }
         });
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        TestLibrary lib = Native.load("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert Boolean argument to Int", MAGIC, lib.returnInt32Argument(true));
     }
     public void testStringToIntArgumentConversion() {
@@ -71,7 +71,7 @@ public class TypeMapperTest extends TestCase {
             }
         });
         final int MAGIC = 0x7BEDCF23;
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        TestLibrary lib = Native.load("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert String argument to Int", MAGIC,
                      lib.returnInt32Argument(Integer.toHexString(MAGIC)));
     }
@@ -88,7 +88,7 @@ public class TypeMapperTest extends TestCase {
             }
         });
         final String MAGIC = "magic" + UNICODE;
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        TestLibrary lib = Native.load("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert String argument to WString", new WString(MAGIC),
                      lib.returnWStringArgument(MAGIC));
     }
@@ -105,7 +105,7 @@ public class TypeMapperTest extends TestCase {
             }
         });
         final int MAGIC = 0x7BEDCF23;
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        TestLibrary lib = Native.load("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert String argument to Int", MAGIC, lib.returnInt32Argument(Integer.toHexString(MAGIC)));
     }
     public void testNumberToIntArgumentConversion() {
@@ -122,7 +122,7 @@ public class TypeMapperTest extends TestCase {
         });
 
         final int MAGIC = 0x7BEDCF23;
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        TestLibrary lib = Native.load("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert Double argument to Int", MAGIC,
                      lib.returnInt32Argument(Double.valueOf(MAGIC)));
     }
@@ -142,7 +142,7 @@ public class TypeMapperTest extends TestCase {
                 return WString.class;
             }
         });
-        TestLibrary lib = Native.loadLibrary("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        TestLibrary lib = Native.load("testlib", TestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert WString result to String", MAGIC, lib.returnWStringArgument(new WString(MAGIC)));
     }
 
@@ -172,7 +172,7 @@ public class TypeMapperTest extends TestCase {
                 return Integer.class;
             }
         });
-        BooleanTestLibrary lib = Native.loadLibrary("testlib", BooleanTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        BooleanTestLibrary lib = Native.load("testlib", BooleanTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Failed to convert integer return to boolean TRUE", true, lib.returnInt32Argument(true));
         assertEquals("Failed to convert integer return to boolean FALSE", false, lib.returnInt32Argument(false));
     }
@@ -206,7 +206,7 @@ public class TypeMapperTest extends TestCase {
             }
         };
         mapper.addTypeConverter(Boolean.class, converter);
-		Native.loadLibrary("testlib", StructureTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+		Native.load("testlib", StructureTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         StructureTestLibrary.TestStructure s = new StructureTestLibrary.TestStructure(mapper);
         assertEquals("Wrong native size", 4, s.size());
 
@@ -252,7 +252,7 @@ public class TypeMapperTest extends TestCase {
             }
         };
         mapper.addTypeConverter(Enumeration.class, converter);
-        EnumerationTestLibrary lib = Native.loadLibrary("testlib", EnumerationTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
+        EnumerationTestLibrary lib = Native.load("testlib", EnumerationTestLibrary.class, Collections.singletonMap(Library.OPTION_TYPE_MAPPER, mapper));
         assertEquals("Enumeration improperly converted", Enumeration.STATUS_1, lib.returnInt32Argument(Enumeration.STATUS_1));
     }
 

--- a/test/com/sun/jna/VarArgsTest.java
+++ b/test/com/sun/jna/VarArgsTest.java
@@ -48,7 +48,7 @@ public class VarArgsTest extends TestCase {
     TestLibrary lib;
     @Override
     protected void setUp() {
-        lib = Native.loadLibrary("testlib", TestLibrary.class);
+        lib = Native.load("testlib", TestLibrary.class);
     }
     @Override
     protected void tearDown() {

--- a/test/com/sun/jna/WebStartTest.java
+++ b/test/com/sun/jna/WebStartTest.java
@@ -121,19 +121,19 @@ public class WebStartTest extends TestCase implements Paths {
     public void testJNLPFindCustomLibrary() {
         assertNotNull("Custom library path not found by JNLP class loader",
                       Native.getWebStartLibraryPath("jnidispatch"));
-        Native.loadLibrary("jnidispatch", Dummy.class);
+        Native.load("jnidispatch", Dummy.class);
     }
 
     public void testJNLPFindProcessLibrary() {
         String libname = Platform.C_LIBRARY_NAME;
         assertNull("Process library path not expected to be found by JNLP class loader",
                    Native.getWebStartLibraryPath(libname));
-        Native.loadLibrary(libname, Dummy.class);
+        Native.load(libname, Dummy.class);
     }
 
     public void testJNLPFindLibraryFailure() {
         try {
-            Native.loadLibrary("xyzzy", Dummy.class);
+            Native.load("xyzzy", Dummy.class);
             fail("Missing native libraries should throw UnsatisfiedLinkError");
         }
         catch(UnsatisfiedLinkError e) {
@@ -305,7 +305,7 @@ public class WebStartTest extends TestCase implements Paths {
             }
             // NOTE: win64 only includes javaws in the system path
             if (Platform.isWindows()) {
-                FolderInfo info = Native.loadLibrary("shell32", FolderInfo.class);
+                FolderInfo info = Native.load("shell32", FolderInfo.class);
                 char[] buf = new char[FolderInfo.MAX_PATH];
                 //int result =
                         info.SHGetFolderPathW(null, FolderInfo.CSIDL_WINDOWS, null, 0, buf);
@@ -335,7 +335,7 @@ public class WebStartTest extends TestCase implements Paths {
             vendor = vendor.substring(0, vendor.indexOf(" "));
         }
         if (Platform.isWindows()) {
-            FolderInfo info = Native.loadLibrary("shell32", FolderInfo.class);
+            FolderInfo info = Native.load("shell32", FolderInfo.class);
             char[] buf = new char[FolderInfo.MAX_PATH];
             info.SHGetFolderPathW(null, FolderInfo.CSIDL_APPDATA,
                                   null, 0, buf);

--- a/test/com/sun/jna/win32/W32APIMapperTest.java
+++ b/test/com/sun/jna/win32/W32APIMapperTest.java
@@ -84,8 +84,8 @@ public class W32APIMapperTest extends TestCase {
 
     @Override
     protected void setUp() {
-        unicode = Native.loadLibrary("testlib", UnicodeLibrary.class, W32APIOptions.UNICODE_OPTIONS);
-        ascii = Native.loadLibrary("testlib", ASCIILibrary.class, W32APIOptions.ASCII_OPTIONS);
+        unicode = Native.load("testlib", UnicodeLibrary.class, W32APIOptions.UNICODE_OPTIONS);
+        ascii = Native.load("testlib", ASCIILibrary.class, W32APIOptions.ASCII_OPTIONS);
     }
 
     @Override

--- a/test/com/sun/jna/win32/W32StdCallTest.java
+++ b/test/com/sun/jna/win32/W32StdCallTest.java
@@ -91,7 +91,7 @@ public class W32StdCallTest extends TestCase {
 
     @Override
     protected void setUp() {
-        testlib = Native.loadLibrary("testlib", TestLibrary.class,
+        testlib = Native.load("testlib", TestLibrary.class,
                 Collections.singletonMap(Library.OPTION_FUNCTION_MAPPER, StdCallLibrary.FUNCTION_MAPPER));
     }
 

--- a/test/com/sun/jna/wince/CoreDLLTest.java
+++ b/test/com/sun/jna/wince/CoreDLLTest.java
@@ -35,7 +35,7 @@ public class CoreDLLTest extends TestCase {
     }
 
     public interface CoreDLL extends StdCallLibrary {
-        CoreDLL INSTANCE = Native.loadLibrary("coredll", CoreDLL.class, W32APIOptions.UNICODE_OPTIONS);
+        CoreDLL INSTANCE = Native.load("coredll", CoreDLL.class, W32APIOptions.UNICODE_OPTIONS);
 
         public static class SECURITY_ATTRIBUTES extends Structure {
             public static final List<String> FIELDS = createFieldsOrder("dwLength", "lpSecurityDescriptor", "bInheritHandle");

--- a/www/CallbacksAndClosures.md
+++ b/www/CallbacksAndClosures.md
@@ -23,7 +23,7 @@ public interface CLibrary extends Library {
     int raise(int sig);
 }
 /* ... */
-CLibrary lib = (CLibrary)Native.loadLibrary("c", CLibrary.class);
+CLibrary lib = (CLibrary)Native.load("c", CLibrary.class);
 // WARNING: you must keep a reference to the callback object
 // until you deregister the callback; if the callback object
 // is garbage-collected, the native callback invocation will

--- a/www/Contributing.md
+++ b/www/Contributing.md
@@ -94,7 +94,7 @@ DLL functions are mapped into Unicode interfaces of the same name, like this
    * @author dblock[at]dblock.org
    */
   public interface Advapi32 extends StdCallLibrary {
-    Advapi32 INSTANCE = (Advapi32) Native.loadLibrary("Advapi32", 
+    Advapi32 INSTANCE = (Advapi32) Native.load("Advapi32", 
       Advapi32.class, W32APIOptions.UNICODE_OPTIONS);
 
     // function definitions go here

--- a/www/CustomMappings.md
+++ b/www/CustomMappings.md
@@ -1,9 +1,9 @@
 Customized Mapping from Java to Native
 ======================================
 
-The `TypeMapper` class and related interfaces provide for converting any Java type used as an argument, return value, or structure member to be converted to or from a native type. The example Win32 API interfaces use a type mapper to convert Java boolean into the Win32 BOOL type. A TypeMapper instance is passed as the value for the `TYPE_MAPPER` key in the options map passed to `Native.loadLibrary`.
+The `TypeMapper` class and related interfaces provide for converting any Java type used as an argument, return value, or structure member to be converted to or from a native type. The example Win32 API interfaces use a type mapper to convert Java boolean into the Win32 BOOL type. A TypeMapper instance is passed as the value for the `TYPE_MAPPER` key in the options map passed to `Native.load`.
 
 Alternatively, user-defined types may implement the `NativeMapped` interface, which determines conversion to and from native types on a class-by-class basis.
 
-You may also customize the mapping of Java method names to the corresponding native function name. The `StdCallFunctionMapper` is one implementation which automatically generates stdcall-decorated function names from a Java interface method signature. The mapper should be passed as the value for the `OPTION_FUNCTION_MAPPER` key in the options map passed to the `Native.loadLibrary` call.
+You may also customize the mapping of Java method names to the corresponding native function name. The `StdCallFunctionMapper` is one implementation which automatically generates stdcall-decorated function names from a Java interface method signature. The mapper should be passed as the value for the `OPTION_FUNCTION_MAPPER` key in the options map passed to the `Native.load` call.
 

--- a/www/DirectMapping.md
+++ b/www/DirectMapping.md
@@ -6,7 +6,7 @@ approaching that of custom JNI. Method signatures are the same as they would be
 in a JNA interface mapping, but they can be any static or object methods. You 
 only need register them within the static initializer of the defining class,
 as in the example below. The `Native.register()` method takes the name of your 
-native library, the same as `Native.loadLibrary()` would.
+native library, the same as `Native.load()` would.
 
     import com.sun.jna.*;
 
@@ -41,7 +41,7 @@ Methods may be either static or member methods; the class or object is ignored o
 You can easily convert from interface mapping to direct mapping by creating a 
 direct mapping class which implements your library interface, with all methods 
 defined as native methods. Then your library instance variable can be assigned 
-an instance of this new class instead of the object returned by `Native.loadLibrary()`.
+an instance of this new class instead of the object returned by `Native.load()`.
 
 If you are using a profiler which rewrites native methods, you may need to
 set the system property `jna.profiler.prefix` to the prefix used by the

--- a/www/FrequentlyAskedQuestions.md
+++ b/www/FrequentlyAskedQuestions.md
@@ -11,14 +11,14 @@ No, it's not, it's just waiting for you to add it :)
 
     public interface MyUser32 extends User32 {
         // DEFAULT_OPTIONS is critical for W32 API functions to simplify ASCII/UNICODE details
-        MyUser32 INSTANCE = (MyUser32)Native.loadLibrary("user32", W32APIOptions.DEFAULT_OPTIONS);
+        MyUser32 INSTANCE = (MyUser32)Native.load("user32", W32APIOptions.DEFAULT_OPTIONS);
         void ThatFunctionYouReallyNeed();
     }
     
 That's all it takes.  If you'd like to submit the change back to JNA, make sure you provide a change log entry and corresponding test that invokes the function to prove that the mapping works.  We don't really care what the API actually does, the call can be a very minimal invocation, but should ensure all the parameters are correctly passed and that you get a reasonable return value.
 
-Calling `Native.loadLibrary()` causes an UnsatisfiedLinkError
--------------------------------------------------------------
+Calling `Native.load()` causes an UnsatisfiedLinkError
+------------------------------------------------------
 
 Set the system property `jna.debug_load=true`, and JNA will print its library 
 search steps to the console. `jna.debug_load.jna` will trace the search for 

--- a/www/FunctionalDescription.md
+++ b/www/FunctionalDescription.md
@@ -16,7 +16,7 @@ return value.
 
 Interface Mapping
 -----------------
-When you instantiate a native library interface via `Native.loadLibrary()`,
+When you instantiate a native library interface via `Native.load()`,
 JNA creates a proxy which routes all method invocations through a single
 `invoke` function in `Library.Handler`.  This method looks up an appropriate
 `Function` object which represents a function exported by the native library.

--- a/www/GettingStarted.md
+++ b/www/GettingStarted.md
@@ -21,7 +21,7 @@ public class HelloWorld {
 
     public interface CLibrary extends Library {
         CLibrary INSTANCE = (CLibrary)
-            Native.loadLibrary((Platform.isWindows() ? "msvcrt" : "c"),
+            Native.load((Platform.isWindows() ? "msvcrt" : "c"),
                                 CLibrary.class);
 
         void printf(String format, Object... args);
@@ -60,17 +60,17 @@ public interface Kernel32 extends StdCallLibrary {
 }
 ```
 
-Within this interface, define an instance of the native library using the Native.loadLibrary(Class) method, providing the native library interface you defined previously.
+Within this interface, define an instance of the native library using the Native.load(Class) method, providing the native library interface you defined previously.
 ``` java
 Kernel32 INSTANCE = (Kernel32)
-    Native.loadLibrary("kernel32", Kernel32.class);
+    Native.load("kernel32", Kernel32.class);
 // Optional: wraps every call to the native library in a
 // synchronized block, limiting native calls to one at a time
 Kernel32 SYNC_INSTANCE = (Kernel32)
     Native.synchronizedLibrary(INSTANCE);
 ```
 
-The `INSTANCE` variable is for convenient reuse of a single instance of the library. Alternatively, you can load the library into a local variable so that it will be available for garbage collection when it goes out of scope. A Map of options may be provided as the third argument to loadLibrary to customize the library behavior; some of these options are explained in more detail below. The `SYNC_INSTANCE` is also optional; use it if you need to ensure that your native library has only one call to it at a time.
+The `INSTANCE` variable is for convenient reuse of a single instance of the library. Alternatively, you can load the library into a local variable so that it will be available for garbage collection when it goes out of scope. A Map of options may be provided as the third argument to load to customize the library behavior; some of these options are explained in more detail below. The `SYNC_INSTANCE` is also optional; use it if you need to ensure that your native library has only one call to it at a time.
 
 Declare methods that mirror the functions in the target library by defining Java methods with the same name and argument types as the native function (refer to the basic mappings below or the detailed table of type mappings). You may also need to declare native structures to pass to your native functions. To do this, create a class within the interface definition that extends Structure and add public fields (which may include arrays or nested structures). 
 ``` java


### PR DESCRIPTION
It is expected, that libraries move to JNA 5.X at different rates, so
it is important to be able to create bindings compatible with 4.X and
5.X.