### PR TITLE
Add getTokenPrimaryGroup to Advapi32Util

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Features
 * [#1168](https://github.com/java-native-access/jna/pull/1168): Add `c.s.j.p.win32.Kernel32#SetProcessAffinityMask` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1169](https://github.com/java-native-access/jna/issues/1169): Wait for process in getLinuxLdPaths - [@rdesgroppes](https://github.com/rdesgroppes).
 * [#1178](https://github.com/java-native-access/jna/pull/1178): Add `c.s.j.p.win32.IPHlpAPI#GetTcpStatistics`, `c.s.j.p.win32.IPHlpAPI#GetUdpStatistics`, `c.s.j.p.win32.IPHlpAPI#GetTcpStatisticsEx` and `c.s.j.p.win32.IPHlpAPI#GetUdpStatisticsEx` - [@dbwiddis](https://github.com/dbwiddis).
+* [#1191](https://github.com/java-native-access/jna/pull/1191): Add `c.s.j.p.win32.Advapi32Util#getTokenPrimaryGroup` - [@dbwiddis](https://github.com/dbwiddis).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -32,6 +32,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.Union;
 import com.sun.jna.ptr.ByReference;
 import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
@@ -423,6 +424,33 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         }
 
         public TOKEN_USER(int size) {
+            super(new Memory(size));
+        }
+    }
+
+    /**
+     * The TOKEN_PRIMARY_GROUP structure specifies a group security identifier (SID)
+     * for an access token.
+     */
+    @FieldOrder({ "PrimaryGroup" })
+    public static class TOKEN_PRIMARY_GROUP extends Structure {
+        /**
+         * A pointer to a SID structure representing a group that will become the
+         * primary group of any objects created by a process using this access token.
+         * The SID must be one of the group SIDs already in the token.
+         */
+        public PSID.ByReference PrimaryGroup;
+
+        public TOKEN_PRIMARY_GROUP() {
+            super();
+        }
+
+        public TOKEN_PRIMARY_GROUP(Pointer memory) {
+            super(memory);
+            read();
+        }
+
+        public TOKEN_PRIMARY_GROUP(int size) {
             super(new Memory(size));
         }
     }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
@@ -171,16 +171,24 @@ public class Advapi32UtilTest extends TestCase {
         try {
             HANDLEByReference phUser = new HANDLEByReference();
             try {
-                assertTrue(Advapi32.INSTANCE.LogonUser(userInfo.usri1_name,
-                                                       null, userInfo.usri1_password, WinBase.LOGON32_LOGON_NETWORK,
-                                                       WinBase.LOGON32_PROVIDER_DEFAULT, phUser));
+                assertTrue(Advapi32.INSTANCE.LogonUser(userInfo.usri1_name, null, userInfo.usri1_password,
+                        WinBase.LOGON32_LOGON_NETWORK, WinBase.LOGON32_PROVIDER_DEFAULT, phUser));
+                Account primaryGroup = Advapi32Util.getTokenPrimaryGroup(phUser.getValue());
+                assertTrue(primaryGroup.name.length() > 0);
+                assertTrue(primaryGroup.sidString.length() > 0);
+                assertTrue(primaryGroup.sid.length > 0);
                 Account[] groups = Advapi32Util.getTokenGroups(phUser.getValue());
+                boolean primaryGroupFound = false;
                 assertTrue(groups.length > 0);
-                for(Account group : groups) {
+                for (Account group : groups) {
                     assertTrue(group.name.length() > 0);
                     assertTrue(group.sidString.length() > 0);
                     assertTrue(group.sid.length > 0);
+                    if (primaryGroup.name.equals(group.name)) {
+                        primaryGroupFound = true;
+                    }
                 }
+                assertTrue("PrimaryGroup must be in group list", primaryGroupFound);
             } finally {
                 HANDLE hUser = phUser.getValue();
                 if (!WinBase.INVALID_HANDLE_VALUE.equals(hUser)) {


### PR DESCRIPTION
The current Advapi32Util#getTokenGroups method can incur significant latency, 20-45 seconds on my corporate machine.  Only asking for the primary group is on the order of 20-45 milliseconds.