### PR TITLE
Prevent duplicates in library paths

### DIFF
--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -96,7 +96,7 @@ public class NativeLibrary {
 
     private static final Map<String, Reference<NativeLibrary>> libraries = new HashMap<String, Reference<NativeLibrary>>();
     private static final Map<String, List<String>> searchPaths = Collections.synchronizedMap(new HashMap<String, List<String>>());
-    private static final List<String> librarySearchPath = new ArrayList<String>();
+    private static final LinkedHashSet<String> librarySearchPath = new LinkedHashSet<String>();
 
     static {
         // Force initialization of native library

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -155,16 +155,8 @@ public class NativeLibrary {
 
         List<Throwable> exceptions = new ArrayList<Throwable>();
         boolean isAbsolutePath = new File(libraryName).isAbsolute();
-        List<String> searchPath = new ArrayList<String>();
+        LinkedHashSet<String> searchPath = new LinkedHashSet<String>();
         int openFlags = openFlags(options);
-
-        // Append web start path, if available.  Note that this does not
-        // attempt any library name variations
-        String webstartPath = Native.getWebStartLibraryPath(libraryName);
-        if (webstartPath != null) {
-            LOG.log(DEBUG_LOAD_LEVEL, "Adding web start path " + webstartPath);
-            searchPath.add(webstartPath);
-        }
 
         //
         // Prepend any custom search paths specifically for this library
@@ -172,8 +164,16 @@ public class NativeLibrary {
         List<String> customPaths = searchPaths.get(libraryName);
         if (customPaths != null) {
             synchronized (customPaths) {
-                searchPath.addAll(0, customPaths);
+                searchPath.addAll(customPaths);
             }
+        }
+
+        // Append web start path, if available.  Note that this does not
+        // attempt any library name variations
+        String webstartPath = Native.getWebStartLibraryPath(libraryName);
+        if (webstartPath != null) {
+            LOG.log(DEBUG_LOAD_LEVEL, "Adding web start path " + webstartPath);
+            searchPath.add(webstartPath);
         }
 
         LOG.log(DEBUG_LOAD_LEVEL, "Adding paths from jna.library.path: " + System.getProperty("jna.library.path"));
@@ -705,7 +705,7 @@ public class NativeLibrary {
     }
 
     /** Use standard library search paths to find the library. */
-    private static String findLibraryPath(String libName, List<String> searchPath) {
+    private static String findLibraryPath(String libName, Collection<String> searchPath) {
 
         //
         // If a full path to the library was specified, don't search for it
@@ -805,7 +805,7 @@ public class NativeLibrary {
      * where /usr/lib/libc.so does not exist, or it is not a valid symlink to
      * a versioned file (e.g. /lib/libc.so.6).
      */
-    static String matchLibrary(final String libName, List<String> searchPath) {
+    static String matchLibrary(final String libName, Collection<String> searchPath) {
         File lib = new File(libName);
         if (lib.isAbsolute()) {
             searchPath = Arrays.asList(lib.getParent());


### PR DESCRIPTION
Whilst debugging #1175 , I noticed that the search paths contained duplicate paths (in my case, `/usr/lib`). These two patches change the variables that hold the paths to `LinkedHashSet` as it both preserves the insertion order and prevents duplicate entries.