### PR TITLE
COM Cleanup Part 1

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMBindingBaseObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMBindingBaseObject.java
@@ -175,6 +175,157 @@ public class COMBindingBaseObject extends COMInvoker {
     }
 
     protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
+            String name, VARIANT[] pArgs) throws COMException {
+
+        // variable declaration
+        WString[] ptName = new WString[] { new WString(name) };
+        DISPIDByReference pdispID = new DISPIDByReference();
+
+        // Get DISPID for name passed...
+        HRESULT hr = iDispatch.GetIDsOfNames(new REFIID(Guid.IID_NULL), ptName, 1,
+                LOCALE_USER_DEFAULT, pdispID);
+
+        COMUtils.checkRC(hr);
+
+        return this
+                .oleMethod(nType, pvResult, iDispatch, pdispID.getValue(), pArgs);
+    }
+
+    protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
+            DISPID dispId, VARIANT[] pArgs)
+            throws COMException {
+
+        // variable declaration
+        int _argsLen = 0;
+        VARIANT[] _args = null;
+        DISPPARAMS.ByReference dp = new DISPPARAMS.ByReference();
+        EXCEPINFO.ByReference pExcepInfo = new EXCEPINFO.ByReference();
+        IntByReference puArgErr = new IntByReference();
+
+        // make parameter reverse ordering as expected by COM runtime
+        if ((pArgs != null) && (pArgs.length > 0)) {
+            _argsLen = pArgs.length;
+            _args = new VARIANT[_argsLen];
+
+            int revCount = _argsLen;
+            for (int i = 0; i < _argsLen; i++) {
+                _args[i] = pArgs[--revCount];
+            }
+        }
+
+        // Handle special-case for property-puts!
+        if (nType == OleAuto.DISPATCH_PROPERTYPUT) {
+            dp.setRgdispidNamedArgs(new DISPID[] {OaIdl.DISPID_PROPERTYPUT});
+        }
+
+        // Build DISPPARAMS
+        if (_argsLen > 0) {
+            dp.setArgs(_args);
+
+            // write 'DISPPARAMS' structure to memory
+            dp.write();
+        }
+
+        // Apply "fix" according to
+        // https://www.delphitools.info/2013/04/30/gaining-visual-basic-ole-super-powers/
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/ms221486(v=vs.85).aspx
+        //
+        // Summary: there are methods in the word typelibrary that require both
+        // PROPERTYGET _and_ METHOD to be set. With only one of these set the call
+        // fails.
+        //
+        // The article from delphitools argues, that automation compatible libraries
+        // need to be compatible with VisualBasic which does not distingish methods
+        // and property getters and will set both flags always.
+        //
+        // The MSDN article advises this behaviour: "[...] Some languages cannot
+        // distinguish between retrieving a property and calling a method. In this
+        //case, you should set the flags DISPATCH_PROPERTYGET and DISPATCH_METHOD.
+        // [...]"))
+        //
+        // This was found when trying to bind InchesToPoints from the _Application
+        // dispatch interface of the MS Word 15 type library
+        //
+        // The signature according the ITypeLib Viewer (OLE/COM Object Viewer):
+        // [id(0x00000172), helpcontext(0x09700172)]
+        // single InchesToPoints([in] single Inches);
+
+        final int finalNType;
+        if (nType == OleAuto.DISPATCH_METHOD || nType == OleAuto.DISPATCH_PROPERTYGET) {
+            finalNType = OleAuto.DISPATCH_METHOD | OleAuto.DISPATCH_PROPERTYGET;
+        } else {
+            finalNType = nType;
+        }
+
+        // Make the call!
+        HRESULT hr = iDispatch.Invoke(dispId, new REFIID(Guid.IID_NULL), LOCALE_SYSTEM_DEFAULT,
+                new WinDef.WORD(finalNType), dp, pvResult, pExcepInfo, puArgErr);
+
+        COMUtils.checkRC(hr, pExcepInfo, puArgErr);
+        return hr;
+    }
+
+    /**
+     * Ole method.
+     *
+     * @param nType
+     *            the n type
+     * @param pvResult
+     *            the pv result
+     * @param pDisp
+     *            the disp
+     * @param name
+     *            the name
+     * @param pArg
+     *            the arg
+     * @return the hresult
+     * @throws COMException
+     *             the cOM exception
+     */
+    protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
+            String name, VARIANT pArg) throws COMException {
+
+        return this.oleMethod(nType, pvResult, name, new VARIANT[] { pArg });
+    }
+
+    protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
+            DISPID dispId, VARIANT pArg) throws COMException {
+
+        return this.oleMethod(nType, pvResult, dispId, new VARIANT[] { pArg });
+    }
+
+    /**
+     * Ole method.
+     *
+     * @param nType
+     *            the n type
+     * @param pvResult
+     *            the pv result
+     * @param pDisp
+     *            the disp
+     * @param name
+     *            the name
+     * @return the hresult
+     * @throws COMException
+     *             the cOM exception
+     */
+    protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
+            String name) throws COMException {
+
+        return this.oleMethod(nType, pvResult, name, (VARIANT[]) null);
+    }
+
+    protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
+            DISPID dispId) throws COMException {
+
+        return this.oleMethod(nType, pvResult, dispId, (VARIANT[]) null);
+    }
+
+    /**
+     * @deprecated {@link COMBindingBaseObject#oleMethod(int, com.sun.jna.platform.win32.Variant.VARIANT.ByReference, java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT[]) }
+     */
+    @Deprecated
+    protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
             IDispatch pDisp, String name, VARIANT[] pArgs) throws COMException {
 
         if (pDisp == null)
@@ -194,6 +345,10 @@ public class COMBindingBaseObject extends COMInvoker {
                 .oleMethod(nType, pvResult, pDisp, pdispID.getValue(), pArgs);
     }
 
+    /**
+     * @deprecated {@link COMBindingBaseObject#oleMethod(int, com.sun.jna.platform.win32.Variant.VARIANT.ByReference, com.sun.jna.platform.win32.OaIdl.DISPID, com.sun.jna.platform.win32.Variant.VARIANT[]) }
+     */
+    @Deprecated
     protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
             IDispatch pDisp, DISPID dispId, VARIANT[] pArgs)
             throws COMException {
@@ -272,22 +427,9 @@ public class COMBindingBaseObject extends COMInvoker {
     }
 
     /**
-     * Ole method.
-     *
-     * @param nType
-     *            the n type
-     * @param pvResult
-     *            the pv result
-     * @param pDisp
-     *            the disp
-     * @param name
-     *            the name
-     * @param pArg
-     *            the arg
-     * @return the hresult
-     * @throws COMException
-     *             the cOM exception
+     * @deprecated Use {@link #oleMethod(int, com.sun.jna.platform.win32.Variant.VARIANT.ByReference, java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT)
      */
+    @Deprecated
     protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
             IDispatch pDisp, String name, VARIANT pArg) throws COMException {
 
@@ -295,6 +437,10 @@ public class COMBindingBaseObject extends COMInvoker {
                 new VARIANT[] { pArg });
     }
 
+    /**
+     * @deprecated Use {@link #oleMethod(int, com.sun.jna.platform.win32.Variant.VARIANT.ByReference, com.sun.jna.platform.win32.OaIdl.DISPID, com.sun.jna.platform.win32.Variant.VARIANT)
+     */
+    @Deprecated
     protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
             IDispatch pDisp, DISPID dispId, VARIANT pArg) throws COMException {
 
@@ -303,26 +449,19 @@ public class COMBindingBaseObject extends COMInvoker {
     }
 
     /**
-     * Ole method.
-     *
-     * @param nType
-     *            the n type
-     * @param pvResult
-     *            the pv result
-     * @param pDisp
-     *            the disp
-     * @param name
-     *            the name
-     * @return the hresult
-     * @throws COMException
-     *             the cOM exception
+     * @deprecated Use {@link #oleMethod(int, com.sun.jna.platform.win32.Variant.VARIANT.ByReference, java.lang.String)
      */
+    @Deprecated
     protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
             IDispatch pDisp, String name) throws COMException {
 
         return this.oleMethod(nType, pvResult, pDisp, name, (VARIANT[]) null);
     }
 
+    /**
+     * @deprecated Use {@link #oleMethod(int, com.sun.jna.platform.win32.Variant.VARIANT.ByReference, com.sun.jna.platform.win32.OaIdl.DISPID) }
+     */
+    @Deprecated
     protected HRESULT oleMethod(int nType, VARIANT.ByReference pvResult,
             IDispatch pDisp, DISPID dispId) throws COMException {
 
@@ -334,7 +473,9 @@ public class COMBindingBaseObject extends COMInvoker {
      *
      * @param hr
      *            the hr
+     * @deprecated Use {@link COMUtils#checkRC(com.sun.jna.platform.win32.WinNT.HRESULT)
      */
+    @Deprecated
     protected void checkFailed(HRESULT hr) {
         COMUtils.checkRC(hr);
     }

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMEarlyBindingObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMEarlyBindingObject.java
@@ -56,15 +56,13 @@ public class COMEarlyBindingObject extends COMBindingBaseObject implements
 
     protected String getStringProperty(DISPID dispId) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                this.getIDispatch(), dispId);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, dispId);
 
         return result.getValue().toString();
     }
 
     protected void setProperty(DISPID dispId, boolean value) {
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
-                dispId, new VARIANT(value));
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, dispId, new VARIANT(value));
     }
 
     @Override

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
@@ -83,8 +83,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected IDispatch getAutomationProperty(String propertyName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                this.getIDispatch(), propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         return ((IDispatch) result.getValue());
     }
@@ -101,8 +100,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
     protected IDispatch getAutomationProperty(String propertyName,
             COMLateBindingObject comObject) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                comObject.getIDispatch(), propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         return ((IDispatch) result.getValue());
     }
@@ -121,8 +119,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
     protected IDispatch getAutomationProperty(String propertyName,
             COMLateBindingObject comObject, VARIANT value) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                comObject.getIDispatch(), propertyName, value);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName, value);
 
         return ((IDispatch) result.getValue());
     }
@@ -139,8 +136,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
     protected IDispatch getAutomationProperty(String propertyName,
             IDispatch iDispatch) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                iDispatch, propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         return ((IDispatch) result.getValue());
     }
@@ -154,8 +150,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected boolean getBooleanProperty(String propertyName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                this.getIDispatch(), propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         return result.booleanValue();
     }
@@ -169,8 +164,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected Date getDateProperty(String propertyName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                this.getIDispatch(), propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         return result.dateValue();
     }
@@ -184,8 +178,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected int getIntProperty(String propertyName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                this.getIDispatch(), propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         return result.intValue();
     }
@@ -199,8 +192,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected short getShortProperty(String propertyName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                this.getIDispatch(), propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         return result.shortValue();
     }
@@ -214,13 +206,12 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected String getStringProperty(String propertyName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result,
-                this.getIDispatch(), propertyName);
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYGET, result, propertyName);
 
         String res = result.stringValue();
-        
+
         OleAuto.INSTANCE.VariantClear(result);
-        
+
         return res;
     }
 
@@ -233,8 +224,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected VARIANT invoke(String methodName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_METHOD, result, this.getIDispatch(),
-                methodName);
+        this.oleMethod(OleAuto.DISPATCH_METHOD, result, methodName);
 
         return result;
     }
@@ -250,8 +240,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected VARIANT invoke(String methodName, VARIANT arg) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_METHOD, result, this.getIDispatch(),
-                methodName, arg);
+        this.oleMethod(OleAuto.DISPATCH_METHOD, result, methodName, arg);
 
         return result;
     }
@@ -267,8 +256,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected VARIANT invoke(String methodName, VARIANT[] args) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_METHOD, result, this.getIDispatch(),
-                methodName, args);
+        this.oleMethod(OleAuto.DISPATCH_METHOD, result, methodName, args);
 
         return result;
     }
@@ -327,27 +315,18 @@ public class COMLateBindingObject extends COMBindingBaseObject {
     }
 
     /**
-     * Invoke no reply.
-     * 
-     * @param methodName
-     *            the method name
-     * @param dispatch
-     *            the dispatch
+     * @deprecated Use {@link #invokeNoReply(java.lang.String)
      */
+    @Deprecated
     protected void invokeNoReply(String methodName, IDispatch dispatch) {
         this.oleMethod(OleAuto.DISPATCH_METHOD, null, dispatch, methodName);
     }
 
     /**
-     * Invoke no reply.
-     * 
-     * @param methodName
-     *            the method name
-     * @param comObject
-     *            the com object
+     * @deprecated Use {@link #invokeNoReply(java.lang.String)
      */
-    protected void invokeNoReply(String methodName,
-            COMLateBindingObject comObject) {
+    @Deprecated
+    protected void invokeNoReply(String methodName, COMLateBindingObject comObject) {
         this.oleMethod(OleAuto.DISPATCH_METHOD, null, comObject.getIDispatch(),
                 methodName);
     }
@@ -357,34 +336,36 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      * 
      * @param methodName
      *            the method name
-     * @param dispatch
-     *            the dispatch
      * @param arg
      *            the arg
      */
+    protected void invokeNoReply(String methodName, VARIANT arg) {
+        this.oleMethod(OleAuto.DISPATCH_METHOD, null, methodName, arg);
+    }
+
+    /**
+     * @deprecated Use {@link #invokeNoReply(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT)
+     */
+    @Deprecated
     protected void invokeNoReply(String methodName, IDispatch dispatch,
             VARIANT arg) {
         this.oleMethod(OleAuto.DISPATCH_METHOD, null, dispatch, methodName, arg);
     }
 
     /**
-     * Invoke no reply.
-     * 
-     * @param methodName
-     *            the method name
-     * @param dispatch
-     *            the dispatch
-     * @param arg1
-     *            the arg1
-     * @param arg2
-     *            the arg2
+     * @deprecated Use {@link #invokeNoReply(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT[])
      */
+    @Deprecated
     protected void invokeNoReply(String methodName, IDispatch dispatch,
             VARIANT arg1, VARIANT arg2) {
         this.oleMethod(OleAuto.DISPATCH_METHOD, null, dispatch, methodName,
                 new VARIANT[] { arg1, arg2 });
     }
 
+    /**
+     * @deprecated Use {@link #invokeNoReply(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT[])
+     */
+    @Deprecated
     protected void invokeNoReply(String methodName, COMLateBindingObject comObject,
             VARIANT arg1, VARIANT arg2) {
         this.oleMethod(OleAuto.DISPATCH_METHOD, null, comObject.getIDispatch(), methodName,
@@ -392,14 +373,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
     }
 
     /**
-     * Invoke no reply.
-     * 
-     * @param methodName
-     *            the method name
-     * @param comObject
-     *            the com object
-     * @param arg
-     *            the arg
+     * @deprecated Use {@link #invokeNoReply(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT)
      */
     protected void invokeNoReply(String methodName,
             COMLateBindingObject comObject, VARIANT arg) {
@@ -407,16 +381,11 @@ public class COMLateBindingObject extends COMBindingBaseObject {
                 methodName, arg);
     }
 
+
     /**
-     * Invoke no reply.
-     * 
-     * @param methodName
-     *            the method name
-     * @param dispatch
-     *            the dispatch
-     * @param args
-     *            the args
+     * @deprecated Use {@link #invokeNoReply(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT[]) 
      */
+    @Deprecated
     protected void invokeNoReply(String methodName, IDispatch dispatch,
             VARIANT[] args) {
         this.oleMethod(OleAuto.DISPATCH_METHOD, null, dispatch, methodName,
@@ -431,22 +400,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected void invokeNoReply(String methodName) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_METHOD, result, this.getIDispatch(),
-                methodName);
-    }
-
-    /**
-     * Invoke no reply.
-     * 
-     * @param methodName
-     *            the method name
-     * @param arg
-     *            the arg
-     */
-    protected void invokeNoReply(String methodName, VARIANT arg) {
-        VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_METHOD, result, this.getIDispatch(),
-                methodName, arg);
+        this.oleMethod(OleAuto.DISPATCH_METHOD, result, methodName);
     }
 
     /**
@@ -459,8 +413,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      */
     protected void invokeNoReply(String methodName, VARIANT[] args) {
         VARIANT.ByReference result = new VARIANT.ByReference();
-        this.oleMethod(OleAuto.DISPATCH_METHOD, result, this.getIDispatch(),
-                methodName, args);
+        this.oleMethod(OleAuto.DISPATCH_METHOD, result, methodName, args);
     }
 
     /**
@@ -522,8 +475,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      *            the value
      */
     protected void setProperty(String propertyName, boolean value) {
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
-                propertyName, new VARIANT(value));
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, propertyName, new VARIANT(value));
     }
 
     /**
@@ -535,8 +487,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      *            the value
      */
     protected void setProperty(String propertyName, Date value) {
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
-                propertyName, new VARIANT(value));
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, propertyName, new VARIANT(value));
     }
 
     /**
@@ -548,8 +499,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      *            the value
      */
     protected void setProperty(String propertyName, IDispatch value) {
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
-                propertyName, new VARIANT(value));
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, propertyName, new VARIANT(value));
     }
 
     /**
@@ -561,8 +511,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      *            the value
      */
     protected void setProperty(String propertyName, int value) {
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
-                propertyName, new VARIANT(value));
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, propertyName, new VARIANT(value));
     }
 
     /**
@@ -574,8 +523,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      *            the value
      */
     protected void setProperty(String propertyName, short value) {
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
-                propertyName, new VARIANT(value));
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, propertyName, new VARIANT(value));
     }
 
     /**
@@ -587,8 +535,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      *            the value
      */
     protected void setProperty(String propertyName, String value) {
-        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getIDispatch(),
-                propertyName, new VARIANT(value));
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, propertyName, new VARIANT(value));
     }
 
     /**
@@ -596,11 +543,17 @@ public class COMLateBindingObject extends COMBindingBaseObject {
      * 
      * @param propertyName
      *            the property name
-     * @param iDispatch
-     *            the i dispatch
      * @param value
      *            the value
      */
+    protected void setProperty(String propertyName, VARIANT value) {
+        this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, propertyName, value);
+    }
+
+    /**
+     * @deprecated Use {@link #setProperty(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT)}
+     */
+    @Deprecated
     protected void setProperty(String propertyName, IDispatch iDispatch,
             VARIANT value) {
         this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, iDispatch,
@@ -608,15 +561,9 @@ public class COMLateBindingObject extends COMBindingBaseObject {
     }
 
     /**
-     * Sets the property.
-     * 
-     * @param propertyName
-     *            the property name
-     * @param comObject
-     *            the com object
-     * @param value
-     *            the value
+     * @deprecated Use {@link #setProperty(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT)}
      */
+    @Deprecated
     protected void setProperty(String propertyName,
             COMLateBindingObject comObject, VARIANT value) {
         this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null,

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Convert.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/Convert.java
@@ -23,6 +23,7 @@
  */
 package com.sun.jna.platform.win32.COM.util;
 
+import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
 import com.sun.jna.platform.win32.OleAuto;
 import com.sun.jna.platform.win32.Variant;
 import java.lang.reflect.InvocationHandler;
@@ -105,8 +106,8 @@ class Convert {
 			return new VARIANT((String) value);
                 } else if (value instanceof Boolean) {
 			return new VARIANT((Boolean) value);
-                } else if (value instanceof com.sun.jna.platform.win32.COM.IDispatch) {
-			return new VARIANT((com.sun.jna.platform.win32.COM.IDispatch) value);
+                } else if (value instanceof com.sun.jna.platform.win32.COM.Dispatch) {
+			return new VARIANT((com.sun.jna.platform.win32.COM.Dispatch) value);
 		} else if (value instanceof Date) {
 			return new VARIANT((Date) value);
                 } else if (value instanceof Proxy) {
@@ -257,15 +258,19 @@ class Convert {
                     result = value.dateValue();
                 } else if (String.class.equals(targetClass)) {
                     result = value.stringValue();
-                } else if (value.getValue() instanceof com.sun.jna.platform.win32.COM.IDispatch) {
-                    com.sun.jna.platform.win32.COM.IDispatch d = (com.sun.jna.platform.win32.COM.IDispatch) value.getValue();
-                    Object proxy = factory.createProxy(targetClass, d);
-                    // must release a COM reference, createProxy adds one, as does the
-                    // call
-                    if (!addReference) {
-                        int n = d.Release();
+                } else if (value.getValue() instanceof com.sun.jna.platform.win32.COM.Dispatch) {
+                    com.sun.jna.platform.win32.COM.Dispatch d = (com.sun.jna.platform.win32.COM.Dispatch) value.getValue();
+                    if(targetClass != null && targetClass.isInterface()) {
+                        Object proxy = factory.createProxy(targetClass, d);
+                        // must release a COM reference, createProxy adds one, as does the
+                        // call
+                        if (!addReference) {
+                            int n = d.Release();
+                        }
+                        result = proxy;
+                    } else {
+                        result = d;
                     }
-                    result = proxy;
                 } else {
                     /*
                     WinDef.SCODE.class.equals(targetClass) 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
@@ -23,7 +23,6 @@
 package com.sun.jna.platform.win32;
 
 import java.util.Date;
-import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -285,11 +284,20 @@ public interface Variant {
             this.setValue(VT_BOOL, new VARIANT_BOOL(value));
         }
 
+        /**
+         * @deprecated Use {@link #VARIANT(com.sun.jna.platform.win32.COM.Dispatch) 
+         */
+        @Deprecated
         public VARIANT(IDispatch value) {
             this();
             this.setValue(Variant.VT_DISPATCH, value);
         }
 
+        public VARIANT(Dispatch value) {
+            this();
+            this.setValue(Variant.VT_DISPATCH, value);
+        }
+        
         public VARIANT(Date value) {
             this();
             this.setValue(VT_DATE, new DATE(value));


### PR DESCRIPTION
This prepares for API cleanup in JNA 6, where the now
deprecated methods will be removed and the 
COM*Binding objects will be rebased onto Dispatch.