### PR TITLE
Mac osx build to use jdk11 for 1.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
           os: linux
         - env: JDK=ea
           os: linux
-        - env: JDK=12
+        - env: JDK=11
           os: osx
     exclude:
         - env: JDK=default

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,5 @@ matrix:
           os: linux
         - env: JDK=ea
           os: linux
-        - env: JDK=8
+        - env: JDK=12
           os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ matrix:
           os: linux
         - env: JDK=ea
           os: linux
+        - env: JDK=8
+          os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,6 @@ matrix:
           os: linux
         - env: JDK=12
           os: osx
+    exclude:
+        - env: JDK=default
+          os: osx


### PR DESCRIPTION
`contrib` projects that use `javac` target/source = 1.6 no longer compile on jdk 13 on mac osx. 
This PR attempts to update the CI config to use jdk11 on the mac OS X build to allow an older javac target/source value (1.6) in the contrib tree. Using jdk11 instead of 12 because 11 is still maintained.

A different solution (updating `contrib` to target/source = 1.7)  is presented in PR #1163