### PR TITLE
Optimized Map/Set lookups in Structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Features
 * [#1237](https://github.com/java-native-access/jna/pull/1237): *Experimental:* Add artifacts that make jna and jna-platform named modules (provide `module-info.class`). The new artifacts are named `jna-jpms.jar` and `jna-platform-jpms.jar` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1242](https://github.com/java-native-access/jna/pull/1242): Add CallWindowProc to User32 - [@heldplayer](https://github.com/heldplayer).
 * [#1239](https://github.com/java-native-access/jna/pull/1239): Improve performance of allocation of `c.s.j.Memory` objects - [@joerg1985](https://github.com/joerg1985).
+* [#1246](https://github.com/java-native-access/jna/pull/1246): Improve performance of `c.s.j.Structure#read` and `c.s.j.Structure#write` - [@joerg1985](https://github.com/joerg1985).
 
 Bug Fixes
 ---------


### PR DESCRIPTION
Reduced the number of Set lookups in Structure.read / Structure.write.
Introduced a new class to replace two entries of a HashMap with one.
This reduces the number of lookups and the initial capacity has been
reduced too.

There is one additional change in line ~363 to avoid a Memory.share() 
call if the size of the structure is known.

I could create a benchmark if required.