### PR TITLE
Add package versions to OSGi metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Release 5.0.0 (Next release)
 
 Features
 --------
+* [#975](https://github.com/java-native-access/jna/pull/982): Add package versions to OSGi metadata. - [@io7m](https://github.com/io7m).
 * [#915](https://github.com/java-native-access/jna/pull/915): Adding interfaces to call to Cryptui and Crypt32 windows libraries and adding related structures to Wincrypt. - [@rosh89](https://github.com/rosh89).
 * [#903](https://github.com/java-native-access/jna/pull/903): Carry `HRESULT` in `c.s.j.p.win32.COM.COMException`, introduce `c.s.j.p.win32.COM.COMInvokeException` as subclass of `COMException` for exception as the result of a `IDispatch#Invoke`. The `EXECPINFO` is unwrapped into fields in the `COMInvokeException` and correctly freed. - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#822](https://github.com/java-native-access/jna/issues/822): `Native#loadLibrary` requires that the interface class passed in is an instance of Library. The runtime check can be enhanced by using a constraint generic. This breaks binary compatibility (see notes below) - [@d-noll](https://github.com/d-noll).<br /><br />In a followup, the original `loadLibrary` methods were deprecated and `Native#load` methods were introduced, that hold the new generic definitions. So this change is now binary compatible.

--- a/build.xml
+++ b/build.xml
@@ -402,7 +402,7 @@
         <attribute name="Bundle-RequiredExecutionEnvironment" value="J2SE-1.4"/>
         <attribute name="Bundle-Vendor" value="${vendor}"/>
         <attribute name="Bundle-ActivationPolicy" value="lazy"/>
-        <attribute name="Export-Package" value="com.sun.jna,com.sun.jna.ptr,com.sun.jna.win32"/>
+        <attribute name="Export-Package" value="com.sun.jna;version=${jna.major}.${jna.minor}.${jna.revision}, com.sun.jna.ptr;version=${jna.major}.${jna.minor}.${jna.revision}, com.sun.jna.win32;version=${jna.major}.${jna.minor}.${jna.revision}"/>
         <!-- Note that no terminal "*" is included in this list,
              which will force failure on unsupported platforms.
           -->

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -124,15 +124,15 @@
             <attribute name="Require-Bundle" value="com.sun.jna;bundle-version=&quot;${osgi.version}&quot;"/>
             <attribute name="Export-Package"
                    value="
-com.sun.jna.platform,
-com.sun.jna.platform.dnd,
-com.sun.jna.platform.mac,
-com.sun.jna.platform.unix,
-com.sun.jna.platform.win32,
-com.sun.jna.platform.win32.COM,
-com.sun.jna.platform.win32.COM.tlb,
-com.sun.jna.platform.win32.COM.tlb.imp,
-com.sun.jna.platform.wince
+com.sun.jna.platform;version=${osgi.version},
+com.sun.jna.platform.dnd;version=${osgi.version},
+com.sun.jna.platform.mac;version=${osgi.version},
+com.sun.jna.platform.unix;version=${osgi.version},
+com.sun.jna.platform.win32;version=${osgi.version},
+com.sun.jna.platform.win32.COM;version=${osgi.version},
+com.sun.jna.platform.win32.COM.tlb;version=${osgi.version},
+com.sun.jna.platform.win32.COM.tlb.imp;version=${osgi.version},
+com.sun.jna.platform.wince;version=${osgi.version}
 "/>
         </manifest>
     </target>


### PR DESCRIPTION
This adds version declarations to each exported package in the
OSGi metadata. This allows users to specify that they want a
specific version (or range of versions) of JNA in their OSGi
applications/libraries.

Fix #975