### PR TITLE
[GITHUB-1089] Fix missing reflection use in `c.s.j.internal.ReflectionUtils`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Features
 
 Bug Fixes
 ---------
+* [#1089](https://github.com/java-native-access/jna/issues/1089): `c.s.j.internal.ReflectionUtils` accesses `java.lang.invoke.MethodType` without reflection, causing `java.lang.NoClassDefFoundError` on android API level < 26 - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.3.0
 =============

--- a/src/com/sun/jna/internal/ReflectionUtils.java
+++ b/src/com/sun/jna/internal/ReflectionUtils.java
@@ -23,7 +23,6 @@
  */
 package com.sun.jna.internal;
 
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -74,7 +73,7 @@ public class ReflectionUtils {
         METHOD_HANDLES_LOOKUP = lookupMethod(methodHandles, "lookup");
         METHOD_HANDLES_LOOKUP_IN = lookupMethod(lookup, "in", Class.class);
         METHOD_HANDLES_LOOKUP_UNREFLECT_SPECIAL = lookupMethod(lookup, "unreflectSpecial", Method.class, Class.class);
-        METHOD_HANDLES_LOOKUP_FIND_SPECIAL = lookupMethod(lookup, "findSpecial", Class.class, String.class, MethodType.class, Class.class);
+        METHOD_HANDLES_LOOKUP_FIND_SPECIAL = lookupMethod(lookup, "findSpecial", Class.class, String.class, methodType, Class.class);
         METHOD_HANDLES_BIND_TO = lookupMethod(methodHandle, "bindTo", Object.class);
         METHOD_HANDLES_INVOKE_WITH_ARGUMENTS = lookupMethod(methodHandle, "invokeWithArguments", Object[].class);
         METHOD_HANDLES_PRIVATE_LOOKUP_IN = lookupMethod(methodHandles, "privateLookupIn", Class.class, lookup);


### PR DESCRIPTION
`c.s.j.internal.ReflectionUtils` accesses `java.lang.invoke.MethodType`
without reflection, causing `java.lang.NoClassDefFoundError`
on android API level < 26

MethodType is already accessed via reflection and just for the method
lookup the class literal was used. The literal use was removed and
replaced with the class already looked up via reflection.

Closes: #1089