### PR TITLE
Fix bug with recursive IP_ADDR_STRING ByReference

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/IPHlpAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/IPHlpAPI.java
@@ -174,18 +174,12 @@ public interface IPHlpAPI extends Library {
      */
     @FieldOrder({ "Next", "IpAddress", "IpMask", "Context" })
     class IP_ADDR_STRING extends Structure {
-        public Pointer Next; // IP_ADDR_STRING
+        public IP_ADDR_STRING.ByReference Next;
         public IP_ADDRESS_STRING IpAddress;
         public IP_ADDRESS_STRING IpMask;
         public int Context;
 
-        public IP_ADDR_STRING(Pointer p) {
-            super(p);
-            read();
-        }
-
-        public IP_ADDR_STRING() {
-            super();
+        public static class ByReference extends IP_ADDR_STRING implements Structure.ByReference {
         }
     }
 
@@ -201,7 +195,7 @@ public interface IPHlpAPI extends Library {
     class FIXED_INFO extends Structure {
         public byte[] HostName = new byte[MAX_HOSTNAME_LEN + 4];
         public byte[] DomainName = new byte[MAX_DOMAIN_NAME_LEN + 4];
-        public Pointer CurrentDnsServer; // IP_ADDR_STRING
+        public IP_ADDR_STRING.ByReference CurrentDnsServer; // IP_ADDR_STRING
         public IP_ADDR_STRING DnsServerList;
         public int NodeType;
         public byte[] ScopeId = new byte[MAX_SCOPE_ID_LEN + 4];

--- a/contrib/platform/src/com/sun/jna/platform/win32/IPHlpAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/IPHlpAPI.java
@@ -195,7 +195,7 @@ public interface IPHlpAPI extends Library {
     class FIXED_INFO extends Structure {
         public byte[] HostName = new byte[MAX_HOSTNAME_LEN + 4];
         public byte[] DomainName = new byte[MAX_DOMAIN_NAME_LEN + 4];
-        public IP_ADDR_STRING.ByReference CurrentDnsServer; // IP_ADDR_STRING
+        public IP_ADDR_STRING.ByReference CurrentDnsServer;
         public IP_ADDR_STRING DnsServerList;
         public int NodeType;
         public byte[] ScopeId = new byte[MAX_SCOPE_ID_LEN + 4];
@@ -273,6 +273,6 @@ public interface IPHlpAPI extends Library {
      *            ERROR_BUFFER_OVERFLOW.
      * @return If the function succeeds, the return value is ERROR_SUCCESS.
      */
-    int GetNetworkParams(FIXED_INFO pFixedInfo, IntByReference pOutBufLen);
+    int GetNetworkParams(Pointer pFixedInfo, IntByReference pOutBufLen);
 }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/IPHlpAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/IPHlpAPI.java
@@ -174,12 +174,18 @@ public interface IPHlpAPI extends Library {
      */
     @FieldOrder({ "Next", "IpAddress", "IpMask", "Context" })
     class IP_ADDR_STRING extends Structure {
-        public IP_ADDR_STRING.ByReference Next;
+        public Pointer Next; // IP_ADDR_STRING
         public IP_ADDRESS_STRING IpAddress;
         public IP_ADDRESS_STRING IpMask;
         public int Context;
 
-        public static class ByReference extends IP_ADDR_STRING implements Structure.ByReference {
+        public IP_ADDR_STRING(Pointer p) {
+            super(p);
+            read();
+        }
+
+        public IP_ADDR_STRING() {
+            super();
         }
     }
 
@@ -195,7 +201,7 @@ public interface IPHlpAPI extends Library {
     class FIXED_INFO extends Structure {
         public byte[] HostName = new byte[MAX_HOSTNAME_LEN + 4];
         public byte[] DomainName = new byte[MAX_DOMAIN_NAME_LEN + 4];
-        public IP_ADDR_STRING.ByReference CurrentDnsServer; // IP_ADDR_STRING
+        public Pointer CurrentDnsServer; // IP_ADDR_STRING
         public IP_ADDR_STRING DnsServerList;
         public int NodeType;
         public byte[] ScopeId = new byte[MAX_SCOPE_ID_LEN + 4];

--- a/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 import com.sun.jna.Memory;
 import com.sun.jna.platform.win32.IPHlpAPI.FIXED_INFO;
-import com.sun.jna.platform.win32.IPHlpAPI.IP_ADDR_STRING;
 import com.sun.jna.platform.win32.IPHlpAPI.MIB_IFROW;
 import com.sun.jna.platform.win32.IPHlpAPI.MIB_IF_ROW2;
 import com.sun.jna.ptr.IntByReference;
@@ -121,7 +120,7 @@ public class IPHlpAPITest {
         assertEquals(WinError.ERROR_SUCCESS, IPHlpAPI.INSTANCE.GetNetworkParams(buffer, bufferSize));
 
         // Check all DNS servers are valid IPs
-        IP_ADDR_STRING dns = buffer.DnsServerList;
+        IPHlpAPI.IP_ADDR_STRING dns = buffer.DnsServerList;
         while (dns != null) {
             // Start with 16-char byte array
             String addr = new String(dns.IpAddress.String);
@@ -132,7 +131,7 @@ public class IPHlpAPITest {
             }
             // addr is now a dotted-notation IP string. Test valid
             assertTrue(ValidIP.matcher(addr).matches());
-            dns = dns.Next == null ? null : new IP_ADDR_STRING(dns.Next);
+            dns = dns.Next;
         }
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
@@ -116,11 +116,12 @@ public class IPHlpAPITest {
 
         IntByReference bufferSize = new IntByReference();
         assertEquals(WinError.ERROR_BUFFER_OVERFLOW, IPHlpAPI.INSTANCE.GetNetworkParams(null, bufferSize));
-        FIXED_INFO buffer = new FIXED_INFO(new Memory(bufferSize.getValue()));
+        Memory buffer = new Memory(bufferSize.getValue());
         assertEquals(WinError.ERROR_SUCCESS, IPHlpAPI.INSTANCE.GetNetworkParams(buffer, bufferSize));
+        FIXED_INFO fixedInfo = new FIXED_INFO(buffer);
 
         // Check all DNS servers are valid IPs
-        IPHlpAPI.IP_ADDR_STRING dns = buffer.DnsServerList;
+        IPHlpAPI.IP_ADDR_STRING dns = fixedInfo.DnsServerList;
         while (dns != null) {
             // Start with 16-char byte array
             String addr = new String(dns.IpAddress.String);

--- a/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import com.sun.jna.Memory;
 import com.sun.jna.platform.win32.IPHlpAPI.FIXED_INFO;
+import com.sun.jna.platform.win32.IPHlpAPI.IP_ADDR_STRING;
 import com.sun.jna.platform.win32.IPHlpAPI.MIB_IFROW;
 import com.sun.jna.platform.win32.IPHlpAPI.MIB_IF_ROW2;
 import com.sun.jna.ptr.IntByReference;
@@ -120,7 +121,7 @@ public class IPHlpAPITest {
         assertEquals(WinError.ERROR_SUCCESS, IPHlpAPI.INSTANCE.GetNetworkParams(buffer, bufferSize));
 
         // Check all DNS servers are valid IPs
-        IPHlpAPI.IP_ADDR_STRING dns = buffer.DnsServerList;
+        IP_ADDR_STRING dns = buffer.DnsServerList;
         while (dns != null) {
             // Start with 16-char byte array
             String addr = new String(dns.IpAddress.String);
@@ -131,7 +132,7 @@ public class IPHlpAPITest {
             }
             // addr is now a dotted-notation IP string. Test valid
             assertTrue(ValidIP.matcher(addr).matches());
-            dns = dns.Next;
+            dns = dns.Next == null ? null : new IP_ADDR_STRING(dns.Next);
         }
     }
 }


### PR DESCRIPTION
While the `GetNetworkParams` testcase in #983 worked fine on my Windows7 machine, it created Invalid Access Errors on Win 10, probably related to a combination recursive pre-reading of ByReference structures in the constructor, and local thread caching.  See JNA mailing list thread for details.  Bottom line: the `IP_ADDR_STRING` linked list needs to be mapped as a `Pointer` and the linked list traversed manually.