### PR TITLE
Force read of processorArchitecture member of SYSTEM_INFO union

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Bug Fixes
 * [#1127](https://github.com/java-native-access/jna/issues/1127): Windows needs a wide string in `c.s.j.p.win32.COM.IShellFolder#ParseDisplayName` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1128](https://github.com/java-native-access/jna/issues/1128): KEY_ALL_ACCESS value is incorrect in `c.s.j.p.win32.WinNT.java` - [@trevormaggs](https://github.com/trevormaggs).
 * [#1133](https://github.com/java-native-access/jna/issues/1133): Ensure JARs created from the build system don't contain invalid `Info-ZIP Unicode Path` extra info - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1134](https://github.com/java-native-access/jna/issues/1134): Read correct member of `WinBase.SYSTEM_INFO.processorArchitecture` union - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.4.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -1176,6 +1176,18 @@ public interface WinBase extends WinDef, BaseTSD {
              * Processor architecture (unnamed struct).
              */
             public PI pi;
+
+            @Override
+            public void read() {
+                // dwOemID is obsolete but users may have come to rely on its value because it
+                // was initialized by default, so we retain its initialization for
+                // compatibility.
+                setType("dwOemID");
+                super.read();
+                // pi requires type defined for initialization as a structure.
+                setType("pi");
+                super.read();
+            }
         }
 
         /**
@@ -1226,14 +1238,6 @@ public interface WinBase extends WinDef, BaseTSD {
          * Architecture-dependent processor revision.
          */
         public WORD wProcessorRevision;
-
-        // the dwOemID union member is obsolete. Force read of pi instead.
-        @Override
-        public void read() {
-            super.read();
-            processorArchitecture.setType(PI.class);
-            processorArchitecture.read();
-        }
     }
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -1226,6 +1226,14 @@ public interface WinBase extends WinDef, BaseTSD {
          * Architecture-dependent processor revision.
          */
         public WORD wProcessorRevision;
+
+        // the dwOemID union member is obsolete. Force read of pi instead.
+        @Override
+        public void read() {
+            super.read();
+            processorArchitecture.setType(PI.class);
+            processorArchitecture.read();
+        }
     }
 
     /**

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -524,6 +524,10 @@ public class Kernel32Test extends TestCase {
         SYSTEM_INFO lpSystemInfo = new SYSTEM_INFO();
         Kernel32.INSTANCE.GetSystemInfo(lpSystemInfo);
         assertTrue(lpSystemInfo.dwNumberOfProcessors.intValue() > 0);
+        // the dwOemID member is obsolete, but gets a value.
+        // the pi member is a structure and isn't read by default
+        assertEquals(lpSystemInfo.processorArchitecture.dwOemID.getLow(),
+                lpSystemInfo.processorArchitecture.pi.wProcessorArchitecture);
     }
 
     public void testGetSystemTimes() {


### PR DESCRIPTION
Per [MSDN docs](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info), the `dwOemID` member of the `SYSTEM_INFO.processorArchitecture` union is obsolete.  The correct `pi` member of the union is a structure and isn't read by default. This change sets the type so the structure can be read.  Fixes #1057 
