### PR TITLE
Try all frameworks paths regardless of file exist check.

### DIFF
--- a/test/com/sun/jna/NativeLibraryTest.java
+++ b/test/com/sun/jna/NativeLibraryTest.java
@@ -247,26 +247,81 @@ public class NativeLibraryTest extends TestCase {
         process.getFunction("printf");
     }
 
-    private String expected(String f) {
-        return new File(f).exists() ? f : null;
-    }
-
-    public void testMatchFramework() {
+    public void testLoadFoundationFramework() {
         if (!Platform.isMac()) {
             return;
         }
-        final String[][] MAPPINGS = {
-            // Depending on the system, /Library/Frameworks may or may not
-            // have anything in it.
-            { "QtCore", expected("/Library/Frameworks/QtCore.framework/QtCore") },
-            { "Adobe AIR", expected("/Library/Frameworks/Adobe AIR.framework/Adobe AIR") },
+        assertNotNull(NativeLibrary.getInstance("Foundation"));
+    }
 
-            { "QuickTime", expected("/System/Library/Frameworks/QuickTime.framework/QuickTime") },
-            { "QuickTime.framework/Versions/Current/QuickTime", expected("/System/Library/Frameworks/QuickTime.framework/Versions/Current/QuickTime") },
-        };
-        for (int i=0;i < MAPPINGS.length;i++) {
-            assertEquals("Wrong framework mapping", MAPPINGS[i][1], NativeLibrary.matchFramework(MAPPINGS[i][0]));
+    public void testMatchSystemFramework() {
+        if (!Platform.isMac()) {
+            return;
         }
+
+        assertEquals("Wrong framework mapping", 1,
+                NativeLibrary.matchFramework("/System/Library/Frameworks/Foundation.framework/Foundation").length);
+        assertEquals("Wrong framework mapping", "/System/Library/Frameworks/Foundation.framework/Foundation",
+                NativeLibrary.matchFramework("/System/Library/Frameworks/Foundation.framework/Foundation")[0]);
+
+        assertEquals("Wrong framework mapping", 1,
+                NativeLibrary.matchFramework("/System/Library/Frameworks/Foundation").length);
+        assertEquals("Wrong framework mapping", "/System/Library/Frameworks/Foundation.framework/Foundation",
+                NativeLibrary.matchFramework("/System/Library/Frameworks/Foundation")[0]);
+    }
+
+    public void testMatchOptionalFrameworkExists() {
+        if (!Platform.isMac()) {
+            return;
+        }
+
+        if(!new File("/System/Library/Frameworks/QuickTime.framework").exists()) {
+            return;
+        }
+
+        assertEquals("Wrong framework mapping", 1,
+                NativeLibrary.matchFramework("QuickTime").length);
+        assertEquals("Wrong framework mapping", "/System/Library/Frameworks/QuickTime.framework/QuickTime",
+                NativeLibrary.matchFramework("QuickTime")[0]);
+
+        assertEquals("Wrong framework mapping", 1,
+                NativeLibrary.matchFramework("QuickTime.framework/Versions/Current/QuickTime").length);
+        assertEquals("Wrong framework mapping", "/System/Library/Frameworks/QuickTime.framework/Versions/Current/QuickTime",
+                NativeLibrary.matchFramework("QuickTime.framework/Versions/Current/QuickTime")[0]);
+    }
+
+    public void testMatchOptionalFrameworkNotFound() {
+        if (!Platform.isMac()) {
+            return;
+        }
+
+        if(new File(System.getProperty("user.home") + "/Library/Frameworks/QuickTime.framework").exists()) {
+            return;
+        }
+        if(new File("/Library/Frameworks/QuickTime.framework").exists()) {
+            return;
+        }
+        if(new File("/System/Library/Frameworks/QuickTime.framework").exists()) {
+            return;
+        }
+
+        assertEquals("Wrong framework mapping", 3,
+                NativeLibrary.matchFramework("QuickTime").length);
+        assertEquals("Wrong framework mapping", System.getProperty("user.home") + "/Library/Frameworks/QuickTime.framework/QuickTime",
+                NativeLibrary.matchFramework("QuickTime")[0]);
+        assertEquals("Wrong framework mapping", "/Library/Frameworks/QuickTime.framework/QuickTime",
+                NativeLibrary.matchFramework("QuickTime")[1]);
+        assertEquals("Wrong framework mapping", "/System/Library/Frameworks/QuickTime.framework/QuickTime",
+                NativeLibrary.matchFramework("QuickTime")[2]);
+
+        assertEquals("Wrong framework mapping", 3,
+                NativeLibrary.matchFramework("QuickTime.framework/Versions/Current/QuickTime").length);
+        assertEquals("Wrong framework mapping", System.getProperty("user.home") + "/Library/Frameworks/QuickTime.framework/Versions/Current/QuickTime",
+                NativeLibrary.matchFramework("QuickTime.framework/Versions/Current/QuickTime")[0]);
+        assertEquals("Wrong framework mapping", "/Library/Frameworks/QuickTime.framework/Versions/Current/QuickTime",
+                NativeLibrary.matchFramework("QuickTime.framework/Versions/Current/QuickTime")[1]);
+        assertEquals("Wrong framework mapping", "/System/Library/Frameworks/QuickTime.framework/Versions/Current/QuickTime",
+                NativeLibrary.matchFramework("QuickTime.framework/Versions/Current/QuickTime")[2]);
     }
 
     public void testLoadLibraryWithOptions() {


### PR DESCRIPTION
> New in macOS Big Sur 11 beta, the system ships with a built-in dynamic linker cache of all system-provided libraries. As part of this change, copies of dynamic libraries are no longer present on the filesystem. Code that attempts to check for dynamic library presence by looking for a file at a path or enumerating a directory will fail. Instead, check for library presence by attempting to dlopen() the path, which will correctly check for the library in the cache. (62986286)

Fix #1215.

Signed-off-by: David Kocher <dkocher@iterate.ch>