### PR TITLE
Enhance stability of tests and prepare for inclusion of appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: java
 
 install:
-  - '[ "${TRAVIS_OS_NAME}" = "linux" ] && wget http://apache.mirror.iphh.net/ant/binaries/apache-ant-1.9.12-bin.tar.gz && tar xzf apache-ant-1.9.12-bin.tar.gz && sudo mv apache-ant-1.9.12 /usr/local/apache-ant-1.9.12 && sudo rm -f /usr/local/ant && sudo ln -s /usr/local/apache-ant-1.9.12 /usr/local/ant && sudo ln -s /usr/local/apache-ant-1.9.12/bin/ant /usr/local/bin/ant || true'
+  - '[ "${TRAVIS_OS_NAME}" = "linux" ] && wget http://apache.mirror.iphh.net/ant/binaries/apache-ant-1.9.13-bin.tar.gz && tar xzf apache-ant-1.9.13-bin.tar.gz && sudo mv apache-ant-1.9.13 /usr/local/apache-ant-1.9.13 && sudo rm -f /usr/local/ant && sudo ln -s /usr/local/apache-ant-1.9.13 /usr/local/ant && sudo ln -s /usr/local/apache-ant-1.9.13/bin/ant /usr/local/bin/ant || true'
   - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew update || true'
   - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew uninstall libtool && brew install libtool || true'
   - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew install ant || true'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+image: Visual Studio 2015
+
+install:
+- cmd: set PATH=%PATH%;c:\cygwin64;c:\cygwin64\bin
+- cmd: choco install -y -f -i ant
+- cmd: choco install -y -f -i cygwin
+- cmd: C:\cygwin64\cygwinsetup.exe --root C:\cygwin64 --local-package-dir C:\cygwin64\packages --quiet-mode --no-desktop --no-startmenu --packages git,make,automake,automake1.15,libtool,mingw64-x86_64-gcc-g++,mingw64-x86_64-gcc-core,gcc-g++
+- cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+- cmd: set PATH=%JAVA_HOME%\bin;%PATH%
+- cmd: set PATH=c:\cygwin64;c:\cygwin64\bin;%PATH%
+- cmd: '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64'
+
+build_script:
+- cmd: ant dist
+
+test_script:
+- cmd: ant test
+- cmd: ant test-platform

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,5 +15,6 @@ build_script:
 - cmd: ant dist
 
 test_script:
+- cmd: net start spooler
 - cmd: ant test
 - cmd: ant test-platform

--- a/contrib/platform/src/com/sun/jna/platform/win32/Pdh.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Pdh.java
@@ -23,8 +23,6 @@
  */
 package com.sun.jna.platform.win32;
 
-import java.util.List;
-
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -54,6 +52,12 @@ public interface Pdh extends StdCallLibrary {
     int PDH_MAX_COUNTER_PATH = 2048;
     /** Maximum full counter log name length. */
     int PDH_MAX_DATASOURCE_PATH = 1024;
+
+    int PDH_MORE_DATA = 0x800007D2;
+    int PDH_INVALID_ARGUMENT =  0xC0000BBD;
+    int PDH_MEMORY_ALLOCATION_FAILURE = 0xC0000BBB;
+    int PDH_CSTATUS_NO_MACHINE = 0x800007D0;
+    int PDH_CSTATUS_NO_OBJECT = 0xC0000BB8;
 
     /* TODO
      * LPVOID CALLBACK AllocateMemory(_In_ SIZE_T AllocSize,_In_ LPVOID pContext)

--- a/contrib/platform/src/com/sun/jna/platform/win32/PdhUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/PdhUtil.java
@@ -30,6 +30,7 @@ import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.DWORDByReference;
+import java.util.Collections;
 
 /**
  * Pdh utility API.
@@ -61,16 +62,23 @@ public abstract class PdhUtil {
     public static String PdhLookupPerfNameByIndex(String szMachineName, int dwNameIndex) {
         // Call once to get required buffer size
         DWORDByReference pcchNameBufferSize = new DWORDByReference(new DWORD(0));
-        Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, null, pcchNameBufferSize);
-
+        int result = Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, null, pcchNameBufferSize);
+        if(result != WinError.ERROR_SUCCESS && result != Pdh.PDH_MORE_DATA) {
+            throw new PdhException(result);
+        }
+        
         // Can't allocate 0 memory
         if (pcchNameBufferSize.getValue().intValue() < 1) {
             return "";
         }
         // Allocate buffer and call again
         Memory mem = new Memory(pcchNameBufferSize.getValue().intValue() * CHAR_TO_BYTES);
-        Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, mem, pcchNameBufferSize);
+        result = Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, mem, pcchNameBufferSize);
 
+        if(result != WinError.ERROR_SUCCESS) {
+            throw new PdhException(result);
+        }
+        
         // Convert buffer to Java String
         if (CHAR_TO_BYTES == 1) {
             return mem.getString(0);
@@ -113,9 +121,8 @@ public abstract class PdhUtil {
 
     /**
      * Utility method to call Pdh's PdhEnumObjectItems that allocates the
-     * required memory for the mszCounterList parameter based on the type
-     * mapping used, calls to PdhEnumObjectItems, and returns the received lists
-     * of strings.
+     * required memory for the lists parameters based on the type mapping used,
+     * calls to PdhEnumObjectItems, and returns the received lists of strings.
      * 
      * @param szDataSource
      *            String that specifies the name of the log file used to
@@ -137,113 +144,135 @@ public abstract class PdhUtil {
      *            returned.
      * @return Returns a List of Strings of the counters for the object.
      */
-    public static List<String> PdhEnumObjectItemCounters(String szDataSource, String szMachineName, String szObjectName,
+    public static PdhEnumObjectItems PdhEnumObjectItems(String szDataSource, String szMachineName, String szObjectName,
             int dwDetailLevel) {
         List<String> counters = new ArrayList<String>();
-
-        // Call once to get string lengths
-        DWORDByReference pcchCounterListLength = new DWORDByReference(new DWORD(0));
-        DWORDByReference pcchInstanceListLength = new DWORDByReference(new DWORD(0));
-        Pdh.INSTANCE.PdhEnumObjectItems(szDataSource, szMachineName, szObjectName, null, pcchCounterListLength, null,
-                pcchInstanceListLength, dwDetailLevel, 0);
-
-        // Can't allocate 0 memory if no counters
-        if (pcchCounterListLength.getValue().intValue() < 1) {
-            return counters;
-        }
-        // Allocate memory and call again to populate strings
-        Memory mszCounterList = new Memory(pcchCounterListLength.getValue().intValue() * CHAR_TO_BYTES);
-        // Don't need the instances
-        pcchInstanceListLength.getValue().setValue(0);
-        Pdh.INSTANCE.PdhEnumObjectItems(szDataSource, szMachineName, szObjectName, mszCounterList,
-                pcchCounterListLength, null, pcchInstanceListLength, dwDetailLevel, 0);
-
-        // Fetch counters
-        int offset = 0;
-        while (offset < mszCounterList.size()) {
-            String s = null;
-            if (CHAR_TO_BYTES == 1) {
-                s = mszCounterList.getString(offset);
-            } else {
-                s = mszCounterList.getWideString(offset);
-            }
-            // list ends with double null
-            if (s.isEmpty()) {
-                break;
-            }
-            counters.add(s);
-            // Increment for string + null terminator
-            offset += (s.length() + 1) * CHAR_TO_BYTES;
-        }
-
-        return counters;
-    }
-
-    /**
-     * Utility method to call Pdh's PdhEnumObjectItems that allocates the
-     * required memory for the mszInstanceList parameters based on the type
-     * mapping used, calls to PdhEnumObjectItems, and returns the received lists
-     * of strings.
-     * 
-     * @param szDataSource
-     *            String that specifies the name of the log file used to
-     *            enumerate the counter and instance names. If NULL, the
-     *            function uses the computer specified in the szMachineName
-     *            parameter to enumerate the names.
-     * @param szMachineName
-     *            String that specifies the name of the computer that contains
-     *            the counter and instance names that you want to enumerate.
-     *            Include the leading slashes in the computer name, for example,
-     *            \\computername. If the szDataSource parameter is NULL, you can
-     *            set szMachineName to NULL to specify the local computer.
-     * @param szObjectName
-     *            String that specifies the name of the object whose counter and
-     *            instance names you want to enumerate.
-     * @param dwDetailLevel
-     *            Detail level of the performance items to return. All items
-     *            that are of the specified detail level or less will be
-     *            returned.
-     * @return Returns a Lists of Strings of the instances of the object.
-     */
-    public static List<String> PdhEnumObjectItemInstances(String szDataSource, String szMachineName,
-            String szObjectName, int dwDetailLevel) {
         List<String> instances = new ArrayList<String>();
 
         // Call once to get string lengths
         DWORDByReference pcchCounterListLength = new DWORDByReference(new DWORD(0));
         DWORDByReference pcchInstanceListLength = new DWORDByReference(new DWORD(0));
-        Pdh.INSTANCE.PdhEnumObjectItems(szDataSource, szMachineName, szObjectName, null, pcchCounterListLength, null,
+        int result = Pdh.INSTANCE.PdhEnumObjectItems(szDataSource, szMachineName, szObjectName, null, pcchCounterListLength, null,
                 pcchInstanceListLength, dwDetailLevel, 0);
+        if(result != WinError.ERROR_SUCCESS && result != Pdh.PDH_MORE_DATA) {
+            throw new PdhException(result);
+        }
 
-        // Can't allocate 0 memory if no instances
-        if (pcchInstanceListLength.getValue().intValue() < 1) {
+        Memory mszCounterList = null;
+        Memory mszInstanceList = null;
+
+        if (pcchCounterListLength.getValue().intValue() > 0) {
+            mszCounterList = new Memory(pcchCounterListLength.getValue().intValue() * CHAR_TO_BYTES);
+        }
+
+        if (pcchInstanceListLength.getValue().intValue() > 0) {
+            mszInstanceList = new Memory(pcchInstanceListLength.getValue().intValue() * CHAR_TO_BYTES);
+        }
+
+        result = Pdh.INSTANCE.PdhEnumObjectItems(szDataSource, szMachineName, szObjectName, mszCounterList,
+                pcchCounterListLength, mszInstanceList, pcchInstanceListLength, dwDetailLevel, 0);
+
+        if(result != WinError.ERROR_SUCCESS) {
+            throw new PdhException(result);
+        }
+
+        // Fetch counters
+        if (mszCounterList != null) {
+            int offset = 0;
+            while (offset < mszCounterList.size()) {
+                String s = null;
+                if (CHAR_TO_BYTES == 1) {
+                    s = mszCounterList.getString(offset);
+                } else {
+                    s = mszCounterList.getWideString(offset);
+                }
+                // list ends with double null
+                if (s.isEmpty()) {
+                    break;
+                }
+                counters.add(s);
+                // Increment for string + null terminator
+                offset += (s.length() + 1) * CHAR_TO_BYTES;
+            }
+        }
+
+        if(mszInstanceList != null) {
+            int offset = 0;
+            while (offset < mszInstanceList.size()) {
+                String s = null;
+                if (CHAR_TO_BYTES == 1) {
+                    s = mszInstanceList.getString(offset);
+                } else {
+                    s = mszInstanceList.getWideString(offset);
+                }
+                // list ends with double null
+                if (s.isEmpty()) {
+                    break;
+                }
+                instances.add(s);
+                // Increment for string + null terminator
+                offset += (s.length() + 1) * CHAR_TO_BYTES;
+            }
+        }
+
+        return new PdhEnumObjectItems(counters, instances);
+    }
+
+
+    /**
+     * Holder Object for PdhEnumObjectsItems. The embedded lists are modifiable
+     * lists and can be accessed through the {@link #getCounters()} and
+     * {@link #getInstances()} accessors.
+     */
+    public static class PdhEnumObjectItems {
+        private final List<String> counters;
+        private final List<String> instances;
+
+        public PdhEnumObjectItems(List<String> counters, List<String> instances) {
+            this.counters = copyAndEmptyListForNullList(counters);
+            this.instances = copyAndEmptyListForNullList(instances);
+        }
+
+        /**
+         * @return the embedded counters list, all calls to this function receive
+         * the same list and thus share modifications
+         */
+        public List<String> getCounters() {
+            return counters;
+        }
+
+        /**
+         * @return the embedded instances list, all calls to this function receive
+         * the same list and thus share modifications
+         */
+        public List<String> getInstances() {
             return instances;
         }
-        // Allocate memory and call again to populate strings
-        Memory mszInstanceList = new Memory(pcchInstanceListLength.getValue().intValue() * CHAR_TO_BYTES);
-        // Don't need the counters
-        pcchCounterListLength.getValue().setValue(0);
-        Pdh.INSTANCE.PdhEnumObjectItems(szDataSource, szMachineName, szObjectName, null, pcchCounterListLength,
-                mszInstanceList, pcchInstanceListLength, dwDetailLevel, 0);
 
-        // Fetch instances
-        int offset = 0;
-        while (offset < mszInstanceList.size()) {
-            String s = null;
-            if (CHAR_TO_BYTES == 1) {
-                s = mszInstanceList.getString(offset);
+        private List<String> copyAndEmptyListForNullList (List<String> inputList) {
+            if(inputList == null) {
+                return new ArrayList<String>();
             } else {
-                s = mszInstanceList.getWideString(offset);
+                return new ArrayList<String>(inputList);
             }
-            // list ends with double null
-            if (s.isEmpty()) {
-                break;
-            }
-            instances.add(s);
-            // Increment for string + null terminator
-            offset += (s.length() + 1) * CHAR_TO_BYTES;
         }
 
-        return instances;
+        @Override
+        public String toString() {
+            return "PdhEnumObjectItems{" + "counters=" + counters + ", instances=" + instances + '}';
+        }
+    }
+    
+    public static final class PdhException extends RuntimeException {
+        private final int errorCode;
+        
+        public PdhException(int errorCode) {
+            super(String.format("Pdh call failed with error code 0x%08X", errorCode));
+            this.errorCode = errorCode;
+        }
+
+        public int getErrorCode() {
+            return errorCode;
+        }
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/AbstractWin32TestSupport.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/AbstractWin32TestSupport.java
@@ -145,4 +145,38 @@ public abstract class AbstractWin32TestSupport extends AbstractPlatformTestSuppo
         }
         Kernel32.INSTANCE.CloseHandle(hSnapShot);
     }
+    
+    /**
+     * Return true if the supplied uuid can be found in the registry.
+     * 
+     * @param uuid Format: {&lt;UID&gt;}
+     */
+    public static boolean checkCOMRegistered(String uuid) {
+        WinReg.HKEYByReference phkKey = null;
+        try {
+            phkKey = Advapi32Util.registryGetKey(WinReg.HKEY_CLASSES_ROOT, "Interface\\" + uuid, WinNT.KEY_READ);
+            if(phkKey != null) {
+                return true;
+            }
+        } catch (Win32Exception ex) {
+            // Ok - failed ...
+        } finally {
+            if(phkKey != null && phkKey.getValue() != null) {
+                Advapi32Util.registryCloseKey(phkKey.getValue());
+            }
+        }
+        try {
+            phkKey = Advapi32Util.registryGetKey(WinReg.HKEY_CLASSES_ROOT, "CLSID\\" + uuid, WinNT.KEY_READ);
+            if(phkKey != null) {
+                return true;
+            }
+        } catch (Win32Exception ex) {
+            // Ok - failed ...
+        } finally {
+            if(phkKey != null && phkKey.getValue() != null) {
+                Advapi32Util.registryCloseKey(phkKey.getValue());
+            }
+        }
+        return false;
+    }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ITypeLibTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ITypeLibTest.java
@@ -14,9 +14,7 @@ package com.sun.jna.platform.win32.COM;
 
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import junit.framework.TestCase;
 
-import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.CLSID;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.Kernel32;
@@ -33,24 +31,25 @@ import com.sun.jna.platform.win32.WinDef.ULONG;
 import com.sun.jna.platform.win32.WinDef.USHORTByReference;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
 import com.sun.jna.ptr.PointerByReference;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 /**
  * @author dblock[at]dblock[dot]org
  */
-public class ITypeLibTest extends TestCase {
+public class ITypeLibTest {
     static {
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
     }
-    
+
     // Microsoft Shell Controls And Automation
     private static final String SHELL_CLSID = "{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}";
     // Version 1.0
     private static final int SHELL_MAJOR = 1;
     private static final int SHELL_MINOR = 0;
-    
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(ITypeLibTest.class);
-    }
 
     public ITypeLibTest() {
     }
@@ -73,12 +72,17 @@ public class ITypeLibTest extends TestCase {
         return new TypeLib(pShellTypeLib.getValue());
     }
 
+    @Test
     public void testGetTypeInfoCount() {
         ITypeLib shellTypeLib = loadShellTypeLib();
         UINT typeInfoCount = shellTypeLib.GetTypeInfoCount();
-        assertEquals(38, typeInfoCount.intValue());
+        // Validate correct method count range
+        // Observed values in the wild were 37 (Windows 2012 Serve R2) + 38
+        assertTrue(typeInfoCount.intValue() >= 30);
+        assertTrue(typeInfoCount.intValue() <= 40);
     }
 
+    @Test
     public void testGetTypeInfo() {
         ITypeLib shellTypeLib = loadShellTypeLib();
         
@@ -90,6 +94,7 @@ public class ITypeLibTest extends TestCase {
         //System.out.println("ITypeInfo: " + ppTInfo.toString());
     }
 
+    @Test
     public void testGetTypeInfoType() {
         ITypeLib shellTypeLib = loadShellTypeLib();
 
@@ -101,6 +106,7 @@ public class ITypeLibTest extends TestCase {
         //System.out.println("TYPEKIND: " + pTKind);
     }
 
+    @Test
     public void testGetTypeInfoOfGuid() {
          ITypeLib shellTypeLib = loadShellTypeLib();
         
@@ -112,6 +118,7 @@ public class ITypeLibTest extends TestCase {
          assertTrue(COMUtils.SUCCEEDED(hr));
     }
 
+    @Test
     public void testLibAttr() {
          ITypeLib shellTypeLib = loadShellTypeLib();
         
@@ -129,6 +136,7 @@ public class ITypeLibTest extends TestCase {
          shellTypeLib.ReleaseTLibAttr(tlibAttr);
     }
 
+    @Test
     public void testGetTypeComp() {
         ITypeLib shellTypeLib = loadShellTypeLib();
 
@@ -139,6 +147,7 @@ public class ITypeLibTest extends TestCase {
         assertTrue(COMUtils.SUCCEEDED(hr));
     }
 
+    @Test
     public void testIsName() {
         ITypeLib shellTypeLib = loadShellTypeLib();
 
@@ -157,7 +166,8 @@ public class ITypeLibTest extends TestCase {
         
         Ole32.INSTANCE.CoTaskMemFree(p);
     }
-    
+
+    @Test
     public void testFindName() {
         ITypeLib shellTypeLib = loadShellTypeLib();
         

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacks2_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacks2_Test.java
@@ -1,6 +1,8 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.Pointer;
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
+import com.sun.jna.platform.win32.COM.COMUtils;
 import com.sun.jna.platform.win32.COM.util.annotation.ComEventCallback;
 import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
 import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
@@ -8,6 +10,7 @@ import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.Variant;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,18 +20,26 @@ public class ComEventCallbacks2_Test {
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
     }
 
-    Factory factory;
+    private boolean initialized = false;
+    private Factory factory;
 
     @Before
     public void before() {
-        Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
+        // Check if Word is registered in the registry
+        Assume.assumeTrue("Could not find registration", checkCOMRegistered("{000209FF-0000-0000-C000-000000000046}"));
+        COMUtils.checkRC(Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED));
+        initialized = true;
         this.factory = new Factory();
     }
 
     @After
     public void after() {
-        this.factory.disposeAll();
-        Ole32.INSTANCE.CoUninitialize();
+        if(this.factory != null) {
+            this.factory.disposeAll();
+        }
+        if(initialized) {
+            Ole32.INSTANCE.CoUninitialize();
+        }
     }
 
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacksFactory_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacksFactory_Test.java
@@ -13,6 +13,7 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.platform.win32.AbstractWin32TestSupport;
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
 import com.sun.jna.platform.win32.COM.COMUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -36,6 +37,7 @@ import org.hamcrest.CoreMatchers;
 import static com.sun.jna.platform.win32.COM.IUnknown.IID_IUNKNOWN;
 import static com.sun.jna.platform.win32.COM.IDispatch.IID_IDISPATCH;
 import static org.junit.Assert.*;
+import org.junit.Assume;
 
 public class ComEventCallbacksFactory_Test {
 
@@ -47,6 +49,8 @@ public class ComEventCallbacksFactory_Test {
 	
 	@Before
 	public void before() {
+                // Check that Internet Explorer is registered in the registry
+                Assume.assumeTrue("Could not find registration", checkCOMRegistered("{0002DF01-0000-0000-C000-000000000046}"));
                 AbstractWin32TestSupport.killProcessByName("iexplore.exe");
                 try {
                     Thread.sleep(5 * 1000);
@@ -63,8 +67,10 @@ public class ComEventCallbacksFactory_Test {
 
 	@After
 	public void after() {
-		this.factory.disposeAll();
-                this.factory.getComThread().terminate(10000);
+                if(this.factory != null) {
+                        this.factory.disposeAll();
+                        this.factory.getComThread().terminate(10000);
+                }
         }
 	
 	

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacksObjectFactory_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ComEventCallbacksObjectFactory_Test.java
@@ -14,6 +14,7 @@ package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.AbstractWin32TestSupport;
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
 import com.sun.jna.platform.win32.COM.COMUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -38,6 +39,7 @@ import org.hamcrest.CoreMatchers;
 import static com.sun.jna.platform.win32.COM.IUnknown.IID_IUNKNOWN;
 import static com.sun.jna.platform.win32.COM.IDispatch.IID_IDISPATCH;
 import static org.junit.Assert.*;
+import org.junit.Assume;
 
 public class ComEventCallbacksObjectFactory_Test {
 
@@ -45,22 +47,30 @@ public class ComEventCallbacksObjectFactory_Test {
                 ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
         }
     
-	ObjectFactory factory;
+        private boolean initialized = false;
+	private ObjectFactory factory;
 	
 	@Before
 	public void before() {
+                // Check that Internet Explorer is registered in the registry
+                Assume.assumeTrue("Could not find registration", checkCOMRegistered("{0002DF01-0000-0000-C000-000000000046}"));
                 AbstractWin32TestSupport.killProcessByName("iexplore.exe");
                 try {
                     Thread.sleep(5 * 1000);
                 } catch (InterruptedException ex) {}
-                Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
+                COMUtils.checkRC(Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED));
+                initialized= true;
 		this.factory = new ObjectFactory();
 	}
 
 	@After
 	public void after() {
-		this.factory.disposeAll();
-                Ole32.INSTANCE.CoUninitialize();
+                if(this.factory != null) {
+                    this.factory.disposeAll();
+                }
+                if(initialized) {
+                    Ole32.INSTANCE.CoUninitialize();
+                }
 	}
 	
 	

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConfigurateLCID_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConfigurateLCID_Test.java
@@ -1,12 +1,15 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.Pointer;
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
+import com.sun.jna.platform.win32.COM.COMUtils;
 import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
 import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
 import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.WinDef.LCID;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -14,11 +17,15 @@ import org.junit.Test;
 
 public class ConfigurateLCID_Test {
 
+    private boolean initialized = false;
     private Factory factory;
 
     @Before
     public void before() {
-        Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
+        // Check that Excel is registered in the registry
+        Assume.assumeTrue("Could not find registration", checkCOMRegistered("{0002DF01-0000-0000-C000-000000000046}"));
+        COMUtils.checkRC(Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED));
+        initialized= true;
         this.factory = new Factory();
         // switch to english locale (the test is only valid if office is
         // installed in a non-english locale
@@ -27,8 +34,12 @@ public class ConfigurateLCID_Test {
 
     @After
     public void after() {
-        this.factory.disposeAll();
-        Ole32.INSTANCE.CoUninitialize();
+        if(this.factory != null) {
+            this.factory.disposeAll();
+        }
+        if(initialized) {
+            Ole32.INSTANCE.CoUninitialize();
+        }
     }
 
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
@@ -1,10 +1,11 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.Pointer;
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
+import com.sun.jna.platform.win32.COM.COMUtils;
 import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
 import com.sun.jna.platform.win32.COM.util.annotation.ComMethod;
 import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
-import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
 import com.sun.jna.platform.win32.OaIdl.DATE;
 import com.sun.jna.platform.win32.OaIdl.VARIANT_BOOL;
 import com.sun.jna.platform.win32.Ole32;
@@ -20,25 +21,34 @@ import java.util.Date;
 import org.junit.AfterClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 
 // Untested: IDispatch
 // Untested: Proxy
 public class ConvertTest {
 
+    private static boolean initialized = false;
     private static ObjectFactory fact;
 
     @BeforeClass
     public static void init() {
-        Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
+        // Check that FileSystemObject is registered in the registry
+        Assume.assumeTrue("Could not find registration", checkCOMRegistered("{0D43FE01-F093-11CF-8940-00A0C9054228}"));
+        COMUtils.checkRC(Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED));
+        initialized = true;
         fact = new ObjectFactory();
     }
 
     @AfterClass
     public static void destruct() {
-        fact.disposeAll();
+        if(fact != null) {
+            fact.disposeAll();
+        }
         fact = null;
-        Ole32.INSTANCE.CoUninitialize();
+        if(initialized) {
+            Ole32.INSTANCE.CoUninitialize();
+        }
     }
 
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/HybdridCOMInvocationTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/HybdridCOMInvocationTest.java
@@ -1,6 +1,7 @@
 package com.sun.jna.platform.win32.COM.util;
 
 import com.sun.jna.Pointer;
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
 import com.sun.jna.platform.win32.COM.COMException;
 import com.sun.jna.platform.win32.COM.COMLateBindingObject;
 import com.sun.jna.platform.win32.COM.COMUtils;
@@ -33,6 +34,7 @@ import static org.hamcrest.CoreMatchers.is;
 import org.junit.After;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Assume;
 import org.junit.Before;
 
 /**
@@ -59,15 +61,23 @@ public class HybdridCOMInvocationTest {
     private static final GUID CLSID_WORD = new GUID(CLSID_WORD_STRING);
     private static final IID IID_APPLICATION = new IID(new GUID(IID_APPLICATION_STRING));
     
+    private boolean initialized = false;
+    
     @After
     public void tearDown() throws Exception {
-        Ole32.INSTANCE.CoUninitialize();
+        if(initialized) {
+            Ole32.INSTANCE.CoUninitialize();
+            initialized = false;
+        }
     }
     
     @Before
     public void setUp() throws Exception {
         // Initialize COM for this thread...
-        Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED);
+        // Check that FileSystemObject is registered in the registry
+        Assume.assumeTrue("Could not find registration", checkCOMRegistered(CLSID_WORD_STRING));
+        COMUtils.checkRC(Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED));
+        initialized = true;
     }
     
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ProxyObjectFactory_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ProxyObjectFactory_Test.java
@@ -12,6 +12,7 @@
  */
 package com.sun.jna.platform.win32.COM.util;
 
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
 import com.sun.jna.platform.win32.COM.COMException;
 import com.sun.jna.platform.win32.COM.COMInvokeException;
 import static org.junit.Assert.*;
@@ -29,6 +30,7 @@ import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
 import com.sun.jna.platform.win32.COM.util.annotation.ComMethod;
 import com.sun.jna.platform.win32.COM.util.annotation.ComProperty;
 import com.sun.jna.platform.win32.WinError;
+import org.junit.Assume;
 
 public class ProxyObjectFactory_Test {
         private static final Logger LOG = Logger.getLogger(ProxyObjectFactory_Test.class.getName());
@@ -98,10 +100,13 @@ public class ProxyObjectFactory_Test {
 	interface MsWordApp extends Application {
 	}
 
-	Factory factory;
+	private Factory factory;
 
 	@Before
 	public void before() {
+                // Check Existence of Word Application
+                Assume.assumeTrue("Could not find registration", checkCOMRegistered("{00020970-0000-0000-C000-000000000046}"));
+            
 		this.factory = new Factory();
 		//ensure there are no word applications running.
 		while(true) {
@@ -139,8 +144,11 @@ public class ProxyObjectFactory_Test {
 
 	@After
 	public void after() {
+            if(factory != null) {
                 factory.disposeAll();
                 factory.getComThread().terminate(10000);
+                factory = null;
+            }
 	}
 
 	@Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -335,8 +335,6 @@ public class Kernel32Test extends TestCase {
         HANDLE h = Kernel32.INSTANCE.GetCurrentThread();
         assertNotNull("No current thread handle", h);
         assertFalse("Null current thread handle", h.equals(0));
-        // Calling the CloseHandle function with this handle has no effect
-        Kernel32Util.closeHandle(h);
     }
 
     public void testOpenThread() {
@@ -355,8 +353,6 @@ public class Kernel32Test extends TestCase {
         HANDLE h = Kernel32.INSTANCE.GetCurrentProcess();
         assertNotNull("No current process handle", h);
         assertFalse("Null current process handle", h.equals(0));
-        // Calling the CloseHandle function with a pseudo handle has no effect
-        Kernel32Util.closeHandle(h);
     }
 
     public void testOpenProcess() {

--- a/contrib/platform/test/com/sun/jna/platform/win32/SAFEARRAYTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/SAFEARRAYTest.java
@@ -14,6 +14,7 @@ package com.sun.jna.platform.win32;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import static com.sun.jna.platform.win32.AbstractWin32TestSupport.checkCOMRegistered;
 import com.sun.jna.platform.win32.COM.COMException;
 import com.sun.jna.platform.win32.COM.COMUtils;
 import com.sun.jna.platform.win32.COM.util.ObjectFactory;
@@ -63,6 +64,7 @@ import static com.sun.jna.platform.win32.OaIdlUtil.toPrimitiveArray;
 import com.sun.jna.platform.win32.WTypes.VARTYPE;
 import com.sun.jna.platform.win32.WinDef.LONG;
 import java.lang.reflect.Field;
+import org.junit.Assume;
 
 public class SAFEARRAYTest {
     static {
@@ -492,7 +494,11 @@ public class SAFEARRAYTest {
         // Open a record set with a sample search (basicly get the first five
         // entries from the search index
         Connection conn = fact.createObject(Connection.class);
-        conn.Open("Provider=Search.CollatorDSO;Extended Properties='Application=Windows';", "", "", -1);
+        try {
+            conn.Open("Provider=Search.CollatorDSO;Extended Properties='Application=Windows';", "", "", -1);
+        } catch (COMException ex) {
+            Assume.assumeNoException(ex);
+        }
 
         Recordset recordset = fact.createObject(Recordset.class);
         recordset.Open("SELECT TOP 5 System.ItemPathDisplay, System.ItemName, System.ItemUrl, System.DateCreated FROM SYSTEMINDEX ORDER BY System.ItemUrl", conn, CursorTypeEnum.adOpenUnspecified, LockTypeEnum.adLockUnspecified, -1);

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32Test.java
@@ -379,13 +379,18 @@ public class User32Test extends AbstractWin32TestSupport {
         assertTrue("GetCursorPos should return true", result);
         assertTrue("X coordinate in POINT should be >= 0", cursorPos.x >= 0);
         
-        boolean scpResult = User32.INSTANCE.SetCursorPos(cursorPos.x - 20, cursorPos.y);
+        boolean scpResult = User32.INSTANCE.SetCursorPos(cursorPos.x + 20, cursorPos.y);
         assertTrue("SetCursorPos should return true", scpResult);
         
         POINT cursorPos2 = new POINT();
         boolean result2 = User32.INSTANCE.GetCursorPos(cursorPos2);
         assertTrue("GetCursorPos should return true", result2);
-        assertTrue("X coordinate in POINT should be original cursor position - 20", cursorPos2.x  == cursorPos.x - 20);
+        assertTrue(String.format(
+                "X coordinate in POINT should be original cursor position - 20 (Old: %dx%d, New: %dx%d)",
+                cursorPos.x, cursorPos.y, cursorPos2.x, cursorPos2.y
+                ),
+                cursorPos2.x == cursorPos.x + 20
+        );
     }
     
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/Win32ServiceDemo.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Win32ServiceDemo.java
@@ -120,7 +120,18 @@ public class Win32ServiceDemo {
                 }
             }
         }
-        invocation = String.format("java.exe -cp %s com.sun.jna.platform.win32.Win32ServiceDemo", sb.toString());
+
+        String JAVA_HOME = System.getenv("JAVA_HOME");
+        String javaBinary = "java.exe";
+        if(JAVA_HOME != null) {
+            javaBinary = "\"" + new File(JAVA_HOME, "\\bin\\java.exe").getAbsolutePath() + "\"";
+        } else {
+            javaBinary = "java.exe";
+        }
+
+        invocation = String.format("%s -Djna.nosys=true -cp %s com.sun.jna.platform.win32.Win32ServiceDemo",
+                javaBinary,
+                sb.toString());
         System.out.println("Invocation: " + invocation);
 
         SERVICE_DESCRIPTION desc = new SERVICE_DESCRIPTION();

--- a/contrib/platform/test/com/sun/jna/platform/win32/WinspoolTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/WinspoolTest.java
@@ -20,17 +20,29 @@ import com.sun.jna.platform.win32.Winspool.PRINTER_INFO_2;
 import com.sun.jna.platform.win32.Winspool.PRINTER_INFO_4;
 import com.sun.jna.ptr.IntByReference;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * @author dblock[at]dblock[dot]org
  */
-public class WinspoolTest extends TestCase {
+public class WinspoolTest {
 
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(WinspoolTest.class);
+    @BeforeClass
+    public static void setUp() throws Exception {
+        HANDLEByReference hbr = new HANDLEByReference();
+        boolean result = Winspool.INSTANCE.OpenPrinter("Will not be found", hbr, null);
+        Assume.assumeFalse(result);
+        int error = Native.getLastError();
+        Assume.assumeTrue("Print service not available", error != WinError.RPC_S_SERVER_UNAVAILABLE);
     }
 
+    @Test
     public void testEnumPrinters_4() {
     	IntByReference pcbNeeded = new IntByReference();
     	IntByReference pcReturned = new IntByReference();
@@ -47,7 +59,8 @@ public class WinspoolTest extends TestCase {
 	    	}
     	}
     }
-    
+
+    @Test
     public void testEnumPrinters_2() {
         IntByReference pcbNeeded = new IntByReference();
         IntByReference pcReturned = new IntByReference();
@@ -64,7 +77,8 @@ public class WinspoolTest extends TestCase {
             }
         }
     }
-    
+
+    @Test
     public void testEnumPrinters_1() {
     	IntByReference pcbNeeded = new IntByReference();
     	IntByReference pcReturned = new IntByReference();
@@ -81,7 +95,8 @@ public class WinspoolTest extends TestCase {
 	    	}
     	}
     }
-    
+
+    @Test
     public void testOpenPrinter() {
         HANDLEByReference hbr = new HANDLEByReference();
         boolean result = Winspool.INSTANCE.OpenPrinter("1234567890A123", hbr, null);
@@ -89,13 +104,15 @@ public class WinspoolTest extends TestCase {
         assertNull("The pointer-to-a-printer-handle should be null on failure.", hbr.getValue());
         assertEquals("GetLastError() should return ERROR_INVALID_PRINTER_NAME", WinError.ERROR_INVALID_PRINTER_NAME, Native.getLastError());
     }
-    
+
+    @Test
     public void testClosePrinter() {
         boolean result = Winspool.INSTANCE.ClosePrinter(null);
         assertFalse("ClosePrinter should return false on failure.", result);
         assertEquals("GetLastError() should return ERROR_INVALID_HANDLE", WinError.ERROR_INVALID_HANDLE, Native.getLastError());
     }
-    
+
+    @Test
     public void testCorrectDeclarationOfMembers() throws InstantiationException, IllegalAccessException {
         for(Class klass: Winspool.class.getDeclaredClasses()) {
             if(Structure.class.isAssignableFrom(klass)) {

--- a/contrib/platform/test/com/sun/jna/platform/win32/WinspoolUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/WinspoolUtilTest.java
@@ -12,45 +12,64 @@
  */
 package com.sun.jna.platform.win32;
 
+import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Winspool.PRINTER_INFO_1;
 import com.sun.jna.platform.win32.Winspool.PRINTER_INFO_4;
 
-import junit.framework.TestCase;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * @author dblock[at]dblock[dot]org
  */
-public class WinspoolUtilTest extends TestCase {
+public class WinspoolUtilTest {
 
     public static void main(String[] args) {
-        junit.textui.TestRunner.run(WinspoolUtilTest.class);
-        for(PRINTER_INFO_1 printerInfo : WinspoolUtil.getPrinterInfo1()) {
-            System.out.println(printerInfo.pName + ": " + printerInfo.pDescription);        	
+        for (PRINTER_INFO_1 printerInfo : WinspoolUtil.getPrinterInfo1()) {
+            System.out.println(printerInfo.pName + ": " + printerInfo.pDescription);
         }
-        for(PRINTER_INFO_4 printerInfo : WinspoolUtil.getPrinterInfo4()) {
-            System.out.println(printerInfo.pPrinterName + " on " + printerInfo.pServerName);        	
+        for (PRINTER_INFO_4 printerInfo : WinspoolUtil.getPrinterInfo4()) {
+            System.out.println(printerInfo.pPrinterName + " on " + printerInfo.pServerName);
         }
     }
-    
-	public void testGetPrinterInfo1() {
-		assertTrue(WinspoolUtil.getPrinterInfo1().length >= 0);
-	}
-	
-	public void testGetPrinterInfo2() {
-		assertTrue(WinspoolUtil.getPrinterInfo2().length >= 0);
-	}
-	
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WinNT.HANDLEByReference hbr = new WinNT.HANDLEByReference();
+        boolean result = Winspool.INSTANCE.OpenPrinter("Will not be found", hbr, null);
+        Assume.assumeFalse(result);
+        int error = Native.getLastError();
+        Assume.assumeTrue("Print service not available", error != WinError.RPC_S_SERVER_UNAVAILABLE);
+    }
+
+    @Test
+    public void testGetPrinterInfo1() {
+        assertTrue(WinspoolUtil.getPrinterInfo1().length >= 0);
+    }
+
+    @Test
+    public void testGetPrinterInfo2() {
+        assertTrue(WinspoolUtil.getPrinterInfo2().length >= 0);
+    }
+
+    @Test
     public void testGetPrinterInfo2Specific() {
         try {
             WinspoolUtil.getPrinterInfo2("1234567890A123");
             fail("A Win32Exception with ERROR_INVALID_PRINTER_NAME should have been thrown instead of hitting this.");
         } catch (Win32Exception e) {
+            Assume.assumeTrue("Print service not available", WinError.RPC_S_SERVER_UNAVAILABLE != e.getHR().intValue());
             assertEquals("A Win32Exception with ERROR_INVALID_PRINTER_NAME message should have been thrown.",
                     Kernel32Util.formatMessage(W32Errors.HRESULT_FROM_WIN32(WinError.ERROR_INVALID_PRINTER_NAME)), e.getMessage());
         }
     }
 
-	public void testGetPrinterInfo4() {
+    @Test
+    public void testGetPrinterInfo4() {
         assertTrue(WinspoolUtil.getPrinterInfo4().length >= 0);
     }
 }


### PR DESCRIPTION
Running the JNA unittests on the appveyor CI system shows, that implicit assumptions
in the unittests don't hold everywhere. There are:

- corner cases in the behavior of Win32 functions
- missing dependencies (several of the COM tests depend on one of the office products)
- wrong invocations (the Win32DemoService picks up a system wide installed old JNA dll)
- disabled service 
and so on.

The referenced commits either express the assumptions as junit assumption (causing the
affected tests to be skipped) or fix/improve the behavior.

Closes: #685