### PR TITLE
Deprecate EventLogRecord#getEventId in favor of #getInstanceId

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Next release (5.4.0)
 
 Features
 --------
+* [#1105](https://github.com/java-native-access/jna/issues/1105): Deprecate `c.s.j.p.win32.Advapi32Util.EventLogRecord#getEventId` in favor of `#getInstanceId` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1097](https://github.com/java-native-access/jna/issues/1097): Allow `.ocx` as extension of native libraries on windows - [@dmigowski](https://github.com/dmigowski).
 
 Bug Fixes

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -92,7 +93,6 @@ import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.W32APITypeMapper;
-import java.util.List;
 
 /**
  * Advapi32 utility API.
@@ -2342,10 +2342,23 @@ public abstract class Advapi32Util {
         }
 
         /**
-         * Event Id.
+         * The Instance ID, a resource identifier that corresponds to a string
+         * definition in the message resource file of the event source. The
+         * Event ID is the Instance ID with the top two bits masked off.
          *
-         * @return Integer.
+         * @return An integer representing the 32-bit Instance ID.
          */
+        public int getInstanceId() {
+            return _record.EventID.intValue();
+        }
+
+        /**
+         * @deprecated As of 5.4.0, replaced by {@link #getInstanceId()}. The
+         *             Event ID displayed in the Windows Event Viewer
+         *             corresponds to {@link #getStatusCode()} for
+         *             system-generated events.
+         */
+        @Deprecated
         public int getEventId() {
             return _record.EventID.intValue();
         }
@@ -2360,9 +2373,11 @@ public abstract class Advapi32Util {
         }
 
         /**
-         * Status code for the facility, part of the Event ID.
+         * Status code, the rightmost 16 bits of the Instance ID. Corresponds to
+         * the Event ID field in the Windows Event Viewer for system-generated
+         * events.
          *
-         * @return Status code.
+         * @return An integer representing the low 16-bits of the Instance ID.
          */
         public int getStatusCode() {
             return _record.EventID.intValue() & 0xFFFF;

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -103,7 +103,6 @@ import junit.framework.TestCase;
 public class Advapi32Test extends TestCase {
 
     private static final String EVERYONE = "S-1-1-0";
-    private static final int EVENT_LOG_STARTED = 6005;
 
     public static void main(String[] args) {
         junit.textui.TestRunner.run(Advapi32Test.class);
@@ -956,13 +955,29 @@ public class Advapi32Test extends TestCase {
         m.setByte(1, (byte) 2);
         m.setByte(2, (byte) 3);
         m.setByte(3, (byte) 4);
-        assertTrue(Advapi32.INSTANCE.ReportEvent(h, WinNT.EVENTLOG_ERROR_TYPE, 0, 0, null, 2, 4, s, m));
+        int eventId = 123 + 0x40000000;
+        assertTrue(Advapi32.INSTANCE.ReportEvent(h, WinNT.EVENTLOG_ERROR_TYPE, 0, eventId, null, 2, 4, s, m));
         IntByReference after = new IntByReference();
         assertTrue(Advapi32.INSTANCE.GetNumberOfEventLogRecords(h, after));
         assertTrue(before.getValue() < after.getValue());
         assertFalse(h.equals(WinBase.INVALID_HANDLE_VALUE));
         assertTrue(Advapi32.INSTANCE.DeregisterEventSource(h));
         Advapi32Util.registryDeleteKey(WinReg.HKEY_LOCAL_MACHINE, jnaEventSourceRegistryPath);
+
+        // Test the event record
+        EventLogIterator iter = new EventLogIterator(null, "Application", WinNT.EVENTLOG_BACKWARDS_READ);
+        while (iter.hasNext()) {
+            EventLogRecord record = iter.next();
+            if (record.getRecord().EventID.getLow().intValue() == 123 && record.getStrings().length > 1
+                    && "JNA".equals(record.getStrings()[0]) && "Event".equals(record.getStrings()[1])) {
+                // Test Status Code stripping top 16 bits
+                assertEquals(123, record.getStatusCode());
+                // Test InstanceId
+                assertEquals(123 | 0x40000000, record.getInstanceId());
+                // Test Event ID stripping top 2 bits from InstanceId
+                assertEquals(123, record.getInstanceId() & 0x3FFFFFFF);
+            }
+        }
     }
 
     public void testGetNumberOfEventLogRecords() {
@@ -1065,21 +1080,6 @@ public class Advapi32Test extends TestCase {
                    rc == W32Errors.ERROR_HANDLE_EOF || rc == 0);
         assertTrue("Error closing event log",
                    Advapi32.INSTANCE.CloseEventLog(h));
-    }
-
-    public void testGetInstanceId() {
-        // Iterate System log for "The Event log service was started"
-        EventLogIterator iter = new EventLogIterator("System");
-        while (iter.hasNext()) {
-            EventLogRecord record = iter.next();
-            // Search explicitly using only the low 16 bits
-            if (record.getRecord().EventID.getLow().intValue() == EVENT_LOG_STARTED) {
-                // Test Status Code stripping top 16 bits
-                assertEquals(EVENT_LOG_STARTED, record.getStatusCode());
-                // Test Event ID stripping top 2 bits
-                assertEquals(EVENT_LOG_STARTED, record.getInstanceId() & 0x3FFFFFFF);
-            }
-        }
     }
 
     public void testGetOldestEventLogRecord() {


### PR DESCRIPTION
The terms "Event ID" and "event identifier" refer to different things, which leads to confusion and probably led to .NET deprecating the former term. JNA should do the same.