### PR TITLE
Update OSGi headers for the JNA bundle to support 32bit ARM on Raspberry Pi 3 B+

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -475,6 +475,8 @@ com/sun/jna/linux-x86-64/libjnidispatch.so;
 processor=x86-64;osname=linux,
 com/sun/jna/linux-arm/libjnidispatch.so;
 processor=arm;osname=linux,
+com/sun/jna/linux-arm/libjnidispatch.so;
+processor=arm_le;osname=linux,
 com/sun/jna/linux-armel/libjnidispatch.so;
 processor=armel;osname=linux,
 com/sun/jna/linux-aarch64/libjnidispatch.so;


### PR DESCRIPTION
This PR updates the build of the JNA OSGi bundle to support an additional processor architecture to allow the bundle to be installed on OSGi running on Raspberry Pi 3 B+ with a 32bit OS.

Apache Felix's OSGi implementation reports the `osgi.native.processor` as either `arm_le` or `arm_be` when the system property `os.arch` returns `arm`.

When running a 32bit OS on the RPi Java reports `arm` for `os.arch` which is normalized to `arm_le` by Felix. Because of this, the JNA bundle cannot be installed since this architecture is not currently listed in the OSGi `Bundle-NativeCode` header. When attempting to start the bundle you get the following error:

```
Error executing command: Error executing command on bundles:
	Error starting bundle 13: Unable to resolve com.sun.jna [13](R 13.0): missing requirement [com.sun.jna [13](R 13.0)] osgi.native; (|(&(osgi.native.osname~=win32)(osgi.native.processor~=x86))(&(osgi.native.osname~=win32)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=win)(osgi.native.processor~=x86))(&(osgi.native.osname~=win)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=wince)(osgi.native.processor~=arm))(&(osgi.native.osname~=sunos)(osgi.native.processor~=x86))(&(osgi.native.osname~=sunos)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=sunos)(osgi.native.processor~=sparc))(&(osgi.native.osname~=sunos)(osgi.native.processor~=sparcv9))(&(osgi.native.osname~=aix)(osgi.native.processor~=ppc))(&(osgi.native.osname~=aix)(osgi.native.processor~=ppc64))(&(osgi.native.osname~=linux)(osgi.native.processor~=ppc))(&(osgi.native.osname~=linux)(osgi.native.processor~=ppc64))(&(osgi.native.osname~=linux)(osgi.native.processor~=ppc64le))(&(osgi.native.osname~=linux)(osgi.native.processor~=x86))(&(osgi.native.osname~=linux)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=linux)(osgi.native.processor~=arm))(&(osgi.native.osname~=linux)(osgi.native.processor~=armel))(&(osgi.native.osname~=linux)(osgi.native.processor~=aarch64))(&(osgi.native.osname~=linux)(osgi.native.processor~=ia64))(&(osgi.native.osname~=linux)(osgi.native.processor~=sparcv9))(&(osgi.native.osname~=freebsd)(osgi.native.processor~=x86))(&(osgi.native.osname~=freebsd)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=openbsd)(osgi.native.processor~=x86))(&(osgi.native.osname~=openbsd)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=macosx)(|(osgi.native.processor~=x86)(osgi.native.processor~=x86-64)(osgi.native.processor~=ppc)))) Unresolved requirements: [[com.sun.jna [13](R 13.0)] osgi.native; (|(&(osgi.native.osname~=win32)(osgi.native.processor~=x86))(&(osgi.native.osname~=win32)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=win)(osgi.native.processor~=x86))(&(osgi.native.osname~=win)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=wince)(osgi.native.processor~=arm))(&(osgi.native.osname~=sunos)(osgi.native.processor~=x86))(&(osgi.native.osname~=sunos)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=sunos)(osgi.native.processor~=sparc))(&(osgi.native.osname~=sunos)(osgi.native.processor~=sparcv9))(&(osgi.native.osname~=aix)(osgi.native.processor~=ppc))(&(osgi.native.osname~=aix)(osgi.native.processor~=ppc64))(&(osgi.native.osname~=linux)(osgi.native.processor~=ppc))(&(osgi.native.osname~=linux)(osgi.native.processor~=ppc64))(&(osgi.native.osname~=linux)(osgi.native.processor~=ppc64le))(&(osgi.native.osname~=linux)(osgi.native.processor~=x86))(&(osgi.native.osname~=linux)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=linux)(osgi.native.processor~=arm))(&(osgi.native.osname~=linux)(osgi.native.processor~=armel))(&(osgi.native.osname~=linux)(osgi.native.processor~=aarch64))(&(osgi.native.osname~=linux)(osgi.native.processor~=ia64))(&(osgi.native.osname~=linux)(osgi.native.processor~=sparcv9))(&(osgi.native.osname~=freebsd)(osgi.native.processor~=x86))(&(osgi.native.osname~=freebsd)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=openbsd)(osgi.native.processor~=x86))(&(osgi.native.osname~=openbsd)(osgi.native.processor~=x86-64))(&(osgi.native.osname~=macosx)(|(osgi.native.processor~=x86)(osgi.native.processor~=x86-64)(osgi.native.processor~=ppc))))]
```

I confirmed the version of `libjnidispatch.so` could be loaded and that our feature utilizing JNA was working after updating the bundle with the changes in this PR. The bundle can now install and start without error.

Note that on the same hardware when running a 64bit OS the current JNA bundle can be installed fine since the arch is reported as `aarch64` in that case which is already covered.

For reference here is how the ARM architecture is normalized by Felix:
https://github.com/apache/felix/blob/6ee15de7548c56129f82957a1af9f2f78db42922/framework/src/main/java/org/apache/felix/framework/util/manifestparser/NativeLibraryClause.java#L718

And according to the OSGi reference here it appears that what Felix is doing is correct:
https://www.osgi.org/developer/specifications/reference/

Test setup details:
Apache Karaf 4.2.6 on Ubuntu server 18.04 32bit

```
admin@minion> system:version
4.2.6
```

```
ubuntu@ubuntu:/$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.3 LTS
Release:	18.04
Codename:	bionic
```

```
ubuntu@ubuntu:/$ uname -a
Linux ubuntu 4.15.0-1049-raspi2 #53-Ubuntu SMP PREEMPT Wed Oct 2 01:06:03 UTC 2019 armv7l armv7l armv7l GNU/Linux
```

```
ubuntu@ubuntu:/$ lscpu
Architecture:        armv7l
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  1
Core(s) per socket:  4
Socket(s):           1
Vendor ID:           ARM
Model:               4
Model name:          Cortex-A53
Stepping:            r0p4
CPU max MHz:         1400.0000
CPU min MHz:         600.0000
BogoMIPS:            38.40
Flags:               half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32
```

```
ubuntu@ubuntu:/$ java -version
openjdk version "11.0.4" 2019-07-16
OpenJDK Runtime Environment (build 11.0.4+11-post-Ubuntu-1ubuntu218.04.3)
OpenJDK Server VM (build 11.0.4+11-post-Ubuntu-1ubuntu218.04.3, mixed mode)
```