### PR TITLE
Windows expects Unicode String for IShellFolder#ParseDisplayName

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 Bug Fixes
 ---------
 * [#1115](https://github.com/java-native-access/jna/issues/1115): Fix signature for `c.s.j.p.win32.Kernel32#CreateRemoteThread` and bind `VirtualAllocEx`, `VirtualFreeEx`, `GetExitCodeThread` in `c.s.j.p.win32.Kernel32` - [@apangin](https://github.com/apangin), [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1127](https://github.com/java-native-access/jna/issues/1127): Windows needs a wide string in `c.s.j.p.win32.COM.IShellFolder#ParseDisplayName` - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.4.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IShellFolder.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IShellFolder.java
@@ -27,6 +27,7 @@ package com.sun.jna.platform.win32.COM;
  */
 
 import com.sun.jna.Function;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Guid.IID;
 import com.sun.jna.platform.win32.Guid.REFIID;
@@ -480,7 +481,11 @@ public interface IShellFolder {
                 @Override
                 public WinNT.HRESULT ParseDisplayName(WinDef.HWND hwnd, Pointer pbc, String pszDisplayName, IntByReference pchEaten, PointerByReference ppidl, IntByReference pdwAttributes) {
                     Function f = Function.getFunction(vTable[3], Function.ALT_CONVENTION);
-                    return new WinNT.HRESULT(f.invokeInt(new Object[]{interfacePointer, hwnd, pbc, pszDisplayName, pchEaten, ppidl, pdwAttributes}));
+                    // pszDisplayName is mapped as String but Windows needs
+                    // Wide String. Convert and pass here.
+                    char[] pszDisplayNameNative = Native.toCharArray(pszDisplayName);
+                    return new WinNT.HRESULT(f.invokeInt(new Object[] { interfacePointer, hwnd, pbc,
+                        pszDisplayNameNative, pchEaten, ppidl, pdwAttributes }));
                 }
 
                 @Override

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IShellFolderTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IShellFolderTest.java
@@ -27,12 +27,18 @@ package com.sun.jna.platform.win32.COM;
  */
 
 import com.sun.jna.Pointer;
-import junit.framework.TestCase;
-
-import com.sun.jna.platform.win32.*;
+import com.sun.jna.platform.win32.Guid;
 import com.sun.jna.platform.win32.Guid.REFIID;
+import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.ShTypes.STRRET;
+import com.sun.jna.platform.win32.Shell32;
+import com.sun.jna.platform.win32.ShlObj;
+import com.sun.jna.platform.win32.Shlwapi;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
+
+import junit.framework.TestCase;
 
 public class IShellFolderTest extends TestCase {
     static {
@@ -101,5 +107,21 @@ public class IShellFolderTest extends TestCase {
         }
         peidl.Release();
         assertTrue(sawNames); // We should see at least one item with a name
+    }
+
+    public void testParseDisplayName() throws Exception {
+        String directory = System.getenv("WinDir");
+
+        IntByReference pchEaten = new IntByReference();
+        PointerByReference ppidl = new PointerByReference();
+        IntByReference pdwAttributes = new IntByReference();
+        PointerByReference desktopFolder = new PointerByReference();
+
+        WinNT.HRESULT hResult = Shell32.INSTANCE.SHGetDesktopFolder(desktopFolder);
+        assertEquals(COMUtils.S_OK, hResult.intValue());
+
+        IShellFolder shellFolder = IShellFolder.Converter.PointerToIShellFolder(desktopFolder);
+        hResult = shellFolder.ParseDisplayName(null, null, directory, pchEaten, ppidl, pdwAttributes);
+        assertEquals(COMUtils.S_OK, hResult.intValue());
     }
 }


### PR DESCRIPTION
IShellFolder#ParseDisplayName third argument requires a null-terminated wide string in Windows but is mapped as a String.    Initial commit is failing testcase.