### PR TITLE
WinXP Compatibility for PdhUtil#PdhLookupPerfNameByIndex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Features
 
 Bug Fixes
 ---------
-* [#1052](https://github.com/java-native-access/jna/issues/1052): WinXP compatibility for `c.s.j.p.win32.PdhUtil` - [@dbwiddis](https://github.com/dbwiddis).
+* [#1052](https://github.com/java-native-access/jna/issues/1052), [#1053](https://github.com/java-native-access/jna/issues/1053): WinXP compatibility for `c.s.j.p.win32.PdhUtil` - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.2.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/PdhUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/PdhUtil.java
@@ -94,9 +94,9 @@ public abstract class PdhUtil {
         
         // Convert buffer to Java String
         if (CHAR_TO_BYTES == 1) {
-            return mem.getString(0);
+            return mem.getString(0); // NOSONAR squid:S2259
         } else {
-            return mem.getWideString(0);
+            return mem.getWideString(0); // NOSONAR squid:S2259
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/PdhUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/PdhUtil.java
@@ -62,25 +62,33 @@ public abstract class PdhUtil {
         // Call once with null buffer to get required buffer size
         DWORDByReference pcchNameBufferSize = new DWORDByReference(new DWORD(0));
         int result = Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, null, pcchNameBufferSize);
-        // Windows XP requires a non-null buffer
-        if (result == PdhMsg.PDH_INVALID_ARGUMENT) {
-            pcchNameBufferSize = new DWORDByReference(new DWORD(1));
-            result = Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, new Memory(1),
-                    pcchNameBufferSize);
+        Memory mem = null;
+        // Windows XP requires a non-null buffer and nonzero buffer size and
+        // will return PDH_INVALID_ARGUMENT.
+        if (result != PdhMsg.PDH_INVALID_ARGUMENT) {
+            // Vista+ branch: use returned buffer size for second query
+            if (result != WinError.ERROR_SUCCESS && result != Pdh.PDH_MORE_DATA) {
+                throw new PdhException(result);
+            }
+            // Can't allocate 0 memory
+            if (pcchNameBufferSize.getValue().intValue() < 1) {
+                return "";
+            }
+            // Allocate buffer and call again
+            mem = new Memory(pcchNameBufferSize.getValue().intValue() * CHAR_TO_BYTES);
+            result = Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, mem, pcchNameBufferSize);
+        } else {
+            // XP branch: try increasing buffer sizes until successful
+            for (int bufferSize = 32; bufferSize <= Pdh.PDH_MAX_COUNTER_NAME; bufferSize *= 2) {
+                pcchNameBufferSize = new DWORDByReference(new DWORD(bufferSize));
+                mem = new Memory(bufferSize * CHAR_TO_BYTES);
+                result = Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, mem, pcchNameBufferSize);
+                if (result != PdhMsg.PDH_INVALID_ARGUMENT && result != PdhMsg.PDH_INSUFFICIENT_BUFFER) {
+                    break;
+                }
+            }
         }
-        if (result != WinError.ERROR_SUCCESS && result != Pdh.PDH_MORE_DATA && result != Pdh.PDH_INSUFFICIENT_BUFFER) {
-            throw new PdhException(result);
-        }
-        
-        // Can't allocate 0 memory
-        if (pcchNameBufferSize.getValue().intValue() < 1) {
-            return "";
-        }
-        // Allocate buffer and call again
-        Memory mem = new Memory(pcchNameBufferSize.getValue().intValue() * CHAR_TO_BYTES);
-        result = Pdh.INSTANCE.PdhLookupPerfNameByIndex(szMachineName, dwNameIndex, mem, pcchNameBufferSize);
-
-        if(result != WinError.ERROR_SUCCESS) {
+        if (result != WinError.ERROR_SUCCESS) {
             throw new PdhException(result);
         }
         


### PR DESCRIPTION
While the fix in #1052 worked on one XP system it did not work on another. Not sure if it was character encoding or bitness or something else, but [the docs](https://docs.microsoft.com/en-us/windows/desktop/api/pdh/nf-pdh-pdhlookupperfnamebyindexa) were also unclear as to the behavior of the buffer length value:
> The function sets pcchNameBufferSize to either the required size or the size of the buffer that was used.

And also suggesting error code response varied:
> PDH_INVALID_ARGUMENT ... on some releases you could receive this error if the specified size on input is greater than zero but less than the required size.

This second fix should work and passes tests on a few different XP VMs.  Vista+ does the "pass null, get size, get result" calls.  For XP the buffer is incremented until it succeeds so we don't have to rely on the returned size.
