### PR TITLE
[GITHUB-1087] Fix wrong calls to Structure#toArray with zero sized arrays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 Bug Fixes
 ---------
 * [#1089](https://github.com/java-native-access/jna/issues/1089): `c.s.j.internal.ReflectionUtils` accesses `java.lang.invoke.MethodType` without reflection, causing `java.lang.NoClassDefFoundError` on android API level < 26 - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1087](https://github.com/java-native-access/jna/pull/1087): Fix wrong calls to Structure#toArray with zero sized arrays - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.3.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32Util.java
@@ -670,9 +670,11 @@ public abstract class Kernel32Util implements WinDef {
             }
         }
         WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION firstInformation = new WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION(
-                memory);
+            memory);
+        int returnedStructCount = bufferSize.getValue().intValue()
+            / sizePerStruct;
         return (WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[]) firstInformation
-                .toArray(new WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[0]);
+                .toArray(new WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[returnedStructCount]);
     }
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
@@ -636,7 +636,7 @@ public abstract class Netapi32Util {
         }
         try {
             DS_DOMAIN_TRUSTS domainTrustRefs = new DS_DOMAIN_TRUSTS(domainsPointerRef.getValue());
-            DS_DOMAIN_TRUSTS[] domainTrusts = (DS_DOMAIN_TRUSTS[]) domainTrustRefs.toArray(new DS_DOMAIN_TRUSTS[0]);
+            DS_DOMAIN_TRUSTS[] domainTrusts = (DS_DOMAIN_TRUSTS[]) domainTrustRefs.toArray(new DS_DOMAIN_TRUSTS[domainTrustCount.getValue()]);
             ArrayList<DomainTrust> trusts = new ArrayList<DomainTrust>(domainTrustCount.getValue());
             for(DS_DOMAIN_TRUSTS domainTrust : domainTrusts) {
                 DomainTrust t = new DomainTrust();

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
@@ -46,6 +46,7 @@ import com.sun.jna.platform.win32.WinNT.LOGICAL_PROCESSOR_RELATIONSHIP;
 import com.sun.jna.platform.win32.WinNT.NUMA_NODE_RELATIONSHIP;
 import com.sun.jna.platform.win32.WinNT.PROCESSOR_CACHE_TYPE;
 import com.sun.jna.platform.win32.WinNT.PROCESSOR_RELATIONSHIP;
+import com.sun.jna.platform.win32.WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION;
 import com.sun.jna.platform.win32.WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
 
 import junit.framework.TestCase;
@@ -365,6 +366,12 @@ public class Kernel32UtilTest extends TestCase {
     public void testExpandEnvironmentStrings() {
         Kernel32.INSTANCE.SetEnvironmentVariable("DemoVariable", "DemoValue");
         assertEquals("DemoValue", Kernel32Util.expandEnvironmentStrings("%DemoVariable%"));
+    }
+
+    public void testGetLogicalProcessorInformation() {
+        SYSTEM_LOGICAL_PROCESSOR_INFORMATION[] procInfo = Kernel32Util
+                .getLogicalProcessorInformation();
+        assertTrue(procInfo.length > 0);
     }
 
     public void testGetLogicalProcessorInformationEx() {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Netapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Netapi32Test.java
@@ -260,7 +260,7 @@ public class Netapi32Test extends TestCase {
         assertTrue(domainTrustCount.getValue() >= 0);
 
         DS_DOMAIN_TRUSTS domainTrustRefs = new DS_DOMAIN_TRUSTS(domainsPointerRef.getValue());
-        DS_DOMAIN_TRUSTS[] domainTrusts = (DS_DOMAIN_TRUSTS[]) domainTrustRefs.toArray(new DS_DOMAIN_TRUSTS[0]);
+        DS_DOMAIN_TRUSTS[] domainTrusts = (DS_DOMAIN_TRUSTS[]) domainTrustRefs.toArray(new DS_DOMAIN_TRUSTS[domainTrustCount.getValue()]);
 
         for (DS_DOMAIN_TRUSTS trust : domainTrusts) {
             assertTrue(trust.DnsDomainName.length() > 0);


### PR DESCRIPTION
As a performance optimization calls to Collections#toArray where changed
from providing a correctly sized array to using a zero sized array.

See 07f3ce053d947adadf80a20e8acf8caffca8b6cd

The change is invalid if the object toArray is called on is a Structure,
the calls just look the same. This changeset is a partial revert of the
above mentioned commit.

Closes: #1087