### PR TITLE
Always causes ArrayIndexOutOfBoundsException

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
@@ -672,7 +672,7 @@ public abstract class Kernel32Util implements WinDef {
         WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION firstInformation = new WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION(
                 memory);
         return (WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[]) firstInformation
-                .toArray(new WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[0]);
+                .toArray(new WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[((SYSTEM_LOGICAL_PROCESSOR_INFORMATION[])firstInformation).length]);
     }
 
     /**


### PR DESCRIPTION
https://github.com/java-native-access/jna/blob/db28278447a82bf7dd4e2fe8e73df80398c92235/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java#L675

at this line, spesifiying Array's length as 0 does cause ArrayIndexOutOfBoundsException. Either need to alter Structure.java's toArray method or some change in here. I am bit new in java and github so there might be better solution than writing "((SYSTEM_LOGICAL_PROCESSOR_INFORMATION[])firstInformation).length" instead of "0".  If my solution is wrong or there is better solution please consider this propose of file change as bug report.
If somehow this isn't bug please give me some pointers so that i can learn

