### PR TITLE
Change LPWSTR.ByReference to extend LPWSTR instead of BSTR

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WTypes.java
@@ -212,7 +212,7 @@ public interface WTypes {
     }
 
     public static class LPWSTR extends PointerType {
-        public static class ByReference extends BSTR implements
+        public static class ByReference extends LPWSTR implements
                 Structure.ByReference {
         }
 


### PR DESCRIPTION
LPWSTR.ByReference currently extends BSTR, which seems to be a typo (copy-pasted BSTR.ByReference?). Instead, LPWSTR.ByReference should extend LPWSTR to follow the typical ByReference subclass paradigm.