### PR TITLE
Added JString type for passing Java String into JNI methods with jstring

### DIFF
--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -1813,7 +1813,7 @@ dispatch_direct(ffi_cif* cif, void* volatile resp, void** argp, void *cdata) {
         *(void **)args[i] = (void*)env;
         break;
       case CVT_JSTRING:
-        *(void **)args[i] = (jstring)*(void **)args[i];
+        *(void **)args[i] = (*env)->CallObjectMethod(env, *(void **)args[i], MID_Object_toString);
         break;
       case CVT_STRUCTURE:
         objects[i] = *(void **)args[i];

--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -1812,6 +1812,9 @@ dispatch_direct(ffi_cif* cif, void* volatile resp, void** argp, void *cdata) {
       case CVT_JNIENV:
         *(void **)args[i] = (void*)env;
         break;
+      case CVT_JSTRING:
+        *(void **)args[i] = (jstring)*(void **)args[i];
+        break;
       case CVT_STRUCTURE:
         objects[i] = *(void **)args[i];
         writeStructure(env, *(void **)args[i]);

--- a/native/dispatch.h
+++ b/native/dispatch.h
@@ -117,6 +117,7 @@ enum {
   CVT_TYPE_MAPPER_WSTRING = com_sun_jna_Native_CVT_TYPE_MAPPER_WSTRING,
   CVT_OBJECT = com_sun_jna_Native_CVT_OBJECT,
   CVT_JNIENV = com_sun_jna_Native_CVT_JNIENV,
+  CVT_JSTRING = com_sun_jna_Native_CVT_JSTRING,
 };
 
 /* callback behavior flags */

--- a/native/testlib.c
+++ b/native/testlib.c
@@ -1039,6 +1039,12 @@ returnClass(JNIEnv *env, jobject arg) {
   return (*env)->GetObjectClass(env, arg);
 }
 
+EXPORT jboolean
+testJStringArgument(JNIEnv *env, jstring jstr) {
+  int length = (*env)->GetStringUTFLength(env, jstr);
+  return length > 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -620,6 +620,8 @@ public class Function extends Pointer {
         } else if (argClass.isArray()){
             throw new IllegalArgumentException("Unsupported array argument type: "
                                                + argClass.getComponentType());
+        } else if (JString.class == argClass) {
+            return arg.toString();
         } else if (allowObjects) {
             return arg;
         } else if (!Native.isSupportedNativeType(arg.getClass())) {

--- a/src/com/sun/jna/JString.java
+++ b/src/com/sun/jna/JString.java
@@ -1,0 +1,74 @@
+/*
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna;
+
+/** Provides support to call JNI methods via JNA, where one of the parameters required is "jstring"
+ *
+ * @author  Nathan Robinson, nathan@dorkbox.com
+ */
+public
+class JString implements CharSequence, Comparable {
+    private String string;
+
+    public JString(String s) {
+        if (s == null) {
+            throw new NullPointerException("String initializer must be non-null");
+        }
+        this.string = s;
+    }
+
+    @Override
+    public String toString() {
+        return string;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof JString) && toString().equals(o.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        return toString().compareTo(o.toString());
+    }
+
+    @Override
+    public int length() {
+        return toString().length();
+    }
+
+    @Override
+    public char charAt(int index) {
+        return toString().charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return toString().subSequence(start, end);
+    }
+}

--- a/src/com/sun/jna/JString.java
+++ b/src/com/sun/jna/JString.java
@@ -26,8 +26,7 @@ package com.sun.jna;
  *
  * @author  Nathan Robinson, nathan@dorkbox.com
  */
-public
-class JString implements CharSequence, Comparable {
+public class JString implements CharSequence, Comparable {
     private final String string;
 
     public JString(String s) {

--- a/src/com/sun/jna/JString.java
+++ b/src/com/sun/jna/JString.java
@@ -28,7 +28,7 @@ package com.sun.jna;
  */
 public
 class JString implements CharSequence, Comparable {
-    private String string;
+    private final String string;
 
     public JString(String s) {
         if (s == null) {

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -60,11 +60,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.sun.jna.Callback.UncaughtExceptionHandler;
 import com.sun.jna.Structure.FFIType;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /** Provides generation of invocation plumbing for a defined native
  * library interface.  Also provides various utilities for native operations.
@@ -1619,6 +1619,7 @@ public final class Native implements Version {
     private static final int CVT_TYPE_MAPPER_WSTRING = 25;
     private static final int CVT_OBJECT = 26;
     private static final int CVT_JNIENV = 27;
+    private static final int CVT_JSTRING = 28;
 
     private static int getConversion(Class<?> type, TypeMapper mapper, boolean allowObjects) {
         if (type == Void.class) type = void.class;
@@ -1703,6 +1704,9 @@ public final class Native implements Version {
         }
         if (JNIEnv.class == type) {
             return CVT_JNIENV;
+        }
+        if (JString.class == type) {
+            return CVT_JSTRING;
         }
         return allowObjects ? CVT_OBJECT : CVT_UNSUPPORTED;
     }

--- a/test/com/sun/jna/JStringDirectArgumentsTest.java
+++ b/test/com/sun/jna/JStringDirectArgumentsTest.java
@@ -1,0 +1,59 @@
+/* Copyright (c) 2009 Timothy Wall, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna;
+
+import java.util.HashMap;
+
+/** Exercise a range of native methods.
+ *
+ * @author twall@users.sf.net
+ */
+public class JStringDirectArgumentsTest extends JstringArgumentTest {
+
+    public static class DirectTestLibrary implements JStringTestLibrary {
+        @Override
+        public native boolean testJStringArgument(JNIEnv env, JString jstring);
+
+        static {
+            // we have to support objects (for JString/JNIEnv tests)
+            HashMap<String, Object> options = new HashMap<String, Object>();
+            options.put(Library.OPTION_ALLOW_OBJECTS, Boolean.TRUE);
+            options.put(Library.OPTION_CLASSLOADER, DirectTestLibrary.class.getClassLoader());
+
+            NativeLibrary library = NativeLibrary.getInstance("testlib", options);
+
+            Native.register(DirectTestLibrary.class, library);
+        }
+    }
+
+    /* Override original. */
+    @Override
+    protected void setUp() {
+        lib = new DirectTestLibrary();
+    }
+
+    public static void main(String[] argList) {
+        junit.textui.TestRunner.run(JStringDirectArgumentsTest.class);
+    }
+}

--- a/test/com/sun/jna/JstringArgumentTest.java
+++ b/test/com/sun/jna/JstringArgumentTest.java
@@ -1,0 +1,69 @@
+/* Copyright (c) 2007 Timothy Wall, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna;
+
+import java.util.HashMap;
+
+import com.sun.jna.DirectArgumentsMarshalTest.DirectTestLibrary;
+
+import junit.framework.TestCase;
+
+/** Exercise a range of native methods.
+ *
+ * @author twall@users.sf.net
+ */
+public class JstringArgumentTest extends TestCase {
+
+    public static interface JStringTestLibrary extends Library {
+        // test passing jstring without converting to const char *
+        boolean testJStringArgument(JNIEnv env, JString jstring);
+    }
+
+    JStringTestLibrary lib;
+
+    @Override
+    protected void setUp() {
+        // we have to support objects (for JString/JNIEnv tests)
+        HashMap<String, Object> options = new HashMap<String, Object>();
+        options.put(Library.OPTION_ALLOW_OBJECTS, Boolean.TRUE);
+        options.put(Library.OPTION_CLASSLOADER, DirectTestLibrary.class.getClassLoader());
+
+        lib = Native.load("testlib", JStringTestLibrary.class, options);
+    }
+
+    @Override
+    protected void tearDown() {
+        lib = null;
+    }
+
+    public void testJStringArgument() {
+        assertEquals("Error passing jstring as argument to native method", true,
+                     lib.testJStringArgument(JNIEnv.CURRENT, new JString("test string")));
+    }
+
+
+    public static void main(String[] argList) {
+        junit.textui.TestRunner.run(JstringArgumentTest.class);
+    }
+}


### PR DESCRIPTION
As per issue https://github.com/java-native-access/jna/issues/1099, this PR adds the ability to pass a Java `String` to a native method that uses `jstring`, instead of `const char *`.

To use this, just change the method parameter from `String` to `JString`, and change the passed in string from a `String text` to `new JString(text)`.