### PR TITLE
ULONGLONG should always be 8 bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Features
 Bug Fixes
 ---------
 * [#1183](https://github.com/java-native-access/jna/pull/1183): `c.s.j.p.win32.WinDef.CHARByReference#getValue` should only read one byte - [@dbwiddis](https://github.com/dbwiddis).
+* [#1184](https://github.com/java-native-access/jna/pull/1184): `c.s.j.p.win32.WinDef.ULONGLONG` should always be 8 bytes - [@dbwiddis](https://github.com/dbwiddis).
 
 
 Release 5.5.0

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinDef.java
@@ -914,7 +914,7 @@ public interface WinDef {
     public static class ULONGLONG extends IntegerType implements Comparable<ULONGLONG> {
 
         /** The Constant SIZE. */
-        public static final int SIZE = Native.LONG_SIZE *2;
+        public static final int SIZE = 8;
 
         /**
          * Instantiates a new ULONGLONG.


### PR DESCRIPTION
Although this is a Windows types and the existing calculation always works on Windows, there's no reason calculate it based on `LONG` size.