### PR TITLE
Avoid reading the currently written field

### DIFF
--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -812,7 +812,7 @@ public abstract class Structure {
         if (structField == null)
             throw new IllegalArgumentException("No such field: " + name);
         setFieldValue(structField.field, value);
-        writeField(structField);
+        writeField(structField, value);
     }
 
     /**
@@ -823,11 +823,20 @@ public abstract class Structure {
         if (structField.isReadOnly)
             return;
 
-        // Get the offset of the field
-        int offset = structField.offset;
-
         // Get the value from the field
         Object value = getFieldValue(structField.field);
+
+        writeField(structField, value);
+    }
+
+    /**
+     * @param structField internal field representation to synch to native memory
+     * @param value value to write
+     */
+    private void writeField(StructField structField, Object value) {
+
+        // Get the offset of the field
+        int offset = structField.offset;
 
         // Determine the type of the field
         Class<?> fieldType = structField.type;


### PR DESCRIPTION
Dropped the reflective read of the currently written field value from Structure.writeField(String name, Object value). This improves performance of explicit writeField calls, usally done if autoWrite is disabled for performance reasons.