### PR TITLE
Only validate if archive bit is set in file attributes

### DIFF
--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -1049,7 +1049,7 @@ public class Kernel32Test extends TestCase {
             }
             FILE_ATTRIBUTE_TAG_INFO fati = new FILE_ATTRIBUTE_TAG_INFO(p);
             // New files have the archive bit
-            assertEquals(WinNT.FILE_ATTRIBUTE_ARCHIVE, fati.FileAttributes);
+            assertEquals(WinNT.FILE_ATTRIBUTE_ARCHIVE, fati.FileAttributes & WinNT.FILE_ATTRIBUTE_ARCHIVE);
 
             p = new Memory(FILE_ID_INFO.sizeOf());
             if (false == Kernel32.INSTANCE.GetFileInformationByHandleEx(hFile, WinBase.FileIdInfo, p, new DWORD(p.size()))) {


### PR DESCRIPTION
There might be other file attributes set depending on current system
configuration. Don't fail the test if there are other attributes set.

Signed-off-by: Torbjörn Svensson <azoff@svenskalinuxforeningen.se>