### PR TITLE
Add ExitProcess to Kernel32 API

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -3780,4 +3780,12 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      * information, call {@link com.sun.jna.Native#getLastError()}.</p>
      */
     boolean ReleaseMutex(HANDLE handle);
+	
+    /**
+     * Ends the calling process (this process) and all its threads.
+     *
+     * From Java, this will will cause the process to terminate without
+     * execution of any shutdown hooks 
+     */
+    void ExitProcess(int exitCode);
 }


### PR DESCRIPTION
- [documention on msdn](https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-exitprocess)
- I needed this as a hack for my own code, because we have an internal native-windows library that was misbehaving, resulting in the JVM shutting down _but leaving the windows process alive_, which is causing all sorts of headaches. I wanted to use Kernel32 to force shutdown. I thought the most elegant place to put it was the JVM shutdown hooks, but, of course, this is far from elegant. Still, I figured others might want this function, and since it's in MS's API, and it uses pretty plain types, I figure'd Platform should support it. 

_I made this edit in githubs online text editor, I have not checked out the branch and tried it, but I did create my own interface with this exact signature on it, and it worked_. And, of course, covering this function with automation is tricky. I'm happy to talk about how to do that with you guys if you like.