### PR TITLE
Optimize library loading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Features
 * [#1003](https://github.com/java-native-access/jna/pull/1003): Allow `NativeMapped` to be used with enums - [@koraktor](https://github.com/koraktor).
 * [#994](https://github.com/java-native-access/jna/issues/994): Added `CoInitializeSecurity` and `CoSetProxyBlanket` to `c.s.j.platform.win32.Ole32`, added new `c.s.j.platform.win32.Wbemcli` classes needed to query WMI, and added a `WbemcliUtil` class implementing WMI queries. - [@dbwiddis](https://github.com/dbwiddis).
 * [#1013](https://github.com/java-native-access/jna/pull/1013): Add automatic module name entries to manifest of jna and jna-platform - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#985](https://github.com/java-native-access/jna/issues/985): Improve handling of dynamicaly extracted native library. On Mac OS X systems `~/Library/Application Support/JNA/temp` and on other Unix like systems `$XDG_CACHE_DIR/JNA/temp` (Default value is: `~/.cache/JNA/temp`) is used - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,7 +62,8 @@ Bug Fixes
   </ol> - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#958](https://github.com/java-native-access/jna/issues/958): Update for PR 863: Old toolchains produce binaries without hard-/softfloat markers. Rasbian is missinng the markers and the oracle JDK is also affected. For hardfloat detection now also the Arm EABI section is also considered - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#974](https://github.com/java-native-access/jna/issues/974): If the callback code failed to attach to the JVM, this lead to a segfault. The success of attaching to the JVM was checked to late and an invalid `JNIEnv` pointer was used to access the JVM - [@matthiasblaesing](https://github.com/matthiasblaesing).
-* [#1010](https://github.com/java-native-access/jna/issues/1010): Fix binding of `lpAccessName` parameter of `com.sun.jna.platform.win32.Mpr#WNetUseConnection` 
+* [#1010](https://github.com/java-native-access/jna/issues/1010): Fix binding of `lpAccessName` parameter of `com.sun.jna.platform.win32.Mpr#WNetUseConnection` - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#384](https://github.com/java-native-access/jna/issues/384): Switch default value for `jna.nosys` to `true`. By default then the embedded native library is used - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Breaking Changes
 ----------------

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -178,7 +178,6 @@ com.sun.jna.platform.wince;version=${osgi.version}
         <!-- avoid VM conflicts with JNA protected mode -->
         <env key="${ld.preload.name}" file="${libjsig}"/>
         <!-- Ignore any system install of JNA -->
-        <sysproperty key="jna.nosys" value="true"/>
         <sysproperty key="jna.builddir" file="${file.reference.jna.build}"/>
         <jvmarg value="${vmopt.arch}"/>
         <classpath><path path="${run.test.classpath}"/><path path="${file.reference.jna.build}/test-classes"/></classpath>
@@ -206,7 +205,6 @@ com.sun.jna.platform.wince;version=${osgi.version}
 
     <!-- One-off test to check field order definitions -->
     <target name="test-field-order" depends="-pre-test-run-single" >
-        <!-- @todo How to ensure sys prop: jna.nosys=true is seen in tests? -->
         <!--<property name="test.includes" value="com/sun/jna/platform/**/*.java"/>-->
         <property name="test.includes" value="com/sun/jna/platform/StructureFieldOrderTest.java"/>
         <property name="javac.includes" value="**/*"/>

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -980,7 +980,8 @@ public final class Native implements Version {
                 }
             }
         }
-        if (!Boolean.getBoolean("jna.nosys")) {
+        String jnaNosys = System.getProperty("jna.nosys", "true");
+        if (!Boolean.parseBoolean(jnaNosys)) {
             try {
                 if (DEBUG_JNA_LOAD) {
                     System.out.println("Trying (via loadLibrary) " + libName);

--- a/src/com/sun/jna/overview.html
+++ b/src/com/sun/jna/overview.html
@@ -59,19 +59,19 @@ additional JNI or native code.
 JNA includes a small, platform-specific shared library which enables all
 native access.  When the {@link com.sun.jna.Native} class is first accessed,
 JNA will first attempt to load this library from the directories specified
-in <code>jna.boot.library.path</code>.  If that fails, it will fall back to
-loading from the system library paths. Finally it will attempt to extract the
-stub library from from the JNA jar file, and load it. 
+in <code>jna.boot.library.path</code>. If that fails and <code>jna.nosys=false</code>
+is set, it will fall back to loading from the system library paths. Finally it
+will attempt to extract the stub library from from the JNA jar file, and load it.
 <p/>
 The <code>jna.boot.library.path</code> property is mainly to support
 jna.jar being included in -Xbootclasspath, where
 <code>java.library.path</code> and LD_LIBRARY_PATH are ignored.  It is also
 useful for designating a version of the library to use in preference to any
-which may already be installed on the system.  
+which may already be installed on the system.
 <p/>
-Loading from the system may be disabled by <code>jna.nosys=true</code>,
+Loading from the system may be enabled by <code>jna.nosys=false</code>,
 and unpacking from the jar file may be disabled by
-<code>jna.nounpack=true</code>. 
+<code>jna.nounpack=true</code>.
 <p/>
 The library name used to search for JNA's native library may be altered
 by setting <code>jna.boot.library.name</code>, which defaults to

--- a/test/com/sun/jna/JNALoadTest.java
+++ b/test/com/sun/jna/JNALoadTest.java
@@ -125,7 +125,7 @@ public class JNALoadTest extends TestCase implements Paths {
         String path = (String)field.get(null);
         assertNotNull("Native library path unavailable", path);
         assertTrue("Native library not unpacked from jar: " + path,
-                   path.startsWith(System.getProperty("java.io.tmpdir")));
+                path.startsWith(Native.getTempDir().getAbsolutePath()));
 
         Reference<Class<?>> ref = new WeakReference<Class<?>>(cls);
         Reference<ClassLoader> clref = new WeakReference<ClassLoader>(loader);


### PR DESCRIPTION
Two problems are addressed here:
1. it is a long standing issue, that JNA should default to not load the `jnidispatch` library from the system search path. This was again observed when introducing appveyor builds, as there somehow a jnidispatch library is on the system path
2. Unix systems (Mac OS X and Linux at least) default to a global system temp directory. This is unsafe, as an attacker could gain control over that directory. This is nor fixed.