### PR TITLE
Null checks on HANDLE compared to int (0)

### DIFF
--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -23,6 +23,10 @@
  */
 package com.sun.jna.platform.win32;
 
+import static com.sun.jna.platform.win32.WinBase.WAIT_OBJECT_0;
+import static com.sun.jna.platform.win32.WinNT.MEM_COMMIT;
+import static com.sun.jna.platform.win32.WinNT.MEM_RESERVE;
+import static com.sun.jna.platform.win32.WinNT.PAGE_EXECUTE_READWRITE;
 import static com.sun.jna.platform.win32.WinioctlUtil.FSCTL_GET_COMPRESSION;
 import static com.sun.jna.platform.win32.WinioctlUtil.FSCTL_GET_REPARSE_POINT;
 import static com.sun.jna.platform.win32.WinioctlUtil.FSCTL_SET_COMPRESSION;
@@ -47,6 +51,10 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
@@ -66,7 +74,6 @@ import com.sun.jna.platform.win32.WinBase.FILE_STANDARD_INFO;
 import com.sun.jna.platform.win32.WinBase.MEMORYSTATUSEX;
 import com.sun.jna.platform.win32.WinBase.SYSTEMTIME;
 import com.sun.jna.platform.win32.WinBase.SYSTEM_INFO;
-import static com.sun.jna.platform.win32.WinBase.WAIT_OBJECT_0;
 import com.sun.jna.platform.win32.WinBase.WIN32_FIND_DATA;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.DWORDByReference;
@@ -76,18 +83,12 @@ import com.sun.jna.platform.win32.WinDef.USHORT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.platform.win32.WinNT.MEMORY_BASIC_INFORMATION;
-import static com.sun.jna.platform.win32.WinNT.MEM_COMMIT;
-import static com.sun.jna.platform.win32.WinNT.MEM_RESERVE;
 import com.sun.jna.platform.win32.WinNT.OSVERSIONINFO;
 import com.sun.jna.platform.win32.WinNT.OSVERSIONINFOEX;
-import static com.sun.jna.platform.win32.WinNT.PAGE_EXECUTE_READWRITE;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.ShortByReference;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import junit.framework.TestCase;
-import org.junit.Test;
 
 public class Kernel32Test extends TestCase {
 
@@ -372,14 +373,14 @@ public class Kernel32Test extends TestCase {
     public void testGetCurrentThread() {
         HANDLE h = Kernel32.INSTANCE.GetCurrentThread();
         assertNotNull("No current thread handle", h);
-        assertFalse("Null current thread handle", h.equals(0));
+        assertFalse("Null current thread handle", h.getPointer().equals(Pointer.NULL));
     }
 
     public void testOpenThread() {
         HANDLE h = Kernel32.INSTANCE.OpenThread(WinNT.THREAD_ALL_ACCESS, false,
                 Kernel32.INSTANCE.GetCurrentThreadId());
         assertNotNull(h);
-        assertFalse(h.equals(0));
+        assertFalse(h.getPointer().equals(Pointer.NULL));
         Kernel32Util.closeHandle(h);
     }
 
@@ -390,7 +391,7 @@ public class Kernel32Test extends TestCase {
     public void testGetCurrentProcess() {
         HANDLE h = Kernel32.INSTANCE.GetCurrentProcess();
         assertNotNull("No current process handle", h);
-        assertFalse("Null current process handle", h.equals(0));
+        assertFalse("Null current process handle", h.getPointer().equals(Pointer.NULL));
     }
 
     public void testOpenProcess() {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -373,14 +373,14 @@ public class Kernel32Test extends TestCase {
     public void testGetCurrentThread() {
         HANDLE h = Kernel32.INSTANCE.GetCurrentThread();
         assertNotNull("No current thread handle", h);
-        assertFalse("Null current thread handle", h.getPointer().equals(Pointer.NULL));
+        assertNotNull("Null current thread handle", h.getPointer());
     }
 
     public void testOpenThread() {
         HANDLE h = Kernel32.INSTANCE.OpenThread(WinNT.THREAD_ALL_ACCESS, false,
                 Kernel32.INSTANCE.GetCurrentThreadId());
         assertNotNull(h);
-        assertFalse(h.getPointer().equals(Pointer.NULL));
+        assertNotNull(h.getPointer());
         Kernel32Util.closeHandle(h);
     }
 
@@ -391,7 +391,7 @@ public class Kernel32Test extends TestCase {
     public void testGetCurrentProcess() {
         HANDLE h = Kernel32.INSTANCE.GetCurrentProcess();
         assertNotNull("No current process handle", h);
-        assertFalse("Null current process handle", h.getPointer().equals(Pointer.NULL));
+        assertNotNull("Null current process handle", h.getPointer());
     }
 
     public void testOpenProcess() {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Ole32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Ole32Test.java
@@ -106,7 +106,7 @@ public class Ole32Test extends TestCase {
                 // aggregation
                 WTypes.CLSCTX_LOCAL_SERVER, riid, pDispatch);
         assertTrue(W32Errors.SUCCEEDED(hr.intValue()));
-        assertTrue(!pDispatch.getValue().equals(Pointer.NULL));
+        assertNotNull(pDispatch.getValue());
         // We leak this iUnknown reference because we don't have the JNACOM lib
         // here to wrap the native iUnknown pointer and call iUnknown.release()
         if (W32Errors.SUCCEEDED(hrCI.intValue())) {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Ole32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Ole32Test.java
@@ -23,13 +23,13 @@
  */
 package com.sun.jna.platform.win32;
 
-import junit.framework.TestCase;
-
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
 import com.sun.jna.ptr.PointerByReference;
+
+import junit.framework.TestCase;
 
 /**
  * @author dblock[at]dblock[dot]org
@@ -106,7 +106,7 @@ public class Ole32Test extends TestCase {
                 // aggregation
                 WTypes.CLSCTX_LOCAL_SERVER, riid, pDispatch);
         assertTrue(W32Errors.SUCCEEDED(hr.intValue()));
-        assertTrue(!pDispatch.equals(Pointer.NULL));
+        assertTrue(!pDispatch.getValue().equals(Pointer.NULL));
         // We leak this iUnknown reference because we don't have the JNACOM lib
         // here to wrap the native iUnknown pointer and call iUnknown.release()
         if (W32Errors.SUCCEEDED(hrCI.intValue())) {

--- a/test/com/sun/jna/StructureTest.java
+++ b/test/com/sun/jna/StructureTest.java
@@ -31,13 +31,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import junit.framework.TestCase;
-
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.Structure.StructureSet;
 import com.sun.jna.ptr.ByteByReference;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
+
+import junit.framework.TestCase;
 
 /** TODO: need more alignment tests, especially platform-specific behavior
  * @author twall@users.sf.net
@@ -1785,6 +1785,7 @@ public class StructureTest extends TestCase {
         assertNotNull("Field should not be null after read", s.field);
     }
 
+    @SuppressWarnings("unlikely-arg-type")
     public void testStructureEquals() {
         class OtherStructure extends Structure {
             public int first;


### PR DESCRIPTION
Happened to notice some warnings in which Handles were compared as equals to integers, which doesn't seem like the intent.  Since `HANDLE` doesn't override `equals()` I updated to what I think they were supposed to test. 

Similar type comparison in [StructureTest.java lines 1815 and 1816](https://github.com/java-native-access/jna/blob/cc1acdac02e4d0dda93ba01bbe3a3435b8933dab/test/com/sun/jna/StructureTest.java#L1815) where there is an equals, but this one appears intended to test the `equals()` method, so I added `@SuppressWarnings` annotation.