### PR TITLE
Allow enums to implement `NativeMapped`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Features
 
 Bug Fixes
 ---------
+* [#1003](https://github.com/java-native-access/jna/pull/1003): Allow `NativeMapped` to be used with enums - [@koraktor](https://github.com/koraktor)
 * [#652](https://github.com/java-native-access/jna/issues/652): Dead Lock in class initialization - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#843](https://github.com/java-native-access/jna/pull/843): Correctly bind `com.sun.jna.platform.win32.SecBufferDesc` and add convenience binding as `com.sun.jna.platform.win32.SspiUtil.ManagedSecBufferDesc`. Bind SSPI functions `InitializeSecurityContext`, `AcceptSecurityContext`, `QueryCredentialsAttributes`, `QuerySecurityPackageInfo`, `EncryptMessage`, `DecryptMessage`, `MakeSignature`, `VerifySignature` in `com.sun.jna.platform.win32.Secur32` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#863](https://github.com/java-native-access/jna/pull/863): Fix ARM softfloat/hardfloat detection by modifying armSoftFloat condition in ELFAnalyser. Before this fix a softfloat binary could be misdetected as hardfloat. - [@kunkun26](https://github.com/kunkun26).

--- a/src/com/sun/jna/NativeMappedConverter.java
+++ b/src/com/sun/jna/NativeMappedConverter.java
@@ -57,6 +57,10 @@ public class NativeMappedConverter implements TypeConverter {
     }
 
     public NativeMapped defaultValue() {
+        if (type.isEnum()) {
+            return (NativeMapped) type.getEnumConstants()[0];
+        }
+
         try {
             return (NativeMapped)type.newInstance();
         } catch (InstantiationException e) {

--- a/test/com/sun/jna/NativeMappedTestClass.java
+++ b/test/com/sun/jna/NativeMappedTestClass.java
@@ -1,0 +1,26 @@
+package com.sun.jna;
+
+class NativeMappedTestClass implements NativeMapped {
+
+    private String name;
+
+    public NativeMappedTestClass() {}
+
+    @Override
+    public Object fromNative(Object nativeValue, FromNativeContext context) {
+        NativeMappedTestClass object = new NativeMappedTestClass();
+        object.name = (String) nativeValue;
+
+        return object;
+    }
+
+    @Override
+    public Object toNative() {
+        return name;
+    }
+
+    @Override
+    public Class<?> nativeType() {
+        return String.class;
+    }
+}

--- a/test/com/sun/jna/NativedMappedConverterTest.java
+++ b/test/com/sun/jna/NativedMappedConverterTest.java
@@ -1,0 +1,37 @@
+package com.sun.jna;
+
+import junit.framework.TestCase;
+
+public class NativedMappedConverterTest extends TestCase {
+
+    public void testDefaultValueForClass() {
+        NativeMappedConverter converter = new NativeMappedConverter(NativeMappedTestClass.class);
+
+        assertTrue(converter.defaultValue() instanceof NativeMappedTestClass);
+    }
+
+    public void testDefaultValueForEnum() {
+        NativeMappedConverter converter = new NativeMappedConverter(TestEnum.class);
+
+        assertSame(converter.defaultValue(), TestEnum.VALUE1);
+    }
+
+    private enum TestEnum implements NativeMapped { VALUE1, VALUE2;
+
+        @Override
+        public Object fromNative(Object nativeValue, FromNativeContext context) {
+            return values()[(Integer) nativeValue];
+        }
+
+        @Override
+        public Object toNative() {
+            return ordinal();
+        }
+
+        @Override
+        public Class<?> nativeType() {
+            return Integer.class;
+        }
+    }
+
+}


### PR DESCRIPTION
This will allow enums to be used inside structures.

Currently (i.e. 4.5.x), it’s impossible to use enums (instead of `int`) inside a `Structure`. This will fail in `Native.getNativeSize()`.
This patch will fix this problem and allow enums like:

```java
public TestEnum implements NativeMapped {
    ONE, TWO, THREE;

    @Override
    public Object fromNative(Object nativeValue, FromNativeContext context) {
        return values()[(int) nativeValue];
    }

    @Override
    public Object toNative() {
        return ordinal();
    }

    @Override
    public Class<?> nativeType() {
        return Integer.class;
    }
}
```

With Java 8’s `default` methods it’s even possible to completely move this into an own interface, so you’ll only need to add the interface to an enum and be done.

PS: I don’t know which Java version JNA is currently targeting. Should I add such a special enum interface with default methods to this patch?