### PR TITLE
Jhoward/macos xattr get all chars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Features
 
 Bug Fixes
 ---------
+* Avoid truncating final character when macOS getXAttr reads a non-null-terminated xattr, e.g. an xattr created using `xattr -w user.sample 1 myfile.txt`.
 * [#1091](https://github.com/java-native-access/jna/issues/1091): Check target number to be greater than zero, before calling `Structure#toArray` in `c.s.j.p.win32.Netapi32Util` - [@trevormagg](https://github.com/trevormaggs), [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.3.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 Bug Fixes
 ---------
 * Avoid truncating final character when macOS getXAttr reads a non-null-terminated xattr, e.g. an xattr created using `xattr -w user.sample 1 myfile.txt`.
+* Avoid including null termination as part of macOS setXAttr.
 * [#1091](https://github.com/java-native-access/jna/issues/1091): Check target number to be greater than zero, before calling `Structure#toArray` in `c.s.j.p.win32.Netapi32Util` - [@trevormagg](https://github.com/trevormaggs), [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.3.1

--- a/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
@@ -67,12 +67,12 @@ public class XAttrUtil {
         if (valueLength < 0)
             return null;
 
-        return decodeString(valueBuffer.getByteBuffer(0, valueLength)).replace("\0","");
+        return decodeString(valueBuffer.getByteBuffer(0, valueLength));
     }
 
     public static int setXAttr(String path, String name, String value) {
         Memory valueBuffer = encodeString(value);
-        return XAttr.INSTANCE.setxattr(path, name, valueBuffer, valueBuffer.size(), 0, 0);
+        return XAttr.INSTANCE.setxattr(path, name, valueBuffer, valueBuffer.size() - 1, 0, 0);
     }
 
     public static int removeXAttr(String path, String name) {

--- a/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
@@ -67,7 +67,7 @@ public class XAttrUtil {
         if (valueLength < 0)
             return null;
 
-        return decodeString(valueBuffer.getByteBuffer(0, valueLength - 1));
+        return decodeString(valueBuffer.getByteBuffer(0, valueLength)).replace("\0","");
     }
 
     public static int setXAttr(String path, String name, String value) {


### PR DESCRIPTION
On macOS:
- `XAttrUtil.setXAttr()` was including a bonus `\0` char to the end of all xattrs it created.
- `XAttrUtil.getXAttr()` was compensating/removing the bonus `\0` char.  This means all unit tests pass, but macOS JNA is unable to consume xattrs created via the command line.  Any xattrs created via the command line will have their final char truncated.

Here is an example file with two xattrs.  Each xattr is supposed to have a value of "1".  The first was created using JNA, and the second was created using `xattr -w user.samplecli 1 /tmp/jrh.jrh`
```
JRHMBP:jna jhoward$ xattr -l /tmp/jrh.jrh
user.samplejna:
00000000  31 00                                            |1.|
00000002
user.samplecli: 1
```

The change associated with this PR is pretty straightforward.  Let me know if you have any questions.