### PR TITLE
Allow overriding w32.ascii when running test suite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Next Release (5.7.0)
 
 Features
 --------
+* [#1231](https://github.com/java-native-access/jna/pull/1231): The test suite can now be executed on Windows using either ANSI or UNICODE win32 API by passing `-Dw32.ascii=true/false` to ant. Previously, UNICODE was always used. - [@T-Svensson](https://github.com/T-Svensson/)
 
 Bug Fixes
 ---------

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -221,6 +221,9 @@ com.sun.jna.platform.wince;version=${osgi.version}
       <echo>tests.platform.windows=${tests.platform.windows}</echo>
       <echo>tests.platform.linux=${tests.platform.linux}</echo>
       <echo>tests.platform.unix=${tests.platform.unix}</echo>
+      <propertyset id="native.api.windows">
+        <propertyref name="w32.ascii"/>
+      </propertyset>
       <junit fork="${test.fork}" failureproperty="testfailure" tempdir="${build.dir}">
         <!-- optionally run headless -->
         <syspropertyset refid="headless"/>
@@ -228,6 +231,8 @@ com.sun.jna.platform.wince;version=${osgi.version}
         <env key="${ld.preload.name}" file="${libjsig}"/>
         <!-- Ignore any system install of JNA -->
         <sysproperty key="jna.builddir" file="${file.reference.jna.build}"/>
+        <!-- Optionally force native API on Windows -->
+        <syspropertyset refid="native.api.windows"/>
         <jvmarg value="${vmopt.arch}"/>
         <classpath><path path="${run.test.classpath}"/><path path="${file.reference.jna.build}/test-classes"/></classpath>
         <formatter type="brief" usefile="false"/>


### PR DESCRIPTION
Passing -Dw32.ascii=true or -Dw32.ascii=false on the command line to ANT
will forward the property to the test suite. This allows to run tests on
both the ANSI and the UNICODE versions of the API explicitly.
Not passing the -Dw32.ascii command line option results in the same
behavior as previous versions, i.e. the property is not set.

Signed-off-by: Torbjörn Svensson <azoff@svenskalinuxforeningen.se>