### PR TITLE
Reworked the way allocated memory is tracked

### DIFF
--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -79,14 +79,7 @@ public class Memory extends Pointer {
 
                 // handle stale references here to avoid GC overheating when memory is limited
                 while ((stale = (LinkedReference) QUEUE.poll()) != null) {
-                    Memory memory = stale.get();
-
-                    if (memory != null) {
-                        // dispose does the unlink call internal
-                        memory.dispose();
-                    } else {
-                        stale.unlink();
-                    }
+                    stale.unlink();
                 }
             }
 
@@ -168,14 +161,7 @@ public class Memory extends Pointer {
 
             // try to release as mutch memory as possible
             while ((stale = (LinkedReference) QUEUE.poll()) != null) {
-                Memory memory = stale.get();
-
-                if (memory != null) {
-                    // dispose does the unlink call internal
-                    memory.dispose();
-                } else {
-                    stale.unlink();
-                }
+                stale.unlink();
             }
         }
     }

--- a/test/com/sun/jna/MemoryTest.java
+++ b/test/com/sun/jna/MemoryTest.java
@@ -25,9 +25,7 @@ package com.sun.jna;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.util.Map;
 
 import junit.framework.TestCase;
 
@@ -183,23 +181,22 @@ public class MemoryTest extends TestCase {
             "[0c0d0e]" + ls, m.dump());
     }
 
-    public void testRemoveAllocatedMemoryMap() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+    public void testRemoveAllocatedMemory() {
         // Make sure there are no remaining allocations
         Memory.disposeAll();
-
-        // get a reference to the allocated memory
-        Field allocatedMemoryField = Memory.class.getDeclaredField("allocatedMemory");
-        allocatedMemoryField.setAccessible(true);
-        Map<Memory, Reference<Memory>> allocatedMemory = (Map<Memory, Reference<Memory>>) allocatedMemoryField.get(null);
-        assertEquals(0, allocatedMemory.size());
+        assertEquals(0, Memory.integrityCheck());
 
         // Test allocation and ensure it is accounted for
         Memory mem = new Memory(1024);
-        assertEquals(1, allocatedMemory.size());
+        assertEquals(1, Memory.integrityCheck());
+
+        // Test shared memory is not tracked
+        Pointer shared = mem.share(0, 32);
+        assertEquals(1, Memory.integrityCheck());
 
         // Dispose memory and ensure allocation is removed from allocatedMemory-Map
         mem.dispose();
-        assertEquals(0, allocatedMemory.size());
+        assertEquals(0, Memory.integrityCheck());
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Replaced the WeakHashMap with a doubly linked list of WeakReferences to
improve performance by reducing the time spent in synchronized blocks.


| Benchmark                          | Branch           | Java version | Mode   | Cnt       | Score       | Error        | Units
| -----------------------------------|------------------|--------------|--------|-----------|-------------|--------------|-------
| MemoryBenchmark.allocateWithMemory | master           |   1.8        | thrpt  | 25        | 1420406.020 | ± 46239.151  | ops/s
| MemoryBenchmark.allocateWithMemory | linked-reference |   1.8        | thrpt  | 25        | 2020881.615 | ± 33498.284  | ops/s
| MemoryBenchmark.allocateWithMemory | master           |   11         | thrpt  | 25        | 1526824.044 | ± 106555.120 | ops/s
| MemoryBenchmark.allocateWithMemory | linked-reference |   11         | thrpt  | 25        | 2615836.523 | ± 171918.750 | ops/s
| MemoryBenchmark.allocateWithMemory | master           |   14         | thrpt  | 25        | 1877610.032 | ± 108837.116 | ops/s
| MemoryBenchmark.allocateWithMemory | linked-reference |   14         | thrpt  | 25        | 2289198.917 | ± 175390.679 | ops/s