### PR TITLE
Fix win32 ansi api

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
@@ -58,7 +58,6 @@ import java.awt.image.BufferedImage;
 import java.awt.image.Raster;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -113,6 +112,8 @@ import com.sun.jna.platform.win32.WinUser.WNDENUMPROC;
 import com.sun.jna.ptr.ByteByReference;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.W32StringUtil;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -1273,7 +1274,7 @@ public class WindowUtils {
             final int length = User32.INSTANCE.GetWindowText(hwnd, title,
                                                              title.length);
 
-            return Native.toString(Arrays.copyOfRange(title, 0, length));
+            return W32StringUtil.toString(title, 0, length);
         }
 
         @Override

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -23,9 +23,11 @@
  */
 package com.sun.jna.platform.win32;
 
+import com.sun.jna.ParameterTypeMapper;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinBase.FE_EXPORT_FUNC;
 import com.sun.jna.platform.win32.WinBase.FE_IMPORT_FUNC;
 import com.sun.jna.platform.win32.WinBase.PROCESS_INFORMATION;
@@ -2706,6 +2708,7 @@ public interface Advapi32 extends StdCallLibrary {
      * function fails, the return value is zero. To get extended error
      * information, call GetLastError.
      */
+    @ParameterTypeMapper(indexes = 0, types = WString.class)
     boolean EncryptionDisable(String DirPath, boolean Disable);
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMUtils.java
@@ -26,7 +26,6 @@ package com.sun.jna.platform.win32.COM;
 import com.sun.jna.LastErrorException;
 import java.util.ArrayList;
 
-import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.Advapi32Util;
@@ -42,6 +41,7 @@ import com.sun.jna.platform.win32.WinNT.HRESULT;
 import com.sun.jna.platform.win32.WinReg;
 import com.sun.jna.platform.win32.WinReg.HKEYByReference;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * The Class COMUtils.
@@ -235,7 +235,7 @@ public abstract class COMUtils {
             for (int i = 0; i < infoKey.lpcSubKeys.getValue(); i++) {
                 EnumKey enumKey = Advapi32Util.registryRegEnumKey(
                         phkResult.getValue(), i);
-                subKey = Native.toString(enumKey.lpName);
+                subKey = W32StringUtil.toString(enumKey.lpName);
 
                 COMInfo comInfo = new COMInfo(subKey);
 
@@ -247,7 +247,7 @@ public abstract class COMUtils {
                 for (int y = 0; y < infoKey2.lpcSubKeys.getValue(); y++) {
                     EnumKey enumKey2 = Advapi32Util.registryRegEnumKey(
                             phkResult2.getValue(), y);
-                    String subKey2 = Native.toString(enumKey2.lpName);
+                    String subKey2 = W32StringUtil.toString(enumKey2.lpName);
 
                     if (subKey2.equals("InprocHandler32")) {
                         comInfo.inprocHandler32 = (String) Advapi32Util

--- a/contrib/platform/src/com/sun/jna/platform/win32/Crypt32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Crypt32Util.java
@@ -25,10 +25,10 @@ package com.sun.jna.platform.win32;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
 import com.sun.jna.platform.win32.WinCrypt.CRYPTPROTECT_PROMPTSTRUCT;
 import com.sun.jna.platform.win32.WinCrypt.DATA_BLOB;
 import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Crypt32 utility API.
@@ -193,8 +193,6 @@ public abstract class Crypt32Util {
      * @return Returns the retrieved string.
      */
     public static String CertNameToStr(int dwCertEncodingType, int dwStrType, DATA_BLOB pName) {
-        int charToBytes = Boolean.getBoolean("w32.ascii") ? 1 : Native.WCHAR_SIZE;
-
         // Initialize the signature structure.
         int requiredSize = Crypt32.INSTANCE.CertNameToStr(
                 dwCertEncodingType,
@@ -203,7 +201,7 @@ public abstract class Crypt32Util {
                 Pointer.NULL,
                 0);
 
-        Memory mem = new Memory(requiredSize * charToBytes);
+        Memory mem = W32StringUtil.allocateBuffer(requiredSize);
 
         // Initialize the signature structure.
         int resultBytes = Crypt32.INSTANCE.CertNameToStr(
@@ -215,10 +213,6 @@ public abstract class Crypt32Util {
 
         assert resultBytes == requiredSize;
 
-        if (Boolean.getBoolean("w32.ascii")) {
-            return mem.getString(0);
-        } else {
-            return mem.getWideString(0);
-        }
+        return W32StringUtil.toString(mem);
     }
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
@@ -33,6 +33,7 @@ import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinDef.PVOID;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
+import com.sun.jna.win32.W32StringUtil;
 import com.sun.jna.platform.win32.WinDef.BOOL;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.DWORDByReference;
@@ -42,7 +43,6 @@ import com.sun.jna.platform.win32.WinDef.UINT_PTR;
 import com.sun.jna.platform.win32.WinDef.WPARAM;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.SECURITY_QUALITY_OF_SERVICE;
-import com.sun.jna.win32.W32APITypeMapper;
 
 /**
  * Ported from Ddeml.h. Microsoft Windows SDK 7.1.
@@ -434,11 +434,8 @@ public interface Ddeml extends StdCallLibrary {
 
         public String getStr() {
             int offset = fieldOffset("str");
-            if(W32APITypeMapper.DEFAULT == W32APITypeMapper.UNICODE) {
-                return getPointer().getWideString(offset);
-            } else {
-                return getPointer().getString(offset);
-            }
+            Pointer ptr = getPointer().share(offset);
+            return W32StringUtil.toString(ptr);
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ddeml.java
@@ -2581,8 +2581,43 @@ public interface Ddeml extends StdCallLibrary {
      *   <li>{@link #DMLERR_NO_ERROR}</li>
      *   <li>{@link #DMLERR_SYS_ERROR}</li>
      * </ul>
+     *
+     * @deprecated Use {@link #DdeCreateStringHandle(int, Pointer, int)}
      */
+    @Deprecated
     public HSZ DdeCreateStringHandle(int idInst, String psz, int iCodePage);
+
+    /**
+     * Creates a handle that identifies the specified string. A Dynamic
+     * Data Exchange (DDE) client or server application can pass the string
+     * handle as a parameter to other Dynamic Data Exchange Management
+     * Library (DDEML) functions.
+     *
+     * @param idInst The application instance identifier obtained by a previous
+     * call to the {@link #DdeInitialize} function.
+     *
+     * @param psz The null-terminated string for which a handle is to be created.
+     * This string can be up to 255 characters. The reason for this limit is that
+     * DDEML string management functions are implemented using atoms.
+     *
+     * @param iCodePage The code page to be used to render the string. This
+     * value should be either {@link #CP_WINANSI} (the default code page) or
+     * {@link #CP_WINUNICODE}, depending on whether the ANSI or Unicode version of
+     * {@link #DdeInitialize} was called by the client application.
+     *
+     * @return If the function succeeds, the return value is a string handle.
+     *
+     * <p>If the function fails, the return value is 0L.</p>
+     *
+     * <p>The {@link #DdeGetLastError} function can be used to get the error code, which
+     * can be one of the following values:</p>
+     * <ul>
+     *   <li>{@link #DMLERR_INVALIDPARAMETER}</li>
+     *   <li>{@link #DMLERR_NO_ERROR}</li>
+     *   <li>{@link #DMLERR_SYS_ERROR}</li>
+     * </ul>
+     */
+    public HSZ DdeCreateStringHandle(int idInst, Pointer psz, int iCodePage);
 
     /**
      * Copies text associated with a string handle into a buffer.

--- a/contrib/platform/src/com/sun/jna/platform/win32/DdemlUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/DdemlUtil.java
@@ -643,13 +643,9 @@ public abstract class DdemlUtil {
             if(value == null) {
                 return null;
             }
-            int codePage;
-            if(W32APIOptions.DEFAULT_OPTIONS == W32APIOptions.UNICODE_OPTIONS) {
-                codePage = Ddeml.CP_WINUNICODE;
-            } else {
-                codePage = Ddeml.CP_WINANSI;
-            }
-            Ddeml.HSZ handle = Ddeml.INSTANCE.DdeCreateStringHandle(idInst, value, codePage);
+            int codePage = W32StringUtil.isAPITypeWide() ? Ddeml.CP_WINUNICODE : Ddeml.CP_WINANSI;
+            Memory mem = W32StringUtil.allocateBuffer(value);
+            Ddeml.HSZ handle = Ddeml.INSTANCE.DdeCreateStringHandle(idInst, mem, codePage);
             if(handle == null) {
                 throw DdemlException.create(getLastError());
             }

--- a/contrib/platform/src/com/sun/jna/platform/win32/DdemlUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/DdemlUtil.java
@@ -34,8 +34,8 @@ import com.sun.jna.platform.win32.Ddeml.HDDEDATA;
 import com.sun.jna.platform.win32.Ddeml.HSZ;
 import com.sun.jna.platform.win32.Ddeml.HSZPAIR;
 import com.sun.jna.platform.win32.User32Util.MessageLoopThread;
-import com.sun.jna.platform.win32.User32Util.MessageLoopThread.Handler;
-import com.sun.jna.win32.W32APIOptions;
+import com.sun.jna.win32.W32StringUtil;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -699,26 +699,10 @@ public abstract class DdemlUtil {
         }
 
         public String queryString(Ddeml.HSZ value) throws DdemlException {
-            int codePage;
-            int byteWidth;
-            if(W32APIOptions.DEFAULT_OPTIONS == W32APIOptions.UNICODE_OPTIONS) {
-                codePage = Ddeml.CP_WINUNICODE;
-                byteWidth = 2;
-            } else {
-                codePage = Ddeml.CP_WINANSI;
-                byteWidth = 1;
-            }
-            Memory buffer = new Memory((256 + 1) * byteWidth);
-            try {
-                int length = Ddeml.INSTANCE.DdeQueryString(idInst, value, buffer, 256, codePage);
-                if (W32APIOptions.DEFAULT_OPTIONS == W32APIOptions.UNICODE_OPTIONS) {
-                    return buffer.getWideString(0);
-                } else {
-                    return buffer.getString(0);
-                }
-            } finally {
-                buffer.valid();
-            }
+            int codePage = W32StringUtil.isAPITypeWide() ? Ddeml.CP_WINUNICODE : Ddeml.CP_WINANSI;
+            Memory buffer = W32StringUtil.allocateBuffer(256);
+            Ddeml.INSTANCE.DdeQueryString(idInst, value, buffer, W32StringUtil.toSizeInCharacters(buffer), codePage);
+            return W32StringUtil.toString(buffer);
         }
 
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -26,8 +26,6 @@ package com.sun.jna.platform.win32;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
-import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.StdCallLibrary;
@@ -1511,17 +1509,22 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      *         {@link #GetLastError()} returns an error code other than
      *         {@link WinError#ERROR_OLD_WIN_VERSION}.
      */
+    boolean VerifyVersionInfo(OSVERSIONINFOEX lpVersionInformation, int dwTypeMask, long dwlConditionMask);
+
+    /**
+     * @deprecated Use {@link #VerifyVersionInfo(com.sun.jna.platform.win32.WinNT.OSVERSIONINFOEX, int, long)}
+     */
     boolean VerifyVersionInfoW(OSVERSIONINFOEX lpVersionInformation, int dwTypeMask, long dwlConditionMask);
 
     /**
      * Sets the bits of a 64-bit value to indicate the comparison operator to
      * use for a specified operating system version attribute. This function is
      * used to build the {@code dwlConditionMask} parameter of the
-     * {@link #VerifyVersionInfoW} function.
+     * {@link #VerifyVersionInfo} function.
      *
      * @param conditionMask
      *            A value to be passed as the {@code dwlConditionMask} parameter
-     *            of the {@link #VerifyVersionInfoW} function. The function
+     *            of the {@link #VerifyVersionInfo} function. The function
      *            stores the comparison information in the bits of this
      *            variable.
      *            <p>
@@ -1533,10 +1536,10 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
      *            {@link com.sun.jna.platform.win32.WinNT.OSVERSIONINFOEX} structure whose comparison
      *            operator is being set. This value corresponds to one of the
      *            bits specified in the {@code dwTypeMask} parameter for the
-     *            {@link #VerifyVersionInfoW} function.
+     *            {@link #VerifyVersionInfo} function.
      * @param condition
      *            The operator to be used for the comparison. The
-     *            {@link #VerifyVersionInfoW} function uses this operator to
+     *            {@link #VerifyVersionInfo} function uses this operator to
      *            compare a specified attribute value to the corresponding value
      *            for the currently running system.
      * @return The function returns the condition mask value.

--- a/contrib/platform/src/com/sun/jna/platform/win32/Netapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Netapi32.java
@@ -23,6 +23,7 @@
  */
 package com.sun.jna.platform.win32;
 
+import com.sun.jna.ParameterTypeMapper;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -136,6 +137,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return If the function succeeds, the return value is NERR_Success. If
      *         the function fails, the return value is a system error code.
      */
+    @ParameterTypeMapper(indexes = 0, types = WString.class)
     public int NetGetJoinInformation(String lpServer,
             PointerByReference lpNameBuffer, IntByReference BufferType);
 
@@ -176,6 +178,7 @@ public interface Netapi32 extends StdCallLibrary {
      *  to continue an existing local group search.
      * @return If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = 0, types = WString.class)
     public int NetLocalGroupEnum(String serverName, int level,
             PointerByReference bufptr, int prefmaxlen,
             IntByReference entriesread, IntByReference totalentries,
@@ -194,6 +197,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *     If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = {0, 1}, types = {WString.class, WString.class})
     public int NetGetDCName(String serverName, String domainName,
             PointerByReference bufptr);
 
@@ -270,6 +274,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = 0, types = WString.class)
     public int NetUserEnum(String servername, int level, int filter, PointerByReference bufptr,
             int prefmaxlen, IntByReference entriesread, IntByReference totalentries,
             IntByReference resume_handle);
@@ -303,6 +308,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = {0, 1}, types = {WString.class, WString.class})
     public int NetUserGetGroups(String servername, String username, int level,
             PointerByReference bufptr, int prefmaxlen,
             IntByReference entriesread, IntByReference totalentries);
@@ -346,6 +352,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = {0, 1}, types = {WString.class, WString.class})
     public int NetUserGetLocalGroups(String servername, String username, int level,
             int flags, PointerByReference bufptr, int prefmaxlen,
             IntByReference entriesread, IntByReference totalentries);
@@ -367,6 +374,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = 0, types = WString.class)
     public int NetUserAdd(String servername, int level,
             Structure buf, IntByReference parm_err);
 
@@ -382,6 +390,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = {0, 1}, types = {WString.class, WString.class})
     public int NetUserDel(String servername, String username);
 
     /**
@@ -402,6 +411,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = {0, 1, 2, 3}, types = {WString.class, WString.class, WString.class, WString.class})
     public int NetUserChangePassword(String domainname, String username,
             String oldpassword, String newpassword);
 
@@ -516,6 +526,7 @@ public interface Netapi32 extends StdCallLibrary {
      * @return
      *  If the function succeeds, the return value is NERR_Success.
      */
+    @ParameterTypeMapper(indexes = {0, 1}, types = {WString.class, WString.class})
     public int NetUserGetInfo(String servername, String username, int level, PointerByReference bufptr);
 
     /**
@@ -540,6 +551,7 @@ public interface Netapi32 extends StdCallLibrary {
      *  index is not returned on error. For more information, see the NetShareSetInfo function.
      * @return If the function succeeds, the return value is NERR_Success. If the function fails, the return value can be an error code as seen on MSDN.
      */
+    @ParameterTypeMapper(indexes = 0, types = WString.class)
     public int NetShareAdd(String servername, int level, Pointer buf, IntByReference parm_err);
 
     /**
@@ -555,5 +567,6 @@ public interface Netapi32 extends StdCallLibrary {
      * @return If the function succeeds, the return value is LMErr.NERR_Success.
      *  If the function fails, the return value can be an error code as seen on MSDN.
      */
+    @ParameterTypeMapper(indexes = {0, 1}, types = {WString.class, WString.class})
     public int NetShareDel(String servername, String netname, int reserved);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Ole32.java
@@ -23,6 +23,7 @@
  */
 package com.sun.jna.platform.win32;
 
+import com.sun.jna.ParameterTypeMapper;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.COM.Unknown;
@@ -88,6 +89,7 @@ public interface Ole32 extends StdCallLibrary {
      * @return This function can return the standard return values E_INVALIDARG,
      *         E_OUTOFMEMORY, and S_OK.
      */
+    @ParameterTypeMapper(indexes = 0, types = WTypes.LPOLESTR.class)
     HRESULT IIDFromString(String lpsz, GUID lpiid);
 
     /**
@@ -406,6 +408,7 @@ public interface Ole32 extends StdCallLibrary {
      *         are the only two functions that can be used to generate a CLSID
      *         for an OLE 1 object.
      */
+    @ParameterTypeMapper(indexes = 0, types = WTypes.LPOLESTR.class)
     HRESULT CLSIDFromProgID(String lpszProgID, CLSID.ByReference lpclsid);
 
     /**
@@ -432,6 +435,7 @@ public interface Ole32 extends StdCallLibrary {
      *
      *         REGDB_E_READREGDB The registry could not be opened for reading.
      */
+    @ParameterTypeMapper(indexes = 0, types = WTypes.LPOLESTR.class)
     HRESULT CLSIDFromString(String lpsz, CLSID.ByReference pclsid);
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
@@ -23,13 +23,13 @@
  */
 package com.sun.jna.platform.win32;
 
+import com.sun.jna.ParameterTypeMapper;
 import com.sun.jna.Memory;
-import java.util.List;
-
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.WString;
 import com.sun.jna.platform.win32.Guid.GUID;
 import com.sun.jna.platform.win32.OaIdl.DISPID;
 import com.sun.jna.platform.win32.OaIdl.SAFEARRAY;
@@ -153,6 +153,7 @@ public interface OleAuto extends StdCallLibrary {
      * @return Null if there is insufficient memory or if a null pointer is
      *         passed in.
      */
+    @ParameterTypeMapper(indexes = 0, types = WString.class)
     BSTR SysAllocString(String sz);
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/Rasapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Rasapi32Util.java
@@ -36,6 +36,7 @@ import com.sun.jna.platform.win32.WinRas.RASENTRY;
 import com.sun.jna.platform.win32.WinRas.RASPPPIP;
 import com.sun.jna.platform.win32.WinRas.RasDialFunc2;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Rasapi32 utility API.
@@ -120,9 +121,7 @@ public abstract class Rasapi32Util {
         char[] msg = new char[1024];
         int err = Rasapi32.INSTANCE.RasGetErrorString(code, msg, msg.length);
         if (err != WinError.ERROR_SUCCESS) return "Unknown error " + code;
-        int len = 0;
-        for (; len < msg.length; len++) if (msg[len] == 0) break;
-        return new String(msg, 0, len);
+        return W32StringUtil.toString(msg);
     }
 
     /**
@@ -158,7 +157,9 @@ public abstract class Rasapi32Util {
 
         // find connection
         for (int i = 0; i < lpcConnections.getValue(); i++) {
-            if (new String(connections[i].szEntryName).equals(connName)) return connections[i].hrasconn;
+            if (W32StringUtil.toString(connections[i].szEntryName).equals(connName)) {
+                return connections[i].hrasconn;
+            }
         }
         return null;
     }
@@ -240,7 +241,7 @@ public abstract class Rasapi32Util {
     public static RASDIALPARAMS getPhoneBookDialingParams(String entryName) throws Ras32Exception {
         synchronized (phoneBookMutex) {
             RASDIALPARAMS.ByReference rasDialParams = new RASDIALPARAMS.ByReference();
-            System.arraycopy(rasDialParams.szEntryName, 0, entryName.toCharArray(), 0, entryName.length());
+            W32StringUtil.setString(entryName, rasDialParams.szEntryName, 0);
             BOOLByReference lpfPassword = new BOOLByReference();
             int err = Rasapi32.INSTANCE.RasGetEntryDialParams(null, rasDialParams, lpfPassword);
             if (err != WinError.ERROR_SUCCESS) throw new Ras32Exception(err);
@@ -265,7 +266,7 @@ public abstract class Rasapi32Util {
 
         // set the dialing parameters
         RASDIALPARAMS.ByReference rasDialParams = new RASDIALPARAMS.ByReference();
-        System.arraycopy(entryName.toCharArray(), 0, rasDialParams.szEntryName, 0, entryName.length());
+        W32StringUtil.setString(entryName, rasDialParams.szEntryName, 0);
         System.arraycopy(credentials.szUserName, 0, rasDialParams.szUserName, 0, credentials.szUserName.length);
         System.arraycopy(credentials.szPassword, 0, rasDialParams.szPassword, 0, credentials.szPassword.length);
         System.arraycopy(credentials.szDomain, 0, rasDialParams.szDomain, 0, credentials.szDomain.length);
@@ -298,7 +299,7 @@ public abstract class Rasapi32Util {
 
         // set the dialing parameters
         RASDIALPARAMS.ByReference rasDialParams = new RASDIALPARAMS.ByReference();
-        System.arraycopy(entryName.toCharArray(), 0, rasDialParams.szEntryName, 0, entryName.length());
+        W32StringUtil.setString(entryName, rasDialParams.szEntryName, 0);
         System.arraycopy(credentials.szUserName, 0, rasDialParams.szUserName, 0, credentials.szUserName.length);
         System.arraycopy(credentials.szPassword, 0, rasDialParams.szPassword, 0, credentials.szPassword.length);
         System.arraycopy(credentials.szDomain, 0, rasDialParams.szDomain, 0, credentials.szDomain.length);

--- a/contrib/platform/src/com/sun/jna/platform/win32/Secur32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Secur32Util.java
@@ -29,6 +29,7 @@ import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Sspi.PSecPkgInfo;
 import com.sun.jna.platform.win32.Sspi.SecPkgInfo;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Secur32 Utility API.
@@ -81,7 +82,7 @@ public abstract class Secur32Util {
             throw new Win32Exception(Native.getLastError());
         }
 
-        return Native.toString(buffer);
+        return W32StringUtil.toString(buffer);
     }
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/ShellAPI.java
@@ -47,7 +47,7 @@ import com.sun.jna.win32.W32APITypeMapper;
 public interface ShellAPI extends StdCallLibrary {
 
     int STRUCTURE_ALIGNMENT = Platform.is64Bit() ? Structure.ALIGN_DEFAULT : Structure.ALIGN_NONE;
-    TypeMapper TYPE_MAPPER = Boolean.getBoolean("w32.ascii") ? W32APITypeMapper.ASCII : W32APITypeMapper.UNICODE;
+    TypeMapper TYPE_MAPPER = W32APITypeMapper.DEFAULT;
 
     int FO_MOVE = 0x0001;
     int FO_COPY = 0x0002;

--- a/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
@@ -28,6 +28,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.win32.W32APITypeMapper;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Ported from Sspi.h.
@@ -803,7 +804,7 @@ public interface Sspi {
             if (sUserName == null) {
                 return null;
             }
-            return Boolean.getBoolean("w32.ascii") ? sUserName.getString(0) : sUserName.getWideString(0);
+            return W32StringUtil.toString(sUserName);
         }
 
         /**
@@ -940,14 +941,14 @@ public interface Sspi {
             if(sSignatureAlgorithmName == null) {
                 return null;
             }
-            return Boolean.getBoolean("w32.ascii") ? sSignatureAlgorithmName.getString(0) : sSignatureAlgorithmName.getWideString(0);
+            return W32StringUtil.toString(sSignatureAlgorithmName);
         }
 
         public synchronized String getEncryptAlgorithmName() {
             if(sEncryptAlgorithmName == null) {
                 return null;
             }
-            return Boolean.getBoolean("w32.ascii") ? sEncryptAlgorithmName.getString(0) : sEncryptAlgorithmName.getWideString(0);
+            return W32StringUtil.toString(sEncryptAlgorithmName);
         }
 
         public synchronized void free() {

--- a/contrib/platform/src/com/sun/jna/platform/win32/VersionHelpers.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/VersionHelpers.java
@@ -70,7 +70,7 @@ public class VersionHelpers {
         dwlConditionMask = Kernel32.INSTANCE.VerSetConditionMask(dwlConditionMask, WinNT.VER_SERVICEPACKMAJOR,
                 (byte) WinNT.VER_GREATER_EQUAL);
 
-        return Kernel32.INSTANCE.VerifyVersionInfoW(osvi,
+        return Kernel32.INSTANCE.VerifyVersionInfo(osvi,
                 WinNT.VER_MAJORVERSION | WinNT.VER_MINORVERSION | WinNT.VER_SERVICEPACKMAJOR, dwlConditionMask);
     }
 
@@ -202,9 +202,6 @@ public class VersionHelpers {
      * @return true if the current OS is a Windows Server release.
      */
     public static boolean IsWindowsServer() {
-        // This should properly be OSVERSIONINFOEXW which is not defined in JNA.
-        // The OSVERSIONINFOEX structure in JNA is the (W) Unicode-compliant
-        // version.
         OSVERSIONINFOEX osvi = new OSVERSIONINFOEX();
         osvi.dwOSVersionInfoSize = new DWORD(osvi.size());
         osvi.wProductType = WinNT.VER_NT_WORKSTATION;
@@ -212,7 +209,7 @@ public class VersionHelpers {
         long dwlConditionMask = Kernel32.INSTANCE.VerSetConditionMask(0, WinNT.VER_PRODUCT_TYPE,
                 (byte) WinNT.VER_EQUAL);
 
-        return !Kernel32.INSTANCE.VerifyVersionInfoW(osvi, WinNT.VER_PRODUCT_TYPE, dwlConditionMask);
+        return !Kernel32.INSTANCE.VerifyVersionInfo(osvi, WinNT.VER_PRODUCT_TYPE, dwlConditionMask);
     }
 }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -736,7 +736,7 @@ public interface WinBase extends WinDef, BaseTSD {
          * Any characters after the null terminator are random memory. Use function getFileName to
          * get a String with the name.</b>
          */
-        public char[] cFileName = new char[MAX_PATH];
+        public byte[] cFileName = new byte[MAX_PATH * W32StringUtil.getCharWidth()];
 
         /**
          * An alternative name for the file. This name is in the classic 8.3 file name format.
@@ -744,7 +744,7 @@ public interface WinBase extends WinDef, BaseTSD {
          * Any characters after the null terminator are random memory. Use function getAlternateFileName to
          * get a String with the alternate name.</b>
          */
-        public char[] cAlternateFileName = new char[14];
+        public byte[] cAlternateFileName = new byte[14 * W32StringUtil.getCharWidth()];
 
         public static int sizeOf() {
             return Native.getNativeSize(WIN32_FIND_DATA.class, null);
@@ -767,8 +767,8 @@ public interface WinBase extends WinDef, BaseTSD {
                 int nFileSizeLow,
                 int dwReserved0,
                 int dwReserved1,
-                char[] cFileName,
-                char[] cAlternateFileName) {
+                byte[] cFileName,
+                byte[] cAlternateFileName) {
             this.dwFileAttributes = dwFileAttributes;
             this.ftCreationTime = ftCreationTime;
             this.ftLastAccessTime = ftLastAccessTime;

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java
@@ -39,6 +39,7 @@ import com.sun.jna.platform.win32.WinNT.LARGE_INTEGER;
 import com.sun.jna.ptr.ByteByReference;
 import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 import com.sun.jna.win32.W32APITypeMapper;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Ported from Winbase.h (kernel32.dll/kernel services).
@@ -784,14 +785,14 @@ public interface WinBase extends WinDef, BaseTSD {
          * @return String containing the file name
          */
         public String getFileName() {
-            return Native.toString(cFileName);
+            return W32StringUtil.toString(cFileName);
         }
 
         /**
          * @return String containing the alternate file name
          */
         public String getAlternateFileName() {
-            return Native.toString(cAlternateFileName);
+            return W32StringUtil.toString(cAlternateFileName);
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -32,9 +32,9 @@ import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
-import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.Union;
 import com.sun.jna.ptr.ByReference;
+import com.sun.jna.win32.W32StringUtil;
 import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 
 /**
@@ -1876,10 +1876,10 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
          * Pointer to a null-terminated string, such as "Service Pack 3", that
          * indicates the latest Service Pack installed on the system.
          */
-        public char szCSDVersion[];
+        public byte szCSDVersion[];
 
         public OSVERSIONINFO() {
-            szCSDVersion = new char[128];
+            szCSDVersion = new byte[128 * W32StringUtil.getCharWidth()];
             dwOSVersionInfoSize = new DWORD(size()); // sizeof(OSVERSIONINFO)
         }
 
@@ -1933,7 +1933,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
          * the latest Service Pack installed on the system. If no Service Pack
          * has been installed, the string is empty.
          */
-        public char szCSDVersion[];
+        public byte szCSDVersion[];
 
         /**
          * The major version number of the latest Service Pack installed on the
@@ -1966,7 +1966,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         public byte wReserved;
 
         public OSVERSIONINFOEX() {
-            szCSDVersion = new char[128];
+            szCSDVersion = new byte[128 * W32StringUtil.getCharWidth()];
             dwOSVersionInfoSize = new DWORD(size()); // sizeof(OSVERSIONINFOEX)
         }
 
@@ -2009,7 +2009,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
          *         If no Service Pack has been installed, the string is empty.
          */
         public String getServicePack() {
-            return Native.toString(szCSDVersion);
+            return W32StringUtil.toString(szCSDVersion);
         }
 
         /**

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinRas.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinRas.java
@@ -35,6 +35,7 @@ import com.sun.jna.platform.win32.WinDef.BOOL;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.LUID;
+import com.sun.jna.win32.W32StringUtil;
 import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 
 /**
@@ -267,13 +268,13 @@ public interface WinRas {
          * modem connection on the first available modem port, in which case a
          * non-empty szPhoneNumber must be provided.
          */
-        public char[] szEntryName = new char[RAS_MaxEntryName + 1];
+        public byte[] szEntryName = new byte[(RAS_MaxEntryName + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains an overriding phone number. An
          * empty string ("") indicates that the phone-book entry's phone number
          * should be used. If szEntryName is "", szPhoneNumber cannot be "".
          */
-        public char[] szPhoneNumber = new char[RAS_MaxPhoneNumber + 1];
+        public byte[] szPhoneNumber = new byte[(RAS_MaxPhoneNumber + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains a callback phone number. An
          * empty string ("") indicates that callback should not be used. This
@@ -281,26 +282,26 @@ public interface WinRas {
          * permission on the RAS server. An asterisk indicates that the number
          * stored in the phone book should be used for callback.
          */
-        public char[] szCallbackNumber = new char[RAS_MaxCallbackNumber + 1];
+        public byte[] szCallbackNumber = new byte[(RAS_MaxCallbackNumber + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains the user's user name. This
          * string is used to authenticate the user's access to the remote access
          * server.
          */
-        public char[] szUserName = new char[UNLEN + 1];
+        public byte[] szUserName = new byte[(UNLEN + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains the user's password. This
          * string is used to authenticate the user's access to the remote access
          * server.
          */
-        public char[] szPassword = new char[PWLEN + 1];
+        public byte[] szPassword = new byte[(PWLEN + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains the domain on which
          * authentication is to occur. An empty string ("") specifies the domain
          * in which the remote access server is a member. An asterisk specifies
          * the domain stored in the phone book for the entry.
          */
-        public char[] szDomain = new char[DNLEN + 1];
+        public byte[] szDomain = new byte[(DNLEN + 1) * W32StringUtil.getCharWidth()];
     }
 
     /**
@@ -339,23 +340,23 @@ public interface WinRas {
          * established using an empty entry name, this string consists of a
          * PERIOD followed by the connection phone number.
          */
-        public char[] szEntryName = new char[RAS_MaxEntryName + 1];
+        public byte[] szEntryName = new byte[(RAS_MaxEntryName + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains the device type through which
          * the connection is made. See RASENTRY for a list of possible device
          * types.
          */
-        public char[] szDeviceType = new char[RAS_MaxDeviceType + 1];
+        public byte[] szDeviceType = new byte[(RAS_MaxDeviceType + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains the device name through which
          * the connection is made.
          */
-        public char[] szDeviceName = new char[RAS_MaxDeviceName + 1];
+        public byte[] szDeviceName = new byte[(RAS_MaxDeviceName + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that specifies the full path and file name
          * of a phone-book (PBK) file.
          */
-        public char[] szPhonebook = new char[MAX_PATH];
+        public byte[] szPhonebook = new byte[MAX_PATH * W32StringUtil.getCharWidth()];
         /**
          * For multilink connections, a value that specifies the subentry
          * one-based index of a connected link.
@@ -542,14 +543,14 @@ public interface WinRas {
          * An array that contains a null-terminated string that is the client's IP address on the RAS connection.
          * This address string has the form a.b.c.d.
          */
-        public char[] szIpAddress = new char[RAS_MaxIpAddress + 1];
+        public byte[] szIpAddress = new byte[(RAS_MaxIpAddress + 1) * W32StringUtil.getCharWidth()];
         /**
          * An array that contains a null-terminated string that is the server's IP address on the RAS connection.
          * This string is in a.b.c.d form.
          * PPP does not require that servers provide this address, but servers will consistently return the address anyway.
          * Other PPP vendors may not provide the address. If the address is not available, this member returns an empty string, "".
          */
-        public char[] szServerIpAddress = new char[RAS_MaxIpAddress + 1];
+        public byte[] szServerIpAddress = new byte[(RAS_MaxIpAddress + 1) * W32StringUtil.getCharWidth()];
         /**
          * A value that specifies IPCP options for the local client.
          */
@@ -645,17 +646,17 @@ public interface WinRas {
          * A string that specifies the type of the current device, if available. For example, common device types supported by
          * RAS are "modem", "pad", "switch", "ISDN", or "null". See RASENTRY for a complete list of possible device types.
          */
-        public char[] szDeviceType = new char[RAS_MaxDeviceType + 1];
+        public byte[] szDeviceType = new byte[(RAS_MaxDeviceType + 1) * W32StringUtil.getCharWidth()];
         /**
          * A string that specifies the name of the current device, if available. This would be the name of the modem -
          * for example, "Hayes SmartModem 2400"; the name of the PAD, for example "US Sprint"; or the name of a
          * switch device, for example "Racal-Guardata".
          */
-        public char[] szDeviceName = new char[RAS_MaxDeviceName + 1];
+        public byte[] szDeviceName = new byte[(RAS_MaxDeviceName + 1) * W32StringUtil.getCharWidth()];
         /**
          * A string that indicates the phone number dialed for this specific connection.
          */
-        public char[] szPhoneNumber = new char[RAS_MaxPhoneNumber + 1];
+        public byte[] szPhoneNumber = new byte[(RAS_MaxPhoneNumber + 1) * W32StringUtil.getCharWidth()];
         /**
          * A RASTUNNELENDPOINT structure that contains the local client endpoint information of a virtual private network (VPN) endpoint.
          */
@@ -699,15 +700,15 @@ public interface WinRas {
         /**
          * Specifies a null-terminated string that contains a user name.
          */
-        public char[] szUserName = new char[UNLEN + 1];
+        public byte[] szUserName = new byte[(UNLEN + 1) * W32StringUtil.getCharWidth()];
         /**
          * Specifies a null-terminated string that contains a password.
          */
-        public char[] szPassword = new char[PWLEN + 1];
+        public byte[] szPassword = new byte[(PWLEN + 1) * W32StringUtil.getCharWidth()];
         /**
          * A null-terminated string that contains a domain name.
          */
-        public char[] szDomain = new char[DNLEN + 1];
+        public byte[] szDomain = new byte[(DNLEN + 1) * W32StringUtil.getCharWidth()];
     }
 
     /**
@@ -780,12 +781,12 @@ public interface WinRas {
          * For example, "206" is a valid area code; "(206)" is not. This member is ignored unless the dwfOptions member
          * specifies the RASEO_UseCountryAndAreaCodes flag.
          */
-        public char[] szAreaCode = new char[RAS_MaxAreaCode + 1];
+        public byte[] szAreaCode = new byte[(RAS_MaxAreaCode + 1) * W32StringUtil.getCharWidth()];
         /**
          * Specifies a null-terminated device-type specific destination string.
          * The following table describes the contents of the szLocalPhoneNumber member for various device types.
          */
-        public char[] szLocalPhoneNumber = new char[RAS_MaxPhoneNumber + 1];
+        public byte[] szLocalPhoneNumber = new byte[(RAS_MaxPhoneNumber + 1) * W32StringUtil.getCharWidth()];
         /**
          * Specifies the offset, in bytes, from the beginning of the structure to a list of consecutive null-terminated strings.
          * The last string is terminated by two consecutive null characters. The strings are alternate phone numbers that RAS
@@ -835,45 +836,45 @@ public interface WinRas {
          * Specifies a null-terminated string that contains the name of the script file.
          * The file name should be a full path. This field is only used for analog dial-up connections.
          */
-        public char[] szScript = new char[MAX_PATH];
+        public byte[] szScript = new byte[MAX_PATH * W32StringUtil.getCharWidth()];
         /**
          * Windows 2000 or later: This member is no longer supported. The szCustomDialDll member of the
          * RASENTRY structure specifies the path to the custom-dial DLL. For more information on custom dialers, see RAS Custom Dialers.
          */
-        public char[] szAutodialDll = new char[MAX_PATH];
+        public byte[] szAutodialDll = new byte[MAX_PATH * W32StringUtil.getCharWidth()];
         /**
          * Windows 2000 or later: This member is no longer supported. See RAS Custom Dialers for more information on custom dialers.
          */
-        public char[] szAutodialFunc = new char[MAX_PATH];
+        public byte[] szAutodialFunc = new byte[MAX_PATH * W32StringUtil.getCharWidth()];
         /**
          * Specifies a null-terminated string that indicates the RAS device type referenced by szDeviceName. This member can be one of the following string constants.
          */
-        public char[] szDeviceType = new char[RAS_MaxDeviceType + 1];
+        public byte[] szDeviceType = new byte[(RAS_MaxDeviceType + 1) * W32StringUtil.getCharWidth()];
         /**
          * Contains a null-terminated string that contains the name of a TAPI device to use with this phone-book entry, for example,
          * "XYZ Corp 28800 External". To enumerate all available RAS-capable devices, use the RasEnumDevices function.
          */
-        public char[] szDeviceName = new char[RAS_MaxDeviceName + 1];
+        public byte[] szDeviceName = new byte[(RAS_MaxDeviceName + 1) * W32StringUtil.getCharWidth()];
         /**
          * Contains a null-terminated string that identifies the X.25 PAD type. Set this member to "" unless the entry
          * should dial using an X.25 PAD. The szX25PadType string maps to a section name in PAD.INF.
          */
-        public char[] szX25PadType = new char[RAS_MaxPadType + 1];
+        public byte[] szX25PadType = new byte[(RAS_MaxPadType + 1) * W32StringUtil.getCharWidth()];
         /**
          * Contains a null-terminated string that identifies the X.25 address to which to connect .
          * Set this member to "" unless the entry should dial using an X.25 PAD or native X.25 device.
          */
-        public char[] szX25Address = new char[RAS_MaxX25Address + 1];
+        public byte[] szX25Address = new byte[(RAS_MaxX25Address + 1) * W32StringUtil.getCharWidth()];
         /**
          * Contains a null-terminated string that specifies the facilities to request from the X.25 host at connection.
          * This member is ignored if szX25Address is an empty string ("").
          */
-        public char[] szX25Facilities = new char[RAS_MaxFacilities + 1];
+        public byte[] szX25Facilities = new byte[(RAS_MaxFacilities + 1) * W32StringUtil.getCharWidth()];
         /**
          * Contains a null-terminated string that specifies additional connection information supplied to the X.25
          * host at connection. This member is ignored if szX25Address is an empty string ("").
          */
-        public char[] szX25UserData = new char[RAS_MaxUserData + 1];
+        public byte[] szX25UserData = new byte[(RAS_MaxUserData + 1) * W32StringUtil.getCharWidth()];
         /**
          * Reserved for future use
          */
@@ -947,7 +948,7 @@ public interface WinRas {
          * RasCustomDialDlg. These functions should have prototypes RasCustomDialFn and RasCustomHangUpFn as defined in Ras.h,
          * and RasCustomDialDlgFn and RasCustomEntryDlgFn as defined in Rasdlg.h.
          */
-        public char[] szCustomDialDll = new char[MAX_PATH];
+        public byte[] szCustomDialDll = new byte[MAX_PATH * W32StringUtil.getCharWidth()];
         /**
          * The VPN strategy to use when dialing a VPN connection. This member can have one of the following values.
          */
@@ -965,7 +966,7 @@ public interface WinRas {
          * Pointer to a string that specifies the Domain Name Service (DNS) suffix for the connection.
          * This string can be Unicode depending on the version of the structure you are using.
          */
-        public char[] szDnsSuffix = new char[RAS_MaxDnsSuffix];
+        public byte[] szDnsSuffix = new byte[RAS_MaxDnsSuffix * W32StringUtil.getCharWidth()];
         /**
          * Specifies the TCP window size for all TCP sessions that run over this connection.
          * Setting this value can increase the throughput of high-latency devices such as cellular phones.
@@ -975,14 +976,14 @@ public interface WinRas {
          * Pointer to a null-terminated string that specifies the full path and file name of a phone-book (PBK) file.
          * This phone-book file contains the entry specified by the szPrerequisiteEntry member. This member is used only for VPN connections.
          */
-        public char[] szPrerequisitePbk = new char[MAX_PATH];
+        public byte[] szPrerequisitePbk = new byte[MAX_PATH * W32StringUtil.getCharWidth()];
         /**
          * Pointer to a null-terminated string that specifies a phone-book entry.
          * This entry should exist in the phone-book file specified by the szPrerequisitePbk member.
          * The szPrerequisteEntry member specifies an entry that RAS dials prior to establishing the connection
          * specified by this RASENTRY structure. This member is used only for VPN connections.
          */
-        public char[] szPrerequisiteEntry = new char[RAS_MaxEntryName + 1];
+        public byte[] szPrerequisiteEntry = new byte[(RAS_MaxEntryName + 1) * W32StringUtil.getCharWidth()];
         /**
          * Specifies the number of times RAS attempts to redial a connection.
          */

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
@@ -30,10 +30,10 @@ import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.Union;
 import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
-import com.sun.jna.platform.win32.WinDef.HKL;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
 import com.sun.jna.win32.W32APITypeMapper;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Ported from WinUser.h Microsoft Windows SDK 6.0A.
@@ -1473,10 +1473,10 @@ public interface WinUser extends WinDef {
          * applications have no use for a display monitor name, and so can save some bytes
          * by using a MONITORINFO structure.
          */
-        public char[]  szDevice;
+        public byte[]  szDevice;
 
         public MONITORINFOEX() {
-            szDevice = new char[CCHDEVICENAME];
+            szDevice = new byte[CCHDEVICENAME * W32StringUtil.getCharWidth()];
             cbSize = size();
         }
     }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WininetUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WininetUtil.java
@@ -32,6 +32,7 @@ import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Wininet.INTERNET_CACHE_ENTRY_INFO;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Reusable functions that use WinInet
@@ -113,7 +114,9 @@ public class WininetUtil {
             }
 
             for (INTERNET_CACHE_ENTRY_INFO item : items) {
-                cacheItems.put(item.lpszSourceUrlName.getWideString(0), item.lpszLocalFileName == null ? "" : item.lpszLocalFileName.getWideString(0));
+                String key = W32StringUtil.toString(item.lpszSourceUrlName);
+                String value = item.lpszLocalFileName == null ? "" : W32StringUtil.toString(item.lpszLocalFileName);
+                cacheItems.put(key, value);
             }
 
         } catch (Win32Exception e) {

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winsvc.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winsvc.java
@@ -209,11 +209,11 @@ public interface Winsvc {
 
     public abstract class ChangeServiceConfig2Info extends Structure {
         public ChangeServiceConfig2Info() {
-            super(Boolean.getBoolean("w32.ascii") ? W32APITypeMapper.ASCII : W32APITypeMapper.UNICODE);
+            super(W32APITypeMapper.DEFAULT);
         }
 
         public ChangeServiceConfig2Info(Pointer p) {
-            super(p, ALIGN_DEFAULT, Boolean.getBoolean("w32.ascii") ? W32APITypeMapper.ASCII : W32APITypeMapper.UNICODE);
+            super(p, ALIGN_DEFAULT, W32APITypeMapper.DEFAULT);
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winsvc.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winsvc.java
@@ -27,6 +27,7 @@ import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.TypeMapper;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APITypeMapper;
@@ -859,6 +860,8 @@ public interface Winsvc {
      */
     @FieldOrder({"lpServiceName", "lpDisplayName", "ServiceStatusProcess"})
     public static class ENUM_SERVICE_STATUS_PROCESS extends Structure {
+        public static final TypeMapper TYPE_MAPPER = W32APITypeMapper.DEFAULT;
+
         /**
          * The name of a service in the service control manager database. The
          * maximum string length is 256 characters. The service control manager

--- a/contrib/platform/src/com/sun/jna/platform/win32/Wtsapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Wtsapi32.java
@@ -36,6 +36,7 @@ import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
 import com.sun.jna.win32.W32APITypeMapper;
+import com.sun.jna.win32.W32StringUtil;
 
 public interface Wtsapi32 extends StdCallLibrary {
 
@@ -229,8 +230,6 @@ public interface Wtsapi32 extends StdCallLibrary {
             "IncomingCompressedBytes", "OutgoingCompressedBytes", "WinStationName", "Domain", "UserName", "ConnectTime",
             "DisconnectTime", "LastInputTime", "LogonTime", "CurrentTime" })
     class WTSINFO extends Structure {
-        private static final int CHAR_WIDTH = Boolean.getBoolean("w32.ascii") ? 1 : 2;
-
         public int State; // WTS_CONNECTSTATE_CLASS
         public int SessionId;
         public int IncomingBytes;
@@ -239,9 +238,9 @@ public interface Wtsapi32 extends StdCallLibrary {
         public int OutgoingFrames;
         public int IncomingCompressedBytes;
         public int OutgoingCompressedBytes;
-        public final byte[] WinStationName = new byte[WINSTATIONNAME_LENGTH * CHAR_WIDTH];
-        public final byte[] Domain = new byte[DOMAIN_LENGTH * CHAR_WIDTH];
-        public final byte[] UserName = new byte[(USERNAME_LENGTH + 1) * CHAR_WIDTH];
+        public final byte[] WinStationName = new byte[WINSTATIONNAME_LENGTH * W32StringUtil.getCharWidth()];
+        public final byte[] Domain = new byte[DOMAIN_LENGTH * W32StringUtil.getCharWidth()];
+        public final byte[] UserName = new byte[(USERNAME_LENGTH + 1) * W32StringUtil.getCharWidth()];
         public LARGE_INTEGER ConnectTime;
         public LARGE_INTEGER DisconnectTime;
         public LARGE_INTEGER LastInputTime;
@@ -291,7 +290,8 @@ public interface Wtsapi32 extends StdCallLibrary {
         }
 
         private String getStringAtOffset(int offset) {
-            return CHAR_WIDTH == 1 ? getPointer().getString(offset) : getPointer().getWideString(offset);
+            Pointer ptr = getPointer().share(offset);
+            return W32StringUtil.toString(ptr);
         }
     }
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32UtilTest.java
@@ -32,6 +32,7 @@ import java.io.FileWriter;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Advapi32Util.Account;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogIterator;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogRecord;
@@ -558,8 +559,8 @@ public class Advapi32UtilTest extends TestCase {
         Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key2");
         String[] subKeys = Advapi32Util.registryGetKeys(WinReg.HKEY_CURRENT_USER, "Software\\JNA");
         assertEquals(2, subKeys.length);
-        assertEquals(subKeys[0], "Key1");
-        assertEquals(subKeys[1], "Key2");
+        assertEquals("Key1", subKeys[0]);
+        assertEquals("Key2", subKeys[1]);
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key1");
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software\\JNA", "Key2");
         Advapi32Util.registryDeleteKey(WinReg.HKEY_CURRENT_USER, "Software", "JNA");
@@ -683,8 +684,7 @@ public class Advapi32UtilTest extends TestCase {
             throw new Win32Exception(rc);
         }
         try {
-            char[] data = new char[0];
-            rc = Advapi32.INSTANCE.RegSetValueEx(phkKey.getValue(), name, 0, valueType, data, 0);
+            rc = Advapi32.INSTANCE.RegSetValueEx(phkKey.getValue(), name, 0, valueType, Pointer.NULL, 0);
             if (rc != W32Errors.ERROR_SUCCESS) {
                 throw new Win32Exception(rc);
             }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
@@ -28,6 +28,7 @@ import java.security.cert.X509Certificate;
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.WinCrypt.DATA_BLOB;
 import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.W32StringUtil;
 import com.sun.jna.platform.win32.WinCrypt.*;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.Memory;
@@ -116,7 +117,7 @@ public class Crypt32Test extends TestCase {
                     assertTrue("CryptProtectData(Crypt)",
                             Crypt32.INSTANCE.CryptUnprotectData(pDataEncrypted, pDescription,
                                     null, null, null, 0, pDataDecrypted));
-                    assertEquals(description, pDescription.getValue().getWideString(0));
+                    assertEquals(description, W32StringUtil.toString(pDescription.getValue()));
                     assertArrayEquals(payload, pDataDecrypted.getData());
                 } finally {
                     Kernel32Util.freeLocalMemory(pDataDecrypted.pbData);
@@ -152,7 +153,7 @@ public class Crypt32Test extends TestCase {
                     assertTrue("CryptUnprotectData(WithEntropy)",
                             Crypt32.INSTANCE.CryptUnprotectData(pDataEncrypted, pDescription,
                                     pEntropy, null, null, 0, pDataDecrypted));
-                    assertEquals(description, pDescription.getValue().getWideString(0));
+                    assertEquals(description, W32StringUtil.toString(pDescription.getValue()));
                     assertArrayEquals(payload, pDataDecrypted.getData());
                 } finally {
                     Kernel32Util.freeLocalMemory(pDataDecrypted.pbData);
@@ -384,7 +385,7 @@ public class Crypt32Test extends TestCase {
                 mem,
                 requiredSize);
 
-        assertEquals(TESTCERT_CN, mem.getWideString(0));
+        assertEquals(TESTCERT_CN, W32StringUtil.toString(mem));
 
         String utilResult = Crypt32Util.CertNameToStr(WinCrypt.X509_ASN_ENCODING, WinCrypt.CERT_SIMPLE_NAME_STR, pc.pCertInfo.Issuer);
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Crypt32Test.java
@@ -376,9 +376,9 @@ public class Crypt32Test extends TestCase {
 
         assertEquals("Issuer Name length repored incorrectly", TESTCERT_CN.length() + 1, requiredSize);
 
-        Memory mem = new Memory(requiredSize * Native.WCHAR_SIZE);
+        Memory mem = W32StringUtil.allocateBuffer(requiredSize);
 
-        int resultSize = Crypt32.INSTANCE.CertNameToStr(
+        Crypt32.INSTANCE.CertNameToStr(
                 WinCrypt.X509_ASN_ENCODING,
                 pc.pCertInfo.Issuer,
                 WinCrypt.CERT_SIMPLE_NAME_STR,

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32EnvironmentVarsTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32EnvironmentVarsTest.java
@@ -28,7 +28,7 @@ import java.util.Random;
 
 import org.junit.Test;
 
-import com.sun.jna.Native;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * @author lgoldstein
@@ -52,7 +52,7 @@ public class Kernel32EnvironmentVarsTest extends AbstractWin32TestSupport {
             int     size=Kernel32.INSTANCE.GetEnvironmentVariable(name, data, data.length);
             assertEquals("Mismatched retrieved length for " + name, data.length - 1 /* w/o the '\0' */, size);
 
-            String  actual=Native.toString(data);
+            String actual = W32StringUtil.toString(data);
             assertEquals("Mismatched retrieved value for " + name, expected, actual);
         }
     }
@@ -67,9 +67,9 @@ public class Kernel32EnvironmentVarsTest extends AbstractWin32TestSupport {
             assertEquals("Mismatched required buffer size", expected.length() + 1, size);
 
             char[] data = new char[size];
-            assertEquals("Mismatched retrieved variable data length", size - 1, Kernel32.INSTANCE.GetEnvironmentVariable(name, data, size));
+            assertEquals("Mismatched retrieved variable data length", size - 1, Kernel32.INSTANCE.GetEnvironmentVariable(name, data, data.length));
 
-            String  actual=Native.toString(data);
+            String actual = W32StringUtil.toString(data);
             assertEquals("Mismatched retrieved variable value", expected, actual);
         } finally {
             assertCallSucceeded("Clean up variable", Kernel32.INSTANCE.SetEnvironmentVariable(name, null));

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -89,6 +89,7 @@ import com.sun.jna.platform.win32.WinNT.OSVERSIONINFO;
 import com.sun.jna.platform.win32.WinNT.OSVERSIONINFOEX;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.ShortByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 import junit.framework.TestCase;
 
@@ -100,7 +101,7 @@ public class Kernel32Test extends TestCase {
         System.out.println("Operating system: "
                 + lpVersionInfo.dwMajorVersion.longValue() + "." + lpVersionInfo.dwMinorVersion.longValue()
                 + " (" + lpVersionInfo.dwBuildNumber + ")"
-                + " [" + Native.toString(lpVersionInfo.szCSDVersion) + "]");
+                + " [" + W32StringUtil.toString(lpVersionInfo.szCSDVersion) + "]");
         junit.textui.TestRunner.run(Kernel32Test.class);
     }
 
@@ -272,13 +273,13 @@ public class Kernel32Test extends TestCase {
         char buffer[] = new char[WinBase.MAX_COMPUTERNAME_LENGTH + 1];
         lpnSize.setValue(buffer.length);
         assertTrue("Failed to retrieve expected computer name", Kernel32.INSTANCE.GetComputerName(buffer, lpnSize));
-        String expected = Native.toString(buffer);
+        String expected = W32StringUtil.toString(buffer);
 
         // reset
         lpnSize.setValue(buffer.length);
         Arrays.fill(buffer, '\0');
         assertTrue("Failed to retrieve extended computer name", Kernel32.INSTANCE.GetComputerNameEx(WinBase.COMPUTER_NAME_FORMAT.ComputerNameNetBIOS, buffer, lpnSize));
-        String  actual = Native.toString(buffer);
+        String actual = W32StringUtil.toString(buffer);
 
         assertEquals("Mismatched names", expected, actual);
     }
@@ -560,7 +561,7 @@ public class Kernel32Test extends TestCase {
         assertEquals(lpVersionInfo.size(), lpVersionInfo.dwOSVersionInfoSize.longValue());
         assertTrue(lpVersionInfo.dwPlatformId.longValue() > 0);
         assertTrue(lpVersionInfo.dwBuildNumber.longValue() > 0);
-        assertTrue(Native.toString(lpVersionInfo.szCSDVersion).length() >= 0);
+        assertTrue(W32StringUtil.toString(lpVersionInfo.szCSDVersion).length() >= 0);
     }
 
     public void testGetVersionEx_OSVERSIONINFOEX() {
@@ -1221,11 +1222,11 @@ public class Kernel32Test extends TestCase {
 
         DWORD len = Kernel32.INSTANCE.GetPrivateProfileString("Section", "existingKey", "DEF", buffer, new DWORD(buffer.length), tmp.getCanonicalPath());
         assertEquals(3, len.intValue());
-        assertEquals("ABC", Native.toString(buffer));
+        assertEquals("ABC", W32StringUtil.toString(buffer));
 
         len = Kernel32.INSTANCE.GetPrivateProfileString("Section", "missingKey", "DEF", buffer, new DWORD(buffer.length), tmp.getCanonicalPath());
         assertEquals(3, len.intValue());
-        assertEquals("DEF", Native.toString(buffer));
+        assertEquals("DEF", W32StringUtil.toString(buffer));
     }
 
     public final void testWritePrivateProfileString() throws IOException {
@@ -1266,7 +1267,7 @@ public class Kernel32Test extends TestCase {
         final DWORD len = Kernel32.INSTANCE.GetPrivateProfileSection("X", buffer, new DWORD(buffer.length), tmp.getCanonicalPath());
 
         assertEquals(len.intValue(), 7);
-        assertEquals(new String(buffer), "A=1\0B=X\0\0");
+        assertEquals("A=1\0B=X\0\0", W32StringUtil.toRawString(buffer));
     }
 
     public final void testGetPrivateProfileSectionNames() throws IOException {
@@ -1284,7 +1285,7 @@ public class Kernel32Test extends TestCase {
         final char[] buffer = new char[7];
         final DWORD len = Kernel32.INSTANCE.GetPrivateProfileSectionNames(buffer, new DWORD(buffer.length), tmp.getCanonicalPath());
         assertEquals(len.intValue(), 5);
-        assertEquals(new String(buffer), "S1\0S2\0\0");
+        assertEquals("S1\0S2\0\0", W32StringUtil.toRawString(buffer));
     }
 
     public final void testWritePrivateProfileSection() throws IOException {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -522,7 +522,7 @@ public class Kernel32Test extends TestCase {
 
     public void testGetTempPath() {
         char[] buffer = new char[WinDef.MAX_PATH];
-        assertTrue(Kernel32.INSTANCE.GetTempPath(new DWORD(WinDef.MAX_PATH), buffer).intValue() > 0);
+        assertTrue(Kernel32.INSTANCE.GetTempPath(new DWORD(buffer.length), buffer).intValue() > 0);
     }
 
     public void testGetTickCount() throws InterruptedException {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32VolumeManagementFunctionsTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32VolumeManagementFunctionsTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 public class Kernel32VolumeManagementFunctionsTest extends AbstractWin32TestSupport {
     public Kernel32VolumeManagementFunctionsTest() {
@@ -149,7 +150,7 @@ public class Kernel32VolumeManagementFunctionsTest extends AbstractWin32TestSupp
         try {
             int foundPaths = 0;
             do {
-                String volumeGUID = Native.toString(lpszVolumeName);
+                String volumeGUID = W32StringUtil.toString(lpszVolumeName);
                 testEnumVolumeMountMoints(volumeGUID);
                 foundPaths += testGetVolumePathNamesForVolumeName(volumeGUID);
             } while(Kernel32.INSTANCE.FindNextVolume(hFindVolume, lpszVolumeName, lpszVolumeName.length));
@@ -190,7 +191,7 @@ public class Kernel32VolumeManagementFunctionsTest extends AbstractWin32TestSupp
 
         try {
             do {
-                String name = Native.toString(lpszVolumeMountPoint);
+                String name = W32StringUtil.toString(lpszVolumeMountPoint);
                 assertTrue("Empty mount point for " + volumeGUID, name.length() > 0);
 //                System.out.append('\t').append("testEnumVolumeMountMoints").append('[').append(volumeGUID).append(']').append(" - ").println(name);
             } while(Kernel32.INSTANCE.FindNextVolumeMountPoint(hFindVolumeMountPoint, lpszVolumeMountPoint, lpszVolumeMountPoint.length));

--- a/contrib/platform/test/com/sun/jna/platform/win32/MprTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/MprTest.java
@@ -27,7 +27,6 @@ package com.sun.jna.platform.win32;
 import java.io.File;
 
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
 import com.sun.jna.platform.win32.LMShare.SHARE_INFO_2;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.platform.win32.Winnetwk.ConnectFlag;
@@ -38,8 +37,7 @@ import com.sun.jna.platform.win32.Winnetwk.RESOURCETYPE;
 import com.sun.jna.platform.win32.Winnetwk.RESOURCEUSAGE;
 import com.sun.jna.platform.win32.Winnetwk.UNIVERSAL_NAME_INFO;
 import com.sun.jna.ptr.IntByReference;
-import static com.sun.jna.win32.W32APIOptions.DEFAULT_OPTIONS;
-import static com.sun.jna.win32.W32APIOptions.UNICODE_OPTIONS;
+import com.sun.jna.win32.W32StringUtil;
 
 import junit.framework.TestCase;
 
@@ -266,9 +264,7 @@ public class MprTest extends TestCase {
         lpnSize.setValue(buffer.length);
         assertTrue(Kernel32.INSTANCE.GetComputerName(buffer, lpnSize));
         // Return string with computer name
-        String computerName = new String(buffer);
-        computerName = computerName.trim();
-        return computerName;
+        return W32StringUtil.toString(buffer);
     }
 
     /**

--- a/contrib/platform/test/com/sun/jna/platform/win32/MprTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/MprTest.java
@@ -72,20 +72,10 @@ public class MprTest extends TestCase {
             // Cancel any existing connections of the same name
             Mpr.INSTANCE.WNetCancelConnection2(resource.lpRemoteName, 0, true);
             // Establish a new one
-            Memory lpAccessName;
-            if(DEFAULT_OPTIONS==UNICODE_OPTIONS) {
-                lpAccessName = new Memory((WinDef.MAX_PATH + 1) * Native.WCHAR_SIZE);
-            } else {
-                lpAccessName = new Memory(WinDef.MAX_PATH + 1);
-            }
+            Memory lpAccessName = W32StringUtil.allocateBuffer(WinDef.MAX_PATH + 1);
             IntByReference lpAccessNameSize = new IntByReference(WinDef.MAX_PATH);
             assertEquals(WinError.ERROR_SUCCESS, Mpr.INSTANCE.WNetUseConnection(null, resource, null, null, 0, lpAccessName, lpAccessNameSize, null));
-            String accessName;
-            if(DEFAULT_OPTIONS==UNICODE_OPTIONS) {
-                accessName = lpAccessName.getWideString(0);
-            } else {
-                accessName = lpAccessName.getString(0);
-            }
+            String accessName = W32StringUtil.toString(lpAccessName);
             // System.out.println("Size: " + lpAccessNameSize.getValue());
             // System.out.println("lpAccessName: " + accessName);
             assertNotNull(accessName);

--- a/contrib/platform/test/com/sun/jna/platform/win32/MsiTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/MsiTest.java
@@ -25,6 +25,7 @@ package com.sun.jna.platform.win32;
 import java.util.Arrays;
 
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 import junit.framework.TestCase;
 
@@ -36,27 +37,27 @@ public class MsiTest extends TestCase {
     public void testMsiEnumComponents() {
         char[] componentBuffer = new char[40];
         assertEquals("MsiEnumComponents", W32Errors.ERROR_SUCCESS, Msi.INSTANCE.MsiEnumComponents(new WinDef.DWORD(0), componentBuffer));
-        String component = new String(componentBuffer).trim();
+        String component = W32StringUtil.toString(componentBuffer);
         assertFalse("Component is empty", component.isEmpty());
     }
 
     public void testMsiGetProductCodeW() {
         char[] componentBuffer = new char[40];
         assertEquals("MsiEnumComponents", W32Errors.ERROR_SUCCESS, Msi.INSTANCE.MsiEnumComponents(new WinDef.DWORD(0), componentBuffer));
-        String component = new String(componentBuffer).trim();
+        String component = W32StringUtil.toString(componentBuffer);
         assertFalse("Component is empty", component.isEmpty());
 
         char[] productBuffer = new char[40];
         assertEquals("MsiGetProductCode", W32Errors.ERROR_SUCCESS, Msi.INSTANCE.MsiGetProductCode(component, productBuffer));
 
-        String product = new String(productBuffer).trim();
+        String product = W32StringUtil.toString(productBuffer);
         assertFalse("Product is empty", product.isEmpty());
     }
 
     public void testMsiLocateComponentW() {
         char[] componentBuffer = new char[40];
         assertEquals("MsiEnumComponents", W32Errors.ERROR_SUCCESS, Msi.INSTANCE.MsiEnumComponents(new WinDef.DWORD(0), componentBuffer));
-        String component = new String(componentBuffer).trim();
+        String component = W32StringUtil.toString(componentBuffer);
         assertFalse("Component is empty", component.isEmpty());
 
         char[] pathBuffer = new char[WinDef.MAX_PATH];
@@ -72,13 +73,13 @@ public class MsiTest extends TestCase {
     public void testMsiGetComponentPathW() {
         char[] componentBuffer = new char[40];
         assertEquals("MsiEnumComponents", W32Errors.ERROR_SUCCESS, Msi.INSTANCE.MsiEnumComponents(new WinDef.DWORD(0), componentBuffer));
-        String component = new String(componentBuffer).trim();
+        String component = W32StringUtil.toString(componentBuffer);
         assertFalse("Component is empty", component.isEmpty());
 
         char[] productBuffer = new char[40];
         assertEquals("MsiGetProductCode", W32Errors.ERROR_SUCCESS,  Msi.INSTANCE.MsiGetProductCode(component, productBuffer));
 
-        String product = new String(productBuffer).trim();
+        String product = W32StringUtil.toString(productBuffer);
         assertFalse("Product is empty", product.isEmpty());
 
         char[] pathBuffer = new char[WinDef.MAX_PATH];

--- a/contrib/platform/test/com/sun/jna/platform/win32/PdhTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/PdhTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Pdh.PDH_COUNTER_PATH_ELEMENTS;
 import com.sun.jna.platform.win32.Pdh.PDH_RAW_COUNTER;
 import com.sun.jna.platform.win32.PdhUtil.PdhEnumObjectItems;
@@ -40,6 +39,7 @@ import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.DWORDByReference;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * @author lgoldstein
@@ -166,7 +166,7 @@ public class PdhTest extends AbstractWin32TestSupport {
         pcchBufferSize.setValue(new DWORD(szFullPathBuffer.length));
         assertErrorSuccess("PdhMakeCounterPath", pdh.PdhMakeCounterPath(pathElements, szFullPathBuffer,  pcchBufferSize, 0), true);
 
-        return Native.toString(szFullPathBuffer);
+        return W32StringUtil.toString(szFullPathBuffer);
     }
 
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/Rasapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Rasapi32Test.java
@@ -30,6 +30,7 @@ import com.sun.jna.platform.win32.WinRas.RASCREDENTIALS;
 import com.sun.jna.platform.win32.WinRas.RASDIALPARAMS;
 import com.sun.jna.platform.win32.WinRas.RASENTRY;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * @author drrobison@openroadsconsulting.com
@@ -53,14 +54,8 @@ public class Rasapi32Test extends TestCase {
     public void testRasGetErrorString() {
         char[] msg = new char[1024];
         assertEquals(W32Errors.ERROR_SUCCESS, Rasapi32.INSTANCE.RasGetErrorString(632, msg, msg.length));
-        int len = 0;
-        for (; len < msg.length; len++) {
-            if (msg[len] == 0) {
-                break;
-            }
-        }
         if (AbstractWin32TestSupport.isEnglishLocale) {
-            assertEquals("An incorrect structure size was detected.", new String(msg, 0, len));
+            assertEquals("An incorrect structure size was detected.", W32StringUtil.toString(msg));
         } else {
             System.err.println("testRasGetErrorString test can only be run with english locale.");
         }
@@ -82,7 +77,7 @@ public class Rasapi32Test extends TestCase {
 
     public void testRasGetEntryDialParams() {
         RASDIALPARAMS.ByReference rasDialParams = new RASDIALPARAMS.ByReference();
-        System.arraycopy(rasDialParams.szEntryName, 0, "TEST".toCharArray(), 0, "TEST".length());
+        W32StringUtil.setString("TEST", rasDialParams.szEntryName, 0);
         BOOLByReference lpfPassword = new BOOLByReference();
         int err = Rasapi32.INSTANCE.RasGetEntryDialParams(null, rasDialParams, lpfPassword);
         assertEquals(623, err);

--- a/contrib/platform/test/com/sun/jna/platform/win32/Secur32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Secur32Test.java
@@ -24,7 +24,6 @@
 package com.sun.jna.platform.win32;
 
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
 import com.sun.jna.platform.win32.SspiUtil.ManagedSecBufferDesc;
 import com.sun.jna.platform.win32.Sspi.CredHandle;
 import com.sun.jna.platform.win32.Sspi.CtxtHandle;
@@ -37,6 +36,8 @@ import com.sun.jna.platform.win32.Sspi.SecPkgInfo.ByReference;
 import com.sun.jna.platform.win32.Sspi.TimeStamp;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32StringUtil;
+
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
@@ -67,7 +68,7 @@ public class Secur32Test extends TestCase {
         char[] buffer = new char[len.getValue() + 1];
         assertTrue(Secur32.INSTANCE.GetUserNameEx(
                 Secur32.EXTENDED_NAME_FORMAT.NameSamCompatible, buffer, len));
-        String username = Native.toString(buffer);
+        String username = W32StringUtil.toString(buffer);
         assertTrue(username.length() > 0);
     }
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32WindowMessagesTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32WindowMessagesTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 
-import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
@@ -48,6 +47,7 @@ import com.sun.jna.platform.win32.WinUser.MSG;
 import com.sun.jna.platform.win32.WinUser.WNDCLASSEX;
 import com.sun.jna.platform.win32.WinUser.WNDENUMPROC;
 import com.sun.jna.platform.win32.WinUser.WindowProc;
+import com.sun.jna.win32.W32StringUtil;
 
 /**
  * Demonstration of windows message api of complex structures like WM_COPYDATA.
@@ -314,7 +314,7 @@ public class User32WindowMessagesTest extends AbstractWin32TestSupport {
 
             char[] windowText = new char[512];
             assertCallSucceeded("GetClassName", User32.INSTANCE.GetClassName(hWnd, windowText, windowText.length) != 0);
-            String className = Native.toString(windowText);
+            String className = W32StringUtil.toString(windowText);
 
             if (windowClass.equalsIgnoreCase(className)) {
                 // Found handle. No determine root window...

--- a/src/com/sun/jna/ParameterTypeMapper.java
+++ b/src/com/sun/jna/ParameterTypeMapper.java
@@ -1,0 +1,57 @@
+/* Copyright (c) 2020 Torbjörn Svensson, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Map a function parameter to a new type
+ *
+ * @author Torbj&ouml;rn Svensson, azoff[at]svenskalinuxforeninen.se
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface ParameterTypeMapper {
+    /**
+     * The type of each paramter to convert to
+     * WARNING: The length of the array must same as for {@link #indexes()}
+     *
+     * @return Array of new type(s) for parameter(s)
+     */
+    Class<?>[] types();
+
+    /**
+     * The index of the parameter(s) to convert
+     * WARNING: The length of the array must same as for {@link #types()}
+     *
+     * @return Array of index(es) of the parameter(s) to convert
+     */
+    int[] indexes();
+}

--- a/src/com/sun/jna/win32/W32StringUtil.java
+++ b/src/com/sun/jna/win32/W32StringUtil.java
@@ -1,0 +1,390 @@
+/* Copyright (c) 2020 Torbjörn Svensson, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.win32;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+
+/**
+ * Native string methods for Windows.
+ *
+ * @author Torbj&ouml;rn Svensson, azoff[at]svenskalinuxforeningen.se
+ */
+public abstract class W32StringUtil {
+    /**
+     * Returns true for unicode API.
+     *
+     * @return True for unicode API
+     */
+    public static boolean isAPITypeWide() {
+        return W32APITypeMapper.DEFAULT == W32APITypeMapper.UNICODE;
+    }
+
+    /**
+     * Return the width of TCHAR in C
+     *
+     * @return The width of TCHAR in C
+     */
+    public static int getCharWidth() {
+        if (isAPITypeWide()) {
+            return Native.WCHAR_SIZE;
+        }
+        return 1;
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param pointer The buffer
+     * @return The string
+     * @see #toString(Pointer)
+     * @see #toString(Pointer, int)
+     * @see #toString(Pointer, int, int)
+     */
+    public static String toString(Pointer pointer) {
+        return toString(pointer, 0);
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param pointer The buffer
+     * @param offsetInCharacters The offset in characters
+     * @return The string
+     * @see #toString(Pointer)
+     * @see #toString(Pointer, int, int)
+     */
+    public static String toString(Pointer pointer, int offsetInCharacters) {
+        if (isAPITypeWide()) {
+            return pointer.getWideString(offsetInCharacters * getCharWidth());
+        } else {
+            return pointer.getString(offsetInCharacters);
+        }
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param pointer The buffer
+     * @param offsetInCharacters The offset in characters
+     * @param lengthInCharacters The length of the string in characters
+     * @return The string
+     * @see #toString(Pointer)
+     * @see #toString(Pointer, int)
+     */
+    public static String toString(Pointer pointer, int offsetInCharacters, int lengthInCharacters) {
+        byte[] bytes = pointer.getByteArray(offsetInCharacters * getCharWidth(), lengthInCharacters * getCharWidth());
+        return toString(bytes, 0);
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param buffer The buffer
+     * @return The string
+     * @see #toString(byte[], long)
+     */
+    public static String toString(byte[] buffer) {
+        return toString(buffer, 0);
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param buffer The buffer
+     * @param offsetInCharacters The offset in characters
+     * @return The string
+     * @see #toString(byte[])
+     */
+    public static String toString(byte[] buffer, long offsetInCharacters) {
+        Memory pointer = new Memory(buffer.length + 1 * getCharWidth());
+        pointer.write(0, buffer, 0, buffer.length);
+
+        // Ensure null-termination
+        byte[] zeros = new byte[getCharWidth()];
+        Arrays.fill(zeros, (byte)0);
+        pointer.write(buffer.length, zeros, 0, zeros.length);
+
+        if (isAPITypeWide()) {
+            return pointer.getWideString(offsetInCharacters * getCharWidth());
+        } else {
+            return pointer.getString(offsetInCharacters);
+        }
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param buffer The buffer
+     * @return The string
+     * @see #toString(char[], int)
+     * @see #toString(char[], int, int)
+     */
+    public static String toString(char[] buffer) {
+        return toString(buffer, 0);
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param buffer The buffer
+     * @param offsetInCharacters The offset in characters
+     * @return The string
+     * @see #toString(char[])
+     * @see #toString(char[], int, int)
+     */
+    public static String toString(char[] buffer, int offsetInCharacters) {
+        Memory pointer = new Memory((buffer.length + 1) * Native.WCHAR_SIZE); // Always allocate for wide
+        pointer.write(0, buffer, 0, buffer.length);
+
+        // Ensure null-termination
+        byte[] zeros = new byte[getCharWidth()];
+        Arrays.fill(zeros, (byte)0);
+        pointer.write(buffer.length * getCharWidth(), zeros, 0, zeros.length);
+
+        if (isAPITypeWide()) {
+            return pointer.getWideString(offsetInCharacters * getCharWidth());
+        } else {
+            return pointer.getString(offsetInCharacters);
+        }
+    }
+
+    /**
+     * Convert buffer to string
+     *
+     * @param buffer The buffer
+     * @param offsetInCharacters The offset in characters
+     * @param lengthInCharacters The max length in characters of the string
+     * @return The string
+     * @see #toString(char[])
+     * @see #toString(char[], int)
+     */
+    public static String toString(char[] buffer, int offsetInCharacters, int lengthInCharacters) {
+        return toString(buffer, offsetInCharacters).substring(0, lengthInCharacters);
+    }
+
+    /**
+     * Convert buffer to a raw string
+     *
+     * @param biffer The buffer
+     * @return The string. Note that the string can contain embedded \0.
+     * @see #toRawString(char[])
+     */
+    public static String toRawString(char[] buffer) {
+        if (isAPITypeWide()) {
+            return new String(buffer);
+        } else {
+            Memory pointer = new Memory(buffer.length * Native.WCHAR_SIZE); // Always allocate for wide
+            pointer.write(0, buffer, 0, buffer.length);
+            byte[] bytes = pointer.getByteArray(0, (int)pointer.size());
+            return new String(bytes, 0, buffer.length); // Only the first part of the buffer contains data
+        }
+    }
+
+    /**
+     * Convert buffer to a raw string
+     *
+     * @param pointer The buffer
+     * @param sizeInBytes The size of the string to fetch from <code>pointer</code>
+     * @return The string. Note that the string can contain embedded \0.
+     * @see #toRawString(char[])
+     */
+    public static String toRawString(Pointer pointer, int sizeInBytes) {
+        int sizeInCharacters = sizeInBytes / getCharWidth();
+        if (isAPITypeWide()) {
+            char[] buffer = pointer.getCharArray(0, sizeInCharacters);
+            return new String(buffer);
+        } else {
+            byte[] buffer = pointer.getByteArray(0, sizeInCharacters);
+            return new String(buffer);
+        }
+    }
+
+    /**
+     * Set string in buffer <code>mem</code> at offset <code>offsetInCharacters</code>
+     *
+     * @param str The string to set
+     * @param mem The destination buffer
+     * @param offsetInCharacters The offset to the start of the string
+     * @see #setString(String, byte[], int)
+     * @see #setString(String, char[], int)
+     */
+    public static void setString(String str, Memory mem, int offsetInCharacters) {
+        if (isAPITypeWide()) {
+            mem.setWideString(offsetInCharacters * getCharWidth(), str);
+        } else {
+            mem.setString(offsetInCharacters, str);
+        }
+    }
+
+    /**
+     * Set string in buffer <code>dest</code> at position <code>destPos</code>
+     * String will be null-terminated.
+     *
+     * @param src The string to set
+     * @param dest The destination buffer
+     * @param destPos The index in <code>dest</code> to write string to
+     * @see #setString(String, char[], int)
+     * @see #setString(String, Memory, int)
+     */
+    public static void setString(String src, byte[] dest, int destPos) {
+        Memory mem = allocateBuffer(src);
+        byte[] buf = mem.getByteArray(0, (int)mem.size());
+        System.arraycopy(buf, 0, dest, destPos, buf.length);
+
+        // Null termination
+        for (int i = 0; i < getCharWidth(); i++) {
+            dest[destPos + buf.length + i] = 0;
+        }
+    }
+
+    /**
+     * Set string in buffer <code>dest</code> at position <code>destPos</code>
+     * String will be null-terminated.
+     *
+     * @param src The string to set
+     * @param dest The destination buffer
+     * @param destPos The index in <code>dest</code> to write string to
+     * @see #setString(String, byte[], int)
+     * @see #setString(String, Memory, int)
+     */
+    public static void setString(String src, char[] dest, int destPos) {
+        Memory mem = allocateBuffer(src);
+        char[] buf = mem.getCharArray(0, toSizeInCharacters(mem));
+        System.arraycopy(buf, 0, dest, destPos, buf.length);
+
+        // Null termination
+        for (int i = 0; i < getCharWidth(); i++) {
+            dest[destPos + buf.length + i] = 0;
+        }
+    }
+
+    /**
+     * Allocate buffer for string <code>str</code>
+     *
+     * @param str The string
+     * @return Memory object containing string
+     * @see #allocateBuffer(String[])
+     * @see #allocateBuffer(int)
+     */
+    public static Memory allocateBuffer(String str) {
+        Memory mem = allocateBuffer(str.length() + 1);
+        setString(str, mem, 0);
+        return mem;
+    }
+
+    /**
+     * Allocate buffer and join array elements by padding \0
+     * Example in memory: <code>str1\0str2\0str3\0\0</code>
+     *
+     * @param arr The string array
+     * @return Memory object containing string array
+     * @see #allocateBuffer(String)
+     * @see #allocateBuffer(int)
+     */
+    public static Memory allocateBuffer(String[] arr) {
+        int size = 0;
+        for (String s : arr) {
+            size += s.length() + 1; // Null termination
+        }
+        size += 1; // Null termination
+
+        Memory data = W32StringUtil.allocateBuffer(size);
+        data.clear();
+        int offset = 0;
+        for (String s : arr) {
+            setString(s, data, offset);
+            offset += s.length() + 1; // Null termination
+        }
+        return data;
+    }
+
+    /**
+     * Allocate buffer for <code>sizeInCharacters</code> number of characters
+     *
+     * @param sizeInCharacters The number of characters
+     * @return Memory object with desired size
+     * @see #allocateBuffer(String)
+     * @see #allocateBuffer(String[])
+     */
+    public static Memory allocateBuffer(int sizeInCharacters) {
+        return new Memory(sizeInCharacters * getCharWidth());
+    }
+
+    /**
+     * Return the number of characters <code>mem</code> can contain
+     *
+     * @param mem The memory pointer
+     * @return Number of characters that <code>mem</code> contains
+     */
+    public static int toSizeInCharacters(Memory mem) {
+        return (int)mem.size() / getCharWidth();
+    }
+
+    /**
+     * Unpack a list of null terminated string to an array of strings.
+     * The list ends with an empty string.
+     * Example in memory: <code>str1\0str2\0str3\0\0</code>
+     *
+     * @param ptr Pointer to memory containing the list
+     * @return Array of strings
+     * @see #fromJoinedStringArray(char[])
+     */
+    public static String[] fromJoinedStringArray(Pointer ptr) {
+        List<String> result = new ArrayList<String>();
+        int offsetInCharacters = 0;
+        while (true) {
+            String str = toString(ptr, offsetInCharacters);
+            if (str.isEmpty()) { // found the ending '\0'
+                break;
+            }
+
+            result.add(str);
+            offsetInCharacters += str.length() + 1;
+        }
+        return result.toArray(new String[result.size()]);
+    }
+
+    /**
+     * Unpack a list of null terminated string to an array of strings.
+     * The list ends with an empty string.
+     * Example in memory: <code>str1\0str2\0str3\0\0</code>
+     *
+     * @param buffer The buffer
+     * @return Array of strings
+     * @see #fromJoinedStringArray(Pointer)
+     */
+    public static String[] fromJoinedStringArray(char[] buffer) {
+        Memory mem = new Memory((buffer.length + 1) * Native.WCHAR_SIZE); // Always allocate for wide
+        mem.clear();
+        mem.write(0, buffer, 0, buffer.length);
+
+        return fromJoinedStringArray(mem);
+    }
+}


### PR DESCRIPTION
Using JNA on Windows with the system property "w32.ascii" set to "true" is broken.
This PR attempts to fix the problems revealed by the test suite.

I've compared the result of running the test suite from ANT with w32.ascii=true and w32.ascii=false, and there is only one test case that differs. I'm unable to figure out why calling Ddeml.INSTANCE.DdeCreateStringHandle() with oversized string returns null for UNICODE but non-null value for ANSI version of the API.

Looking forward to some feedback on this large PR!