### PR TITLE
Fix broken unittests by 7372ba5

### DIFF
--- a/contrib/platform/test/com/sun/jna/platform/win32/User32WindowMessagesTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32WindowMessagesTest.java
@@ -294,7 +294,7 @@ public class User32WindowMessagesTest extends AbstractWin32TestSupport {
 
     public HWND determineHWNDFromWindowClass(String windowClass) {
         CallBackFindWindowHandleByWindowclass cb = new CallBackFindWindowHandleByWindowclass(windowClass);
-        assertCallSucceeded("Find HWND for " + windowClass, User32.INSTANCE.EnumWindows(cb, null));
+        User32.INSTANCE.EnumWindows(cb, null);
         return cb.getFoundHwnd();
 
     }


### PR DESCRIPTION
Commit 7372ba5 introduced return type checking for calls. This is
invalid for the case of EnumWindow. The callback passed to EnumWindow
(EnumWindowsProc) is documented as:

  To continue enumeration, the callback function must return TRUE; to
  stop enumeration, it must return FALSE.

And EnumWindow:

  If EnumWindowsProc returns zero, the return value is also zero. In
  this case, the callback function should call SetLastError to obtain a
  meaningful error code to be returned to the caller of EnumWindows.

TL;DR: If the iteration is ended early (as is the case here if the
target HWND is found), the return is 0 and thus FALSE.