### PR TITLE
Bind `c.s.j.p.win32.Secur32#CompleteAuthToken`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Features
 * [#1029](https://github.com/java-native-access/jna/issues/1029): Add `statvfs` to `c.s.j.platform.linux.LibC` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1032](https://github.com/java-native-access/jna/pull/1032): Deprecate `c.s.j.platform.win32.COM.util.annotation.ComEventCallback` in favour of `c.s.j.platform.win32.COM.util.annotation.ComMethod` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1021](https://github.com/java-native-access/jna/pull/1021): Added `com.sun.jna.platform.linux.XAttr` and `com.sun.jna.platform.linux.XAttrUtil` JNA wrapper for `<sys/xattr.h>` for Linux - [@wilx](https://github.com/wilx).
+* [#381](https://github.com/java-native-access/jna/issues/381): Bind `c.s.j.p.win32.Secur32#CompleteAuthToken` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Secur32.java
@@ -252,7 +252,37 @@ public interface Secur32 extends StdCallLibrary {
                                      SecBufferDesc pInput, int fContextReq, int TargetDataRep,
                                      CtxtHandle phNewContext, SecBufferDesc pOutput, IntByReference pfContextAttr,
                                      TimeStamp ptsTimeStamp);
-    
+
+    /**
+     * The CompleteAuthToken function completes an authentication token. This
+     * function is used by protocols, such as DCE, that need to revise the
+     * security information after the transport application has updated some
+     * message parameters.
+     * <p>
+     * This function is supported only by the Digest security support provider
+     * (SSP).</p>
+     * <p>
+     * CompleteAuthToken is used on the server side only.</p>
+     *
+     * @param phContext A handle of the context that needs to be completed.
+     * @param pToken    A {@link Sspi.SecBufferDesc} structure that contains the
+     *                  buffer descriptor for the entire message.
+     *
+     * @return If the function succeeds, the function returns SEC_E_OK.
+     *
+     * <p>
+     * If the function fails, it returns one of the following error codes.</p>
+     * <table>
+     * <tr><th>Return code</th><th>Description</th></tr>
+     * <tr><td>SEC_E_INVALID_HANDLE</td><td>The handle that was passed to the function is not valid.</td></tr>
+     * <tr><td>SEC_E_INVALID_TOKEN</td><td>The token that was passed to the function is not valid.</td></tr>
+     * <tr><td>SEC_E_OUT_OF_SEQUENCE</td><td>The client's security context was located, but the message number is incorrect. This return value is used with the Digest SSP.</td></tr>
+     * <tr><td>SEC_E_MESSAGE_ALTERED</td><td>The client's security context was located, but the client's message has been tampered with. This return value is used with the Digest SSP.</td></tr>
+     * <tr><td>SEC_E_INTERNAL_ERROR</td><td>An error occurred that did not map to an SSPI error code.</td></tr>
+     * </table>
+     */
+    int CompleteAuthToken(CtxtHandle phContext, SecBufferDesc pToken);
+
     /**
      * The EnumerateSecurityPackages function returns an array of SecPkgInfo structures that 
      * describe the security packages available to the client.

--- a/contrib/platform/test/com/sun/jna/platform/win32/Secur32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Secur32Test.java
@@ -769,4 +769,15 @@ public class Secur32Test extends TestCase {
     	assertEquals(W32Errors.SEC_E_OK, Secur32.INSTANCE.FreeCredentialsHandle(
     			phClientCredential));
     }
+
+    public void testCompleteAuthToken() {
+        /*
+        This is not a real test of the function, it just ensures, that it is
+        callable and returns a sane error code.
+        */
+        int result = Secur32.INSTANCE.CompleteAuthToken(null, null);
+        assertTrue(String.format("Unexpected error code: 0x%08X%n", result),
+                result == WinError.SEC_E_INVALID_HANDLE
+                || result == WinError.SEC_E_INVALID_TOKEN);
+    }
 }


### PR DESCRIPTION
In the unittests the case, where the call to this method would have been
necessary, was not reachable. Therefore no new unittest for this
function was added.