### PR TITLE
reduced memory footprint of com.sun.jna.Memory

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
@@ -387,7 +387,6 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
         for (int i = 0; i < vargs.length; ++i) {
             vargs[i] = Convert.toVariant(args[i]);
         }
-        Variant.VARIANT.ByReference result = new Variant.VARIANT.ByReference();
         WinNT.HRESULT hr = this.oleMethod(OleAuto.DISPATCH_PROPERTYPUT, null, this.getRawDispatch(), dispID, vargs);
 
         for (int i = 0; i < vargs.length; i++) {

--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -205,9 +205,12 @@ public class Memory extends Pointer {
         try {
             free(peer);
         } finally {
-            if (maintainMap) {
-                synchronized (allocatedMemory) {
+            synchronized (allocatedMemory) {
+                if (maintainMap) {
                     allocatedMemory.remove(this);
+                } else {
+                    // ensures the stale map entries are removed from the map
+                    allocatedMemory.size();
                 }
             }
             peer = 0;

--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -87,6 +87,10 @@ public class Memory extends Pointer {
             this.size = size;
             this.peer = Memory.this.peer + offset;
         }
+        @Override
+        protected void finalize() {
+            dispose();
+        }
         /** No need to free memory. */
         @Override
         protected synchronized void dispose() {

--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -65,12 +65,12 @@ public class Memory extends Pointer {
     /** Dispose of all allocated memory. */
     public static void disposeAll() {
         List<Memory> refs;
-        
+
         synchronized(allocatedMemory) {
             refs = new ArrayList<Memory>(allocatedMemory.keySet());
             allocatedMemory.clear();
         }
-        
+
         for (Memory r : refs) {
             // we cleared the map before, no need to maintain it
             r.dispose0(false);
@@ -189,7 +189,7 @@ public class Memory extends Pointer {
     @Override
     protected void finalize() {
         // if the dispose call is done by the Finalizer the key is not accessible in a WeakHashMap any more
-        // the call of allocatedMemory.remove is a waste of cpu time in this case    
+        // the call of allocatedMemory.remove is a waste of cpu time in this case
         dispose0(false);
     }
 
@@ -197,9 +197,9 @@ public class Memory extends Pointer {
     protected void dispose() {
         dispose0(true);
     }
-    
+
     /** Used to handle different types of dispose calls.
-     * @param maintainMap whether the {@code allocatedMemory} map needs to be updated 
+     * @param maintainMap whether the {@code allocatedMemory} map needs to be updated
      */
     private synchronized void dispose0(boolean maintainMap) {
         try {

--- a/test/com/sun/jna/MemoryTest.java
+++ b/test/com/sun/jna/MemoryTest.java
@@ -190,7 +190,7 @@ public class MemoryTest extends TestCase {
         // get a reference to the allocated memory
         Field allocatedMemoryField = Memory.class.getDeclaredField("allocatedMemory");
         allocatedMemoryField.setAccessible(true);
-        Map<Memory, Reference<Memory>> allocatedMemory = (Map<Memory, Reference<Memory>>) allocatedMemoryField.get(null);
+        Map<Memory, Boolean> allocatedMemory = (Map<Memory, Boolean>) allocatedMemoryField.get(null);
         assertEquals(0, allocatedMemory.size());
 
         // Test allocation and ensure it is accounted for


### PR DESCRIPTION
The allocatedMemory Map had a unused WeakReference as value (the key is a WeakReference to the same Memory instance) and was updated in cases the Map was allready cleared.

I will do some further testing of the change in the next days and post an update here.