### PR TITLE
Check attach result before using resulting JNIEnv pointer in callback code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ Bug Fixes
       <li>The resulting `sunos-x86.jar` is copied back to the original build system to `lib/native/sunos-x86.jar`</li>
   </ol> - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#958](https://github.com/java-native-access/jna/issues/958): Update for PR 863: Old toolchains produce binaries without hard-/softfloat markers. Rasbian is missinng the markers and the oracle JDK is also affected. For hardfloat detection now also the Arm EABI section is also considered - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#974](https://github.com/java-native-access/jna/issues/974): If the callback code failed to attach to the JVM, this lead to a segfault. The success of attaching to the JVM was checked to late and an invalid `JNIEnv` pointer was used to access the JVM - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Breaking Changes
 ----------------

--- a/build.xml
+++ b/build.xml
@@ -69,7 +69,7 @@
   <!-- jnidispatch library release version -->
   <property name="jni.major" value="5"/>
   <property name="jni.minor" value="2"/>
-  <property name="jni.revision" value="1"/>
+  <property name="jni.revision" value="2"/>
   <property name="jni.build" value="0"/> <!--${build.number}-->
   <property name="jni.version" value="${jni.major}.${jni.minor}.${jni.revision}"/>
   <property name="jni.md5" value="74e8f8e397c43487738c5c1f1363498b"/>

--- a/test/com/sun/jna/DirectCallbacksTest.java
+++ b/test/com/sun/jna/DirectCallbacksTest.java
@@ -73,7 +73,7 @@ public class DirectCallbacksTest extends CallbacksTest {
         @Override
         public native void callVoidCallback(VoidCallback c);
         @Override
-        public native void callVoidCallbackThreaded(VoidCallback c, int count, int ms, String name);
+        public native void callVoidCallbackThreaded(VoidCallback c, int count, int ms, String name, int stacksize);
 
         @Override
         public native int callInt32Callback(CustomCallback cb, int arg1, int arg2);


### PR DESCRIPTION
The success of attaching to the JVM was checked to late in callback.c.
After trying to attach the native thread to the JVM, the JNIEnv pointer
is passed to `get_thread_storage`, which uses it to access the JVM.

At this point it is assumed, that the JNIEnv pointer is valid and can
be used. This is not correct, as the attach can fail and if so the
JNIEnv pointer is not valid.

The pointer is later validated, but to late, so a SEGFAULT occurs.

The result check needs to be moved directly after the attachment
code, to be effective.

This is for review, it is planed to backport this to 4.5.X and rebuild the
binaries afterwards on both branches.