### PR TITLE
SystemB extends LibCAPI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Next Release (5.5.0)
 Features
 --------
 * [#1131](https://github.com/java-native-access/jna/pull/1131): Add CoreFoundation, IOKit, and DiskArbitration mappings in `c.s.j.p.mac`. [@dbwiddis](https://github.com/dbwiddis).
+* [#1143](https://github.com/java-native-access/jna/pull/1143): `c.s.j.p.mac.SystemB` now extends `c.s.j.p.unix.LibCAPI`. [@dbwiddis](https://github.com/dbwiddis).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/mac/SystemB.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/SystemB.java
@@ -30,11 +30,12 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.platform.unix.LibCAPI;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
 
-public interface SystemB extends Library {
+public interface SystemB extends LibCAPI, Library {
 
     SystemB INSTANCE = Native.load("System", SystemB.class);
 
@@ -729,24 +730,6 @@ public interface SystemB extends Library {
      */
     int host_processor_info(int hostPort, int flavor, IntByReference procCount, PointerByReference procInfo,
             IntByReference procInfoCount);
-
-    /**
-     * The getloadavg() function returns the number of processes in the system run
-     * queue averaged over various periods of time. Up to nelem samples are
-     * retrieved and assigned to successive elements of loadavg[]. The system
-     * imposes a maximum of 3 samples, representing averages over the last 1, 5, and
-     * 15 minutes, respectively.
-     *
-     * @param loadavg
-     *            An array of doubles which will be filled with the results
-     * @param nelem
-     *            Number of samples to return
-     * @return If the load average was unobtainable, -1 is returned; otherwise, the
-     *         number of samples actually retrieved is returned.
-     * @see <A HREF=
-     *      "https://www.freebsd.org/cgi/man.cgi?query=getloadavg&sektion=3">getloadavg(3)</A>
-     */
-    int getloadavg(double[] loadavg, int nelem);
 
     /**
      * This function searches the password database for the given user uid, always

--- a/contrib/platform/test/com/sun/jna/platform/mac/SystemBTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/mac/SystemBTest.java
@@ -25,6 +25,9 @@ package com.sun.jna.platform.mac;
 
 import static org.junit.Assert.assertNotEquals;
 
+import java.util.Date;
+import java.util.Map;
+
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
@@ -167,6 +170,31 @@ public class SystemBTest extends TestCase {
                 procInfoCount.getValue());
     }
 
+    // From Unix LibCAPI
+    public void testGetenv() {
+        Map<String, String> env = System.getenv();
+        for (Map.Entry<String, String> ee : env.entrySet()) {
+            String name = ee.getKey();
+            String expected = ee.getValue();
+            String actual = SystemB.INSTANCE.getenv(name);
+            assertEquals(name, expected, actual);
+        }
+    }
+
+    // From Unix LibCAPI
+    public void testSetenv() {
+        String name = "SystemBTestEnv";
+        try {
+            String expected = new Date(System.currentTimeMillis()).toString();
+            assertEquals("setenv", 0, SystemB.INSTANCE.setenv(name, expected, 1));
+            assertEquals("Mismatched values", expected, SystemB.INSTANCE.getenv(name));
+            assertEquals("unsetenv", 0, SystemB.INSTANCE.unsetenv(name));
+        } finally {
+            SystemB.INSTANCE.unsetenv(name);
+        }
+    }
+
+    // From Unix LibCAPI
     public void testGetLoadAvg() {
         double[] loadavg = new double[3];
         int retval = SystemB.INSTANCE.getloadavg(loadavg, 3);
@@ -174,6 +202,16 @@ public class SystemBTest extends TestCase {
         assertTrue(loadavg[0] >= 0);
         assertTrue(loadavg[1] >= 0);
         assertTrue(loadavg[2] >= 0);
+    }
+
+    // From Unix LibCAPI
+    public void testGethostnameGetdomainname() {
+        byte[] buffer = new byte[256];
+        assertEquals("gethostname", 0, SystemB.INSTANCE.gethostname(buffer, buffer.length));
+        String hostname = Native.toString(buffer);
+        assertTrue(hostname.length() > 0);
+        assertEquals("getdomainname", 0, SystemB.INSTANCE.getdomainname(buffer, buffer.length));
+        // May have length 0
     }
 
     public void testTimeofDay() {


### PR DESCRIPTION
On macOS, the `System` framework includes the C library headers (`libc`) so it is appropriate to extend the `LibCAPI` class rather than duplicating Unix method mappings.