### PR TITLE
Only fetch the latest ant version in Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: java
 
 install:
-  - export APACHE_ANT_BASE=$(curl http://apache.mirror.iphh.net/ant/binaries/ | grep "apache-ant-1.9..*-bin.tar.gz" | sed  's/.*href="\(.*\)-bin.tar.gz".*/\1/g')
+  - export APACHE_ANT_BASE=$(curl http://apache.mirror.iphh.net/ant/binaries/ | grep "apache-ant-1.9..*-bin.tar.gz" | tail -1 | sed  's/.*href="\(.*\)-bin.tar.gz".*/\1/g')
   - 'echo "Apache Ant ARCHIVE: $APACHE_ANT_BASE"'
   - '[ "${TRAVIS_OS_NAME}" = "linux" ] && wget http://apache.mirror.iphh.net/ant/binaries/$APACHE_ANT_BASE-bin.tar.gz && tar xzf $APACHE_ANT_BASE-bin.tar.gz && sudo mv $APACHE_ANT_BASE /usr/local/$APACHE_ANT_BASE && sudo rm -f /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE/bin/ant /usr/local/bin/ant || true'
   - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew update || true'


### PR DESCRIPTION
As of 2020-05-13, there are two versions of Apache Ant 1.9.x binaries available for download.  The regexp parsing incorrectly resolves to a string containing both versions, separated by a newline character, and the download fails.   This change limits the grep to only the last line, so the latest 1.9.x version will be downloaded.