### PR TITLE
Fixed a broken super() call

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Variant.java
@@ -773,14 +773,15 @@ public interface Variant {
             }
 
             public ByReference(VARIANT[] variantArg) {
-                this.variantArg = variantArg;
+                super(variantArg);
             }
         }
 
-        public VARIANT[] variantArg = new VARIANT[1];
+        public VARIANT[] variantArg;
 
         public VariantArg() {
             super();
+            variantArg = new VARIANT[1];
         }
 
         /**
@@ -789,6 +790,7 @@ public interface Variant {
          */
         public VariantArg(Pointer pointer) {
             super(pointer);
+            variantArg = new VARIANT[1];
         }
 
         public VariantArg(VARIANT[] variantArg) {


### PR DESCRIPTION
The VariantArg#ByReference(VARIANT[]) constructor did not call the
correct super overloading. This change will avoid the creation of an
not needed array by the VariantArg#ByReference(VARIANT[]) constructor.