### PR TITLE
Bug fix required in WinNT.java

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Bug Fixes
 ---------
 * [#1115](https://github.com/java-native-access/jna/issues/1115): Fix signature for `c.s.j.p.win32.Kernel32#CreateRemoteThread` and bind `VirtualAllocEx`, `VirtualFreeEx`, `GetExitCodeThread` in `c.s.j.p.win32.Kernel32` - [@apangin](https://github.com/apangin), [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1127](https://github.com/java-native-access/jna/issues/1127): Windows needs a wide string in `c.s.j.p.win32.COM.IShellFolder#ParseDisplayName` - [@dbwiddis](https://github.com/dbwiddis).
-* [#1128](https://github.com/java-native-access/jna/issues/1128): KEY_ALL_ACCESS value is incorrect in c.s.j.p.win32.WinNT.java - [@trevormaggs](https://github.com/trevormaggs).
+* [#1128](https://github.com/java-native-access/jna/issues/1128): KEY_ALL_ACCESS value is incorrect in `c.s.j.p.win32.WinNT.java` - [@trevormaggs](https://github.com/trevormaggs).
 
 Release 5.4.0
 =============

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Bug Fixes
 ---------
 * [#1115](https://github.com/java-native-access/jna/issues/1115): Fix signature for `c.s.j.p.win32.Kernel32#CreateRemoteThread` and bind `VirtualAllocEx`, `VirtualFreeEx`, `GetExitCodeThread` in `c.s.j.p.win32.Kernel32` - [@apangin](https://github.com/apangin), [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1127](https://github.com/java-native-access/jna/issues/1127): Windows needs a wide string in `c.s.j.p.win32.COM.IShellFolder#ParseDisplayName` - [@dbwiddis](https://github.com/dbwiddis).
+* [#1128](https://github.com/java-native-access/jna/issues/1128): KEY_ALL_ACCESS value is incorrect in c.s.j.p.win32.WinNT.java - [@trevormaggs](https://github.com/trevormaggs).
 
 Release 5.4.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -919,9 +919,9 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
 
     int KEY_EXECUTE = KEY_READ & (~SYNCHRONIZE);
 
-    int KEY_ALL_ACCESS = STANDARD_RIGHTS_ALL | KEY_QUERY_VALUE | KEY_SET_VALUE
-            | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY
-            | KEY_CREATE_LINK & (~SYNCHRONIZE);
+    int KEY_ALL_ACCESS = ((STANDARD_RIGHTS_ALL | KEY_QUERY_VALUE | KEY_SET_VALUE
+            | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY 
+            | KEY_CREATE_LINK) & (~SYNCHRONIZE));
 
     //
     // Open/Create Options

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -920,7 +920,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
     int KEY_EXECUTE = KEY_READ & (~SYNCHRONIZE);
 
     int KEY_ALL_ACCESS = ((STANDARD_RIGHTS_ALL | KEY_QUERY_VALUE | KEY_SET_VALUE
-            | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY 
+            | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY
             | KEY_CREATE_LINK) & (~SYNCHRONIZE));
 
     //


### PR DESCRIPTION
Please refer to Issue #1128 (KEY_ALL_ACCESS value is incorrect in WinNT.java) for details. There is an explanation why it needs to be fixed. 

In short, The KEY_ALL_ACCESS variable has missing parentheses and that gives an incorrect ORed value. It should match with the original winnt.h C header file in Win32.

