### PR TITLE
CHARByReference#getValue should only read one byte

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Features
 
 Bug Fixes
 ---------
+* [#1183](https://github.com/java-native-access/jna/pull/1183): `c.s.j.p.win32.WinDef.CHARByReference#getValue` should only read one byte - [@dbwiddis](https://github.com/dbwiddis).
 
 
 Release 5.5.0

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
@@ -1726,7 +1726,7 @@ public interface WinDef {
          * @return the value
          */
         public CHAR getValue() {
-            return new CHAR(getPointer().getChar(0));
+            return new CHAR(getPointer().getByte(0));
         }
     }
 


### PR DESCRIPTION
`Pointer#getChar` fetches two bytes but this is a one-byte `IntegerType`.

[See mailing list](https://groups.google.com/forum/#!topic/jna-users/XaRVbHM9le8).