### PR TITLE
Fix Linux LibC.Sysinfo FieldOrder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 Bug Fixes
 ---------
 * [#1025](https://github.com/java-native-access/jna/pull/1025): Restore java 6 compatibility and introduce animal-sniffer to prevent regressions - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1028](https://github.com/java-native-access/jna/pull/1028): Fix Linux LibC.Sysinfo FieldOrder - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.0.0
 =============

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -169,16 +169,22 @@ com.sun.jna.platform.wince;version=${osgi.version}
       <property name="results.junit" location="${build}/junit-results/${os.prefix}"/>
       <mkdir dir="${results.junit}"/>
       <echo>Saving test results in ${results.junit}</echo>
-      <condition property="tests.platform" value="**/mac/**/*Test.java">
+      <condition property="tests.platform.mac" value="**/mac/**/*Test.java">
         <os family="mac"/>
       </condition>
-      <condition property="tests.platform" value="**/win32/**/*Test.java">
+      <condition property="tests.platform.windows" value="**/win32/**/*Test.java">
         <os family="windows"/>
       </condition>
-      <condition property="tests.platform" value="**/unix/**/*Test.java">
+      <condition property="tests.platform.linux" value="**/linux/**/*Test.java">
+        <os name="Linux"/>
+      </condition>
+      <condition property="tests.platform.unix" value="**/unix/**/*Test.java">
         <os family="unix"/>
       </condition>
-      <property name="tests.platform" value=""/>
+      <property name="tests.platform.mac" value=""/>
+      <property name="tests.platform.windows" value=""/>
+      <property name="tests.platform.linux" value=""/>
+      <property name="tests.platform.unix" value=""/>
       <property name="tests.exclude" value=""/>
       <property name="tests.exclude-patterns" value=""/>
       <condition property="java.awt.headless" value="true">
@@ -194,7 +200,10 @@ com.sun.jna.platform.wince;version=${osgi.version}
       <propertyset id="headless">
         <propertyref prefix="java.awt.headless"/>
       </propertyset>
-      <echo>tests.platform=${tests.platform}</echo>
+      <echo>tests.platform=${tests.platform.mac}</echo>
+      <echo>tests.platform=${tests.platform.windows}</echo>
+      <echo>tests.platform=${tests.platform.linux}</echo>
+      <echo>tests.platform=${tests.platform.unix}</echo>
       <junit fork="${test.fork}" failureproperty="testfailure" tempdir="${build.dir}">
         <!-- optionally run headless -->
         <syspropertyset refid="headless"/>
@@ -211,7 +220,10 @@ com.sun.jna.platform.wince;version=${osgi.version}
             <!-- Until StructureFieldOrderTest gets fixed up a little -->
             <exclude name="**/StructureFieldOrderTest.java"/>
             <exclude name="com/sun/jna/platform/AbstractWin32TestSupport.java"/>
-            <include name="${tests.platform}"/>
+            <include name="${tests.platform.mac}"/>
+            <include name="${tests.platform.windows}"/>
+            <include name="${tests.platform.linux}"/>
+            <include name="${tests.platform.unix}"/>
             <exclude name="${tests.exclude}"/>
           </fileset>
         </batchtest>

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -179,7 +179,7 @@ com.sun.jna.platform.wince;version=${osgi.version}
         <os name="Linux"/>
       </condition>
       <condition property="tests.platform.unix" value="**/unix/**/*Test.java">
-        <os family="unix"/>
+        <and><os family="unix"/><not><os family="mac"/></not></and>
       </condition>
       <property name="tests.platform.mac" value=""/>
       <property name="tests.platform.windows" value=""/>
@@ -229,10 +229,10 @@ com.sun.jna.platform.wince;version=${osgi.version}
         </batchtest>
       </junit>
       <junitreport todir="${results.junit}">
-	<fileset dir="${results.junit}">
-	  <include name="TEST-*.xml"/>
-	</fileset>
-	<report todir="${reports.junit}"/>
+        <fileset dir="${results.junit}">
+          <include name="TEST-*.xml"/>
+        </fileset>
+        <report todir="${reports.junit}"/>
       </junitreport>
       <echo message="View test report in file://${reports.junit}/index.html" />
       <fail if="testfailure">One or more tests failed</fail>

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -200,10 +200,10 @@ com.sun.jna.platform.wince;version=${osgi.version}
       <propertyset id="headless">
         <propertyref prefix="java.awt.headless"/>
       </propertyset>
-      <echo>tests.platform=${tests.platform.mac}</echo>
-      <echo>tests.platform=${tests.platform.windows}</echo>
-      <echo>tests.platform=${tests.platform.linux}</echo>
-      <echo>tests.platform=${tests.platform.unix}</echo>
+      <echo>tests.platform.mac=${tests.platform.mac}</echo>
+      <echo>tests.platform.windows=${tests.platform.windows}</echo>
+      <echo>tests.platform.linux=${tests.platform.linux}</echo>
+      <echo>tests.platform.unix=${tests.platform.unix}</echo>
       <junit fork="${test.fork}" failureproperty="testfailure" tempdir="${build.dir}">
         <!-- optionally run headless -->
         <syspropertyset refid="headless"/>

--- a/contrib/platform/src/com/sun/jna/platform/linux/LibC.java
+++ b/contrib/platform/src/com/sun/jna/platform/linux/LibC.java
@@ -89,8 +89,8 @@ public interface LibC extends LibCAPI, Library {
         @Override
         protected List<String> getFieldOrder() {
             List<String> fieldOrder = new ArrayList<String>(super.getFieldOrder());
-            if (PADDING_SIZE > 0) {
-                fieldOrder.add("_f");
+            if (PADDING_SIZE == 0) {
+                fieldOrder.remove("_f");
             }
             return fieldOrder;
         }

--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -1061,7 +1061,10 @@ public abstract class Structure {
         if (fieldOrder.size() != flist.size() && flist.size() > 1) {
             if (force) {
                 throw new Error("Structure.getFieldOrder() on " + getClass()
-                                + " does not provide enough names [" + fieldOrder.size()
+                                + (fieldOrder.size() < flist.size() 
+                                    ? " does not provide enough" 
+                                    : " provides too many")
+                                + " names [" + fieldOrder.size()
                                 + "] ("
                                 + sort(fieldOrder)
                                 + ") to match declared fields [" + flist.size()


### PR DESCRIPTION
Fixes #1027. 

Committing build.xml patch first to generate test failure before fixing it.