### PR TITLE
 [GITHUB-1118] Ensure union with floating point and integer member is passed in integer register

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Bug Fixes
 * [#1128](https://github.com/java-native-access/jna/issues/1128): KEY_ALL_ACCESS value is incorrect in `c.s.j.p.win32.WinNT.java` - [@trevormaggs](https://github.com/trevormaggs).
 * [#1133](https://github.com/java-native-access/jna/issues/1133): Ensure JARs created from the build system don't contain invalid `Info-ZIP Unicode Path` extra info - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1134](https://github.com/java-native-access/jna/issues/1134): Read correct member of `WinBase.SYSTEM_INFO.processorArchitecture` union - [@dbwiddis](https://github.com/dbwiddis).
+* [#1118](https://github.com/java-native-access/jna/issues/1118): Fix passing unions containing integer and floating point members as parameters by value - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.4.0
 =============

--- a/native/testlib.c
+++ b/native/testlib.c
@@ -946,6 +946,24 @@ returnStringVarArgs2(const char *fmt, ...) {
   return cp;
 }
 
+typedef union _MixedUnion1 {
+  int intValue;
+  double doubleValue;
+} MixedUnion1;
+
+EXPORT
+int stringifyMixedUnion1(
+        char* buffer, int bufferLength,
+        int dummyInt1, double dummyDouble1,
+        MixedUnion1 union1, MixedUnion1 union2,
+        int dummyInt2, double dummyDouble2) {
+    return snprintf(
+            buffer, bufferLength - 1,
+            "dummyInt1: %d, dummyDouble1: %.0f, dummyInt2: %d, dummyDouble2: %.0f, union1.intValue: %d, union2.doubleValue: %.0f",
+            dummyInt1, dummyDouble1, dummyInt2, dummyDouble2,
+            union1.intValue, union2.doubleValue);
+}
+
 #if defined(_WIN32) && !defined(_WIN64) && !defined(_WIN32_WCE)
 ///////////////////////////////////////////////////////////////////////
 // stdcall tests

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -1770,27 +1770,27 @@ public final class Native implements Version {
                     // FFIType.get() always looks up the native type for any given
                     // class, so if we actually have conversion into a Java
                     // object, make sure we use the proper type information
-                    closure_rtype = FFIType.get(rclass.isPrimitive() ? rclass : Pointer.class).peer;
-                    rtype = FFIType.get(fromNative.nativeType()).peer;
+                    closure_rtype = FFIType.get(rclass.isPrimitive() ? rclass : Pointer.class).getPointer().peer;
+                    rtype = FFIType.get(fromNative.nativeType()).getPointer().peer;
                     break;
                 case CVT_NATIVE_MAPPED:
                 case CVT_NATIVE_MAPPED_STRING:
                 case CVT_NATIVE_MAPPED_WSTRING:
                 case CVT_INTEGER_TYPE:
                 case CVT_POINTER_TYPE:
-                    closure_rtype = FFIType.get(Pointer.class).peer;
-                    rtype = FFIType.get(NativeMappedConverter.getInstance(rclass).nativeType()).peer;
+                    closure_rtype = FFIType.get(Pointer.class).getPointer().peer;
+                    rtype = FFIType.get(NativeMappedConverter.getInstance(rclass).nativeType()).getPointer().peer;
                     break;
                 case CVT_STRUCTURE:
                 case CVT_OBJECT:
-                    closure_rtype = rtype = FFIType.get(Pointer.class).peer;
+                    closure_rtype = rtype = FFIType.get(Pointer.class).getPointer().peer;
                     break;
                 case CVT_STRUCTURE_BYVAL:
-                    closure_rtype = FFIType.get(Pointer.class).peer;
-                    rtype = FFIType.get(rclass).peer;
+                    closure_rtype = FFIType.get(Pointer.class).getPointer().peer;
+                    rtype = FFIType.get(rclass).getPointer().peer;
                     break;
                 default:
-                    closure_rtype = rtype = FFIType.get(rclass).peer;
+                    closure_rtype = rtype = FFIType.get(rclass).getPointer().peer;
             }
 
             for (int t=0;t < ptypes.length;t++) {
@@ -1822,20 +1822,20 @@ public final class Native implements Version {
                     case CVT_NATIVE_MAPPED:
                     case CVT_NATIVE_MAPPED_STRING:
                     case CVT_NATIVE_MAPPED_WSTRING:
-                        atypes[t] = FFIType.get(type).peer;
-                        closure_atypes[t] = FFIType.get(Pointer.class).peer;
+                        atypes[t] = FFIType.get(type).getPointer().peer;
+                        closure_atypes[t] = FFIType.get(Pointer.class).getPointer().peer;
                         break;
                     case CVT_TYPE_MAPPER:
                     case CVT_TYPE_MAPPER_STRING:
                     case CVT_TYPE_MAPPER_WSTRING:
-                        closure_atypes[t] = FFIType.get(type.isPrimitive() ? type : Pointer.class).peer;
-                        atypes[t] = FFIType.get(toNative[t].nativeType()).peer;
+                        closure_atypes[t] = FFIType.get(type.isPrimitive() ? type : Pointer.class).getPointer().peer;
+                        atypes[t] = FFIType.get(toNative[t].nativeType()).getPointer().peer;
                         break;
                     case CVT_DEFAULT:
-                        closure_atypes[t] = atypes[t] = FFIType.get(type).peer;
+                        closure_atypes[t] = atypes[t] = FFIType.get(type).getPointer().peer;
                         break;
                     default:
-                        closure_atypes[t] = atypes[t] = FFIType.get(Pointer.class).peer;
+                        closure_atypes[t] = atypes[t] = FFIType.get(Pointer.class).getPointer().peer;
                 }
             }
             sig += ")";

--- a/test/com/sun/jna/DirectArgumentsMarshalTest.java
+++ b/test/com/sun/jna/DirectArgumentsMarshalTest.java
@@ -123,6 +123,13 @@ public class DirectArgumentsMarshalTest extends ArgumentsMarshalTest {
         @Override
         public native void setCallbackInStruct(CbStruct s);
 
+        @Override
+        public native int stringifyMixedUnion1(
+            byte[] buffer, int bufferLength,
+            int dummyInt1, double dummyDouble1,
+            MixedUnion1.ByValue union1, MixedUnion1.ByValue union2,
+            int dummyInt2, double dummyDouble2);
+
         static {
             Native.register("testlib");
         }

--- a/test/com/sun/jna/PerformanceTest.java
+++ b/test/com/sun/jna/PerformanceTest.java
@@ -163,8 +163,8 @@ public class PerformanceTest extends TestCase implements Paths {
         long resp;
         long argv;
         if (Native.POINTER_SIZE == 4) {
-            b.putInt(0, (int)Structure.FFIType.get(double.class).peer);
-            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(double.class).peer, types);
+            b.putInt(0, (int)Structure.FFIType.get(double.class).getPointer().peer);
+            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(double.class).getPointer().peer, types);
             resp = pb.peer + 4;
             argv = pb.peer + 12;
             double INPUT = 42;
@@ -178,8 +178,8 @@ public class PerformanceTest extends TestCase implements Paths {
             delta = System.currentTimeMillis() - start;
         }
         else {
-            b.putLong(0, Structure.FFIType.get(double.class).peer);
-            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(double.class).peer, types);
+            b.putLong(0, Structure.FFIType.get(double.class).getPointer().peer);
+            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(double.class).getPointer().peer, types);
             resp = pb.peer + 8;
             argv = pb.peer + 16;
             double INPUT = 42;
@@ -305,10 +305,10 @@ public class PerformanceTest extends TestCase implements Paths {
         System.out.println("memset (JNA direct primitives): " + delta + "ms");
 
         if (Native.POINTER_SIZE == 4) {
-            b.putInt(0, (int)Structure.FFIType.get(Pointer.class).peer);
-            b.putInt(4, (int)Structure.FFIType.get(int.class).peer);
-            b.putInt(8, (int)Structure.FFIType.get(int.class).peer);
-            cif = Native.ffi_prep_cif(0, 3, Structure.FFIType.get(Pointer.class).peer, types);
+            b.putInt(0, (int)Structure.FFIType.get(Pointer.class).getPointer().peer);
+            b.putInt(4, (int)Structure.FFIType.get(int.class).getPointer().peer);
+            b.putInt(8, (int)Structure.FFIType.get(int.class).getPointer().peer);
+            cif = Native.ffi_prep_cif(0, 3, Structure.FFIType.get(Pointer.class).getPointer().peer, types);
             resp = pb.peer + 12;
             argv = pb.peer + 16;
             start = System.currentTimeMillis();
@@ -325,10 +325,10 @@ public class PerformanceTest extends TestCase implements Paths {
             delta = System.currentTimeMillis() - start;
         }
         else {
-            b.putLong(0, Structure.FFIType.get(Pointer.class).peer);
-            b.putLong(8, Structure.FFIType.get(int.class).peer);
-            b.putLong(16, Structure.FFIType.get(long.class).peer);
-            cif = Native.ffi_prep_cif(0, 3, Structure.FFIType.get(Pointer.class).peer, types);
+            b.putLong(0, Structure.FFIType.get(Pointer.class).getPointer().peer);
+            b.putLong(8, Structure.FFIType.get(int.class).getPointer().peer);
+            b.putLong(16, Structure.FFIType.get(long.class).getPointer().peer);
+            cif = Native.ffi_prep_cif(0, 3, Structure.FFIType.get(Pointer.class).getPointer().peer, types);
             resp = pb.peer + 24;
             argv = pb.peer + 32;
             start = System.currentTimeMillis();
@@ -405,8 +405,8 @@ public class PerformanceTest extends TestCase implements Paths {
         System.out.println("strlen (JNA direct - Buffer): " + delta + "ms");
 
         if (Native.POINTER_SIZE == 4) {
-            b.putInt(0, (int)Structure.FFIType.get(Pointer.class).peer);
-            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(int.class).peer, types);
+            b.putInt(0, (int)Structure.FFIType.get(Pointer.class).getPointer().peer);
+            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(int.class).getPointer().peer, types);
             resp = pb.peer + 4;
             argv = pb.peer + 8;
             start = System.currentTimeMillis();
@@ -423,8 +423,8 @@ public class PerformanceTest extends TestCase implements Paths {
             delta = System.currentTimeMillis() - start;
         }
         else {
-            b.putLong(0, Structure.FFIType.get(Pointer.class).peer);
-            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(long.class).peer, types);
+            b.putLong(0, Structure.FFIType.get(Pointer.class).getPointer().peer);
+            cif = Native.ffi_prep_cif(0, 1, Structure.FFIType.get(long.class).getPointer().peer, types);
             resp = pb.peer + 8;
             argv = pb.peer + 16;
             start = System.currentTimeMillis();

--- a/test/com/sun/jna/StructureTest.java
+++ b/test/com/sun/jna/StructureTest.java
@@ -1388,7 +1388,7 @@ public class StructureTest extends TestCase {
         assertEquals("Wrong type information for 'inner' field",
                      inner, els.getPointer(0));
         assertEquals("Wrong type information for integer field",
-                     Structure.getTypeInfo(Integer.valueOf(0)),
+                     Structure.getTypeInfo(0).getPointer(),
                      els.getPointer(Native.POINTER_SIZE));
         assertNull("Type element list should be null-terminated",
                    els.getPointer(Native.POINTER_SIZE*2));
@@ -2163,7 +2163,7 @@ public class StructureTest extends TestCase {
         Structure s = new TestStructure();
         assertEquals("Wrong type mapper for structure", mapper, s.getTypeMapper());
 
-        TestFFIType ffi_type = new TestFFIType(Structure.getTypeInfo(s));
+        TestFFIType ffi_type = new TestFFIType(Structure.getTypeInfo(s).getPointer());
         assertEquals("Java Structure size does not match FFIType size",
                      s.size(), ffi_type.size.intValue());
     }

--- a/test/com/sun/jna/UnionTest.java
+++ b/test/com/sun/jna/UnionTest.java
@@ -171,12 +171,12 @@ public class UnionTest extends TestCase {
         assertNotNull("Type information is missing for union instance", u.getTypeInfo());
         if (Native.POINTER_SIZE == 4) {
             assertEquals("Type size should be that of largest field if no field is active",
-                         Structure.getTypeInfo(BigTestStructure.class).getInt(0),
+                         Structure.getTypeInfo(BigTestStructure.class).getPointer().getInt(0),
                          u.getTypeInfo().getInt(0));
         }
         else {
             assertEquals("Type size should be that of largest field if no field is active",
-                         Structure.getTypeInfo(BigTestStructure.class).getLong(0),
+                         Structure.getTypeInfo(BigTestStructure.class).getPointer().getLong(0),
                          u.getTypeInfo().getLong(0));
         }
         u.setType(int.class);
@@ -184,12 +184,12 @@ public class UnionTest extends TestCase {
         assertNotNull("Type information is missing for union instance after type set", u.getTypeInfo());
         if (Native.POINTER_SIZE == 4) {
             assertEquals("Type size should be that of largest field if any field is active",
-                         Structure.getTypeInfo(BigTestStructure.class).getInt(0),
+                         Structure.getTypeInfo(BigTestStructure.class).getPointer().getInt(0),
                          u.getTypeInfo().getInt(0));
         }
         else {
             assertEquals("Type size should be that of largest field if any field is active",
-                         Structure.getTypeInfo(BigTestStructure.class).getLong(0),
+                         Structure.getTypeInfo(BigTestStructure.class).getPointer().getLong(0),
                          u.getTypeInfo().getLong(0));
         }
     }


### PR DESCRIPTION
System V x86-64 ABI requires, that in a union aggregate, that contains
Integer and Double members, the parameters must be passed in the integer
registers. I.e. in the case where the java side declares double and int
members, the wrong FFI Type would be found, because the doubles size is
larger than the int member, but the wrong parameter passing method would
be used.