### PR TITLE
Avoid exception when getting zero-length xattr on mac

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -989,6 +989,7 @@ Bug Fixes
 * Ensure structure size is calculated prior to converting to array
 * Avoid creating new windows when setting a window mask
 * Fix bug in Pointer.setChar.
+* Avoid IllegalArgumentException when reading xattrs with zero length
 
 Release 3.0
 ===========

--- a/contrib/platform/src/com/sun/jna/platform/linux/XAttrUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/linux/XAttrUtil.java
@@ -255,6 +255,10 @@ public abstract class XAttrUtil {
                 throw new IOException("errno: " + eno);
             }
 
+            if (retval.longValue() == 0) {
+                return null;
+            }
+
             valueMem = new Memory(retval.longValue());
             retval = XAttr.INSTANCE.getxattr(path, name, valueMem, new size_t(valueMem.size()));
             if (retval.longValue() < 0) {
@@ -352,6 +356,10 @@ public abstract class XAttrUtil {
                 throw new IOException("errno: " + eno);
             }
 
+            if (retval.longValue() == 0) {
+                return null;
+            }
+
             valueMem = new Memory(retval.longValue());
             retval = XAttr.INSTANCE.lgetxattr(path, name, valueMem, new size_t(valueMem.size()));
             if (retval.longValue() < 0) {
@@ -443,6 +451,10 @@ public abstract class XAttrUtil {
             if (retval.longValue() < 0) {
                 eno = Native.getLastError();
                 throw new IOException("errno: " + eno);
+            }
+
+            if (retval.longValue() == 0) {
+                return null;
             }
 
             valueMem = new Memory(retval.longValue());

--- a/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
@@ -58,6 +58,9 @@ public class XAttrUtil {
 		if (bufferLength < 0)
 			return null;
 
+		if (bufferLength == 0)
+			return "";
+
 		Memory valueBuffer = new Memory(bufferLength);
 		long valueLength = XAttr.INSTANCE.getxattr(path, name, valueBuffer, bufferLength, 0, 0);
 


### PR DESCRIPTION
On MacOS, reading a zero-sized xattr will result in an IllegalArgumentException:
```
Exception in thread "main" java.lang.IllegalArgumentException: Allocation size must be greater than zero
	at com.sun.jna.Memory.<init>(Memory.java:111)
	at com.sun.jna.platform.mac.XAttrUtil.getXAttr(XAttrUtil.java:61)
```
The code change associated with this pull request returns an empty string before attempting to allocate `Memory(0)`.
- Allowing the caller to distinguish between (an xattr that does not exist, return value=`null`) and (an empty xattr, return value=`""`).

This only appears to be a problem on MacOS' implementation of `getXAttr()`.  Linux will return an empty string.
- The Linux version does have `getXAttrAsMemory()` methods that will produce a similar problem, but I'm not sure what would be the most appropriate: (IllegalArgumentException, IOException, null return value) --so I didn't make any changes.