### PR TITLE
Update W32Service.stopService() to be more resilient to large dwWaitH…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Next release (5.3.0)
 
 Features
 --------
+* [#1058](https://github.com/java-native-access/jna/pull/1058): Add selectable timeout to stopService() and improve timeout handling - [@keithharp](https://github.com/keithharp).
 * [#1050](https://github.com/java-native-access/jna/pull/1050): Add `c.s.j.p.win32.VersionHelpers` and supporting functions - [@dbwiddis](https://github.com/dbwiddis).
 
 Bug Fixes

--- a/contrib/platform/src/com/sun/jna/platform/win32/W32Service.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/W32Service.java
@@ -242,7 +242,7 @@ public class W32Service implements Closeable {
 				throw new RuntimeException(String.format("Service stop exceeded timeout time of %d ms", timeout));
 			}
 
-			int dwWaitTime = Math.min(sanitizeWaitTime(status.dwWaitHint), (int)msRemainingBeforeTimeout);
+			long dwWaitTime = Math.min(sanitizeWaitTime(status.dwWaitHint), msRemainingBeforeTimeout);
 
 			try {
 				Thread.sleep( dwWaitTime );


### PR DESCRIPTION
…int values

-- make stopService(long timeout) public so that 30 seconds is not the only valid timeout
-- never wait more than the current timeout
-- if the service stops during the last sleep, do not throw an exception
-- use the preexisting timing logic in waitForNonPendingState to sleep fractions of the total dwWaitHint instead of the entire time
-- get rid of some leftover code that no longer served a purpose