### PR TITLE
Use correct native library on OpenJDK on AIX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Bug Fixes
 ---------
 * [#1052](https://github.com/java-native-access/jna/pull/1052), [#1053](https://github.com/java-native-access/jna/issues/1053): WinXP compatibility for `c.s.j.p.win32.PdhUtil` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1055](https://github.com/java-native-access/jna/pull/1055): Include `c.s.j.p.linux` in OSGi bundle. - [@dbwiddis](https://github.com/dbwiddis).
+* [#1066](https://github.com/java-native-access/jna/issues/1066): On AIX OpenJDK differs from IBM J9 in the mapping of library names. While J9 maps jnidispatch to `libjnidispatch.a`, OpenJDK maps to `libjnidispatch.so`, which causes the native library extractor to fail. AIX is now hard-coded to `libjnidispatch.a` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.2.0
 =============

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -999,7 +999,13 @@ public final class Native implements Version {
      */
     private static void loadNativeDispatchLibraryFromClasspath() {
         try {
-            String libName = "/com/sun/jna/" + Platform.RESOURCE_PREFIX + "/" + System.mapLibraryName("jnidispatch").replace(".dylib", ".jnilib");
+            String mappedName = System.mapLibraryName("jnidispatch").replace(".dylib", ".jnilib");
+            if(Platform.isAIX()) {
+                // OpenJDK is reported to map to .so -- this works around the
+                // difference between J9 and OpenJDK
+                mappedName = "libjnidispatch.a";
+            }
+            String libName = "/com/sun/jna/" + Platform.RESOURCE_PREFIX + "/" + mappedName;
             File lib = extractFromResourcePath(libName, Native.class.getClassLoader());
             if (lib == null) {
                 if (lib == null) {


### PR DESCRIPTION
It seems System#mapLibraryName from OpenJDK works differently on AIX
than J9. J9 expands jnidispatch to libjnidispatch.a, while OpenJDK expands
it to libjnidispatch.so. This in turn causes the loader to search for the wrong file.

https://github.com/java-native-access/jna/issues/1066

Closes: #1066