### PR TITLE
Fix loading jnidispatch on android

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Features
 Bug Fixes
 ---------
 * [#1036](https://github.com/java-native-access/jna/issues/1036): `Advapi32Util.registryValueExists` called on non existing key raises exception instead of returning `false` - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#384](https://github.com/java-native-access/jna/issues/384): Android only supports loading libraries through the JVM `System#loadLibrary` mechanism, defaulting `jna.nosys` to `true` disabled that code path - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.1.0
 =============

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ NOTE: as of JNA 4.0, JNA is now dual-licensed under LGPL and AL 2.0 (see LICENSE
 
 NOTE: JNI native support is typically incompatible between minor versions, and almost always incompatible between major versions.
 
-Release 5.1.1 (Next release)
+Release 5.2.0 (Next release)
 ============================
 
 Features

--- a/build.xml
+++ b/build.xml
@@ -52,15 +52,15 @@
   <property name="javadoc" location="${doc}/javadoc"/>
   <property name="stylesheet" location="${javadoc}/doc/css/javadoc.css"/>
   <property name="vendor" value="JNA Development Team"/>
-  <property name="year" value="2017"/>
+  <property name="year" value="2018"/>
   <property name="copyright"
             value="Copyright &amp;copy; 2007-${year} Timothy Wall. All Rights Reserved."/>
   <buildnumber/>
 
   <!-- JNA library release version - android versionCode is derived from mjar/minor/revision -->
   <property name="jna.major" value="5"/>
-  <property name="jna.minor" value="1"/>
-  <property name="jna.revision" value="1"/>
+  <property name="jna.minor" value="2"/>
+  <property name="jna.revision" value="0"/>
   <property name="jna.build" value="0"/> <!--${build.number}-->
   <condition property="version.suffix" value="" else="-SNAPSHOT">
     <or>

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -974,7 +974,7 @@ public final class Native implements Version {
             }
         }
         String jnaNosys = System.getProperty("jna.nosys", "true");
-        if (!Boolean.parseBoolean(jnaNosys)) {
+        if ((!Boolean.parseBoolean(jnaNosys)) || Platform.isAndroid()) {
             try {
                 LOG.log(DEBUG_JNA_LOAD_LEVEL, "Trying (via loadLibrary) {0}", libName);
                 System.loadLibrary(libName);


### PR DESCRIPTION
Android only supports loading libraries through the JVM `System#loadLibrary`
mechanism, defaulting `jna.nosys` to `true` disabled that code path.