### PR TITLE
Remove too-strict filestore available size test

### DIFF
--- a/contrib/platform/test/com/sun/jna/platform/linux/LibCTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/linux/LibCTest.java
@@ -76,7 +76,6 @@ public class LibCTest extends TestCase {
 
         FileStore fstore = Files.getFileStore(Paths.get(testDirectory));
         assertEquals(fstore.getTotalSpace(), vfs.f_blocks.longValue() * vfs.f_bsize.longValue());
-        assertEquals(fstore.getUsableSpace(), vfs.f_bavail.longValue() * vfs.f_bsize.longValue());
         assertTrue(vfs.f_bsize.longValue() > 0);
         assertTrue(vfs.f_bfree.longValue() <= vfs.f_blocks.longValue());
         assertTrue(vfs.f_ffree.longValue() <= vfs.f_files.longValue());


### PR DESCRIPTION
The test that usable space equals available space on a filestore is too strict, as it can fail in a race condition between fetching `statvfs` and getting the same information from core Java: 
```
assertEquals(fstore.getUsableSpace(), vfs.f_bavail.longValue() * vfs.f_bsize.longValue());
```
[Failed test](https://travis-ci.org/github/java-native-access/jna/jobs/691071994):
```
    [junit] Testcase: testStatvfs(com.sun.jna.platform.linux.LibCTest):	FAILED
    [junit] expected:<816184561664> but was:<816175988736>
```
In theory we could test for something "close" but any change threshold we choose would be arbitrary.  Given the previous line checks equality of total space, which should not change, I think this test can simply be removed.