### PR TITLE
Enhance bindings for Crypt32 and fix bindings for array attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Features
 Bug Fixes
 ---------
 * [#1244](https://github.com/java-native-access/jna/issues/1244): Fix building on GCC 10 - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1252](https://github.com/java-native-access/jna/issues/1252): - Fix bindings of `CTL_ENTRY#getRgAttribute`, `CTL_INFO#getRgCTLEntry`, `CTL_INFO#getRgExtension`, `CERT_EXTENSIONS#getRgExtension`, `CERT_INFO#getRgExtension`, `CRL_INFO#getRgCRLEntry`, `CRL_INFO#getRgExtension`, `CRL_ENTRY#getRgExtension`. Add bindings for `CertEnumCertificatesInStore`, `CertEnumCTLsInStore`, `CertEnumCRLsInStore` and `CryptQueryObject` in `c.s.j.p.win32.Crypt32`.<br> *WARNING:* The signatures for `CTL_INFO#getRgCTLEntry` and `CTL_INFO#getRgExtension` were changed - as the original signatures were obviously wrong and read the wrong attributes, it is not considered an API break - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.6.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Crypt32.java
@@ -501,4 +501,170 @@ public interface Crypt32 extends StdCallLibrary {
      *      "https://msdn.microsoft.com/en-us/library/windows/desktop/aa387314(v=vs.85).aspx">MSDN</a>
      */
     HCERTSTORE PFXImportCertStore(DATA_BLOB pPFX, WTypes.LPWSTR szPassword, int dwFlags);
+
+    /**
+     * The CertEnumCertificatesInStore function retrieves the first or next
+     * certificate in a certificate store. Used in a loop, this function can
+     * retrieve in sequence all certificates in a certificate store.
+     *
+     * @param hCertStore       A handle of a certificate store.
+     * @param pPrevCertContext A pointer to the {@link CERT_CONTEXT} of the
+     *                         previous certificate context found.
+     * <p>
+     * This parameter must be NULL to begin the enumeration and get the first
+     * certificate in the store. Successive certificates are enumerated by
+     * setting {@code pPrevCertContext} to the pointer returned by a previous
+     * call to the function. This function frees the {@link CERT_CONTEXT}
+     * referenced by non-NULL values of this parameter.</p>
+     *
+     * <p>
+     * For logical stores, including collection stores, a duplicate of the
+     * pCertContext returned by this function cannot be used to begin a new
+     * subsequence of enumerations because the duplicated certificate loses the
+     * initial enumeration state. The enumeration skips any certificate
+     * previously deleted by CertDeleteCertificateFromStore.</p>
+     *
+     * @return If the function succeeds, the function returns a pointer to the
+     *         next {@link CERT_CONTEXT} in the store. If no more certificates
+     *         exist in the store, the function returns {@code NULL}.
+     *
+     * <p>
+     * For extended error information, call GetLastError. Some possible error
+     * codes follow.</p>
+     *
+     * <table>
+     * <tr><th>Value</th><th>Description</th></tr>
+     * <tr><td>E_INVALIDARG</td><td>The handle in the {@code hCertStore}
+     * parameter is not the same as that in the certificate context pointed to
+     * by {@code pPrevCertContext}.</td></tr>
+     * <tr><td>CRYPT_E_NOT_FOUND</td><td>No certificates were found. This
+     * happens if the store is empty or if the function reached the end of the
+     * store's list.</td></tr>
+     * <tr><td>ERROR_NO_MORE_FILES</td><td>Applies to external stores. No
+     * certificates were found. This happens if the store is empty or if the
+     * function reached the end of the store's list. </td></tr>
+     * </table>
+     *
+     * @see <a href=
+     *      "https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumcertificatesinstore">MSDN</a>
+     */
+    CERT_CONTEXT.ByReference CertEnumCertificatesInStore(HCERTSTORE hCertStore, Pointer pPrevCertContext);
+
+    /**
+     * The CertEnumCTLsInStore function retrieves the first or next certificate
+     * trust list (CTL) context in a certificate store. Used in a loop, this
+     * function can retrieve in sequence all CTL contexts in a certificate
+     * store.
+     *
+     * @param hCertStore      A handle of a certificate store.
+     * @param pPrevCtlContext A pointer to the previous {@link CTL_CONTEXT}
+     *                        structure found. It must be {@code NULL} to get
+     *                        the first CTL in the store. Successive CTLs are
+     *                        enumerated by setting {@code pPrevCtlContext} to
+     *                        the pointer returned by a previous call. This
+     *                        function frees the {@link CTL_CONTEXT} referenced
+     *                        by non-NULL values of this parameter. The
+     *                        enumeration skips any CTLs previously deleted by
+     *                        CertDeleteCTLFromStore.
+     *
+     * @return If the function succeeds, the return value is a pointer to a
+     *         read-only CTL_CONTEXT.
+     *
+     * <p>
+     * If the function fails and a CTL is not found, the return value is NULL.
+     * For extended error information, call GetLastError.</p>
+     *
+     * <table>
+     * <tr><th>Value</th><th>Description</th></tr>
+     * <tr><td>E_INVALIDARG</td><td>The handle in the {@code hCertStore}
+     * parameter is not the same as that in the CTL context pointed to by the
+     * {@code pPrevCtlContext} parameter. </td></tr>
+     * <tr><td>CRYPT_E_NOT_FOUND</td><td>Either no CTLs exist in the store, or
+     * the function reached the end of the store's list.</td></tr>
+     * </table>
+     *
+     * @see <a href=
+     *      "https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumctlsinstore">MSDN</a>
+     */
+    CTL_CONTEXT.ByReference CertEnumCTLsInStore(HCERTSTORE hCertStore, Pointer pPrevCtlContext);
+
+    /**
+     * The CertEnumCRLsInStore function retrieves the first or next certificate
+     * revocation list (CRL) context in a certificate store. Used in a loop,
+     * this function can retrieve in sequence all CRL contexts in a certificate
+     * store. store.
+     *
+     * @param hCertStore      A handle of a certificate store.
+     * @param pPrevCrlContext A pointer to the previous {@link CRL_CONTEXT}
+     *                        structure found. The {@code code pPrevCrlContext}
+     *                        parameter must be {@code NULL} to get the first
+     *                        CRL in the store. Successive CRLs are enumerated
+     *                        by setting {@code pPrevCrlContext} to the pointer
+     *                        returned by a previous call to the function. This
+     *                        function frees the CRL_CONTEXT referenced by
+     *                        non-NULL values of this parameter. The enumeration
+     *                        skips any CRLs previously deleted by
+     *                        CertDeleteCRLFromStore.
+     *
+     * @return If the function succeeds, the return value is a pointer to the
+     *         next {@link CRL_CONTEXT} in the store.
+     *
+     * <p>
+     * {@code NULL} is returned if the function fails. For extended error
+     * information, call GetLastError. Some possible error codes follow.</p>
+     *
+     * <table>
+     * <tr><th>Value</th><th>Description</th></tr>
+     * <tr><td>E_INVALIDARG</td><td>The handle in the {code hCertStore}
+     * parameter is not the same as that in the certificate context pointed to
+     * by {@code pPrevCrlContext}.</td></tr>
+     * <tr><td>CRYPT_E_NOT_FOUND</td><td>No CRL was found. This happens if the
+     * store is empty or the end of the store's list is reached. </td></tr>
+     * </table>
+     *
+     * @see <a href=
+     *      "https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumcrlsinstore">MSDN</a>
+     */
+    CRL_CONTEXT.ByReference CertEnumCRLsInStore(HCERTSTORE hCertStore, Pointer pPrevCrlContext);
+
+    /**
+     * The CryptQueryObject function retrieves information about the contents of
+     * a cryptography API object, such as a certificate, a certificate
+     * revocation list, or a certificate trust list. The object can either
+     * reside in a structure in memory or be contained in a file.
+     *
+     * @param dwObjectType
+     * @param pvObject
+     * @param dwExpectedContentTypeFlags
+     * @param dwExpectedFormatTypeFlags
+     * @param dwFlags
+     * @param pdwMsgAndCertEncodingType
+     * @param pdwContentType
+     * @param pdwFormatType
+     * @param phCertStore
+     * @param phMsg
+     * @param ppvContext
+     *
+     * @return If the function succeeds, the function returns nonzero.
+     *
+     * <p>
+     * If the function fails, it returns zero. For extended error information,
+     * call GetLastError.</p>
+     *
+     * @see <a href=
+     *      "https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptqueryobject">MSDN</a>
+     */
+    boolean CryptQueryObject(
+        int dwObjectType,
+        Pointer pvObject,
+        int dwExpectedContentTypeFlags,
+        int dwExpectedFormatTypeFlags,
+        int dwFlags,
+        IntByReference pdwMsgAndCertEncodingType,
+        IntByReference pdwContentType,
+        IntByReference pdwFormatType,
+        PointerByReference phCertStore,
+        PointerByReference phMsg,
+        PointerByReference ppvContext
+    );
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
@@ -129,10 +129,12 @@ public interface WinCrypt {
             if (cAttribute == 0) {
                 return new CRYPT_ATTRIBUTE[0];
             } else {
-                return (CRYPT_ATTRIBUTE[]) Structure.newInstance(
-                        CERT_EXTENSION.class,
+                CRYPT_ATTRIBUTE[] result = (CRYPT_ATTRIBUTE[]) Structure.newInstance(
+                        CRYPT_ATTRIBUTE.class,
                         rgAttribute)
                         .toArray(cAttribute);
+                result[0].read();
+                return result;
             }
         }
     }
@@ -248,25 +250,29 @@ public interface WinCrypt {
         public int cExtension;
         public Pointer rgExtension;
 
-        public CTL_ENTRY[] getRgExtension() {
+        public CTL_ENTRY[] getRgCTLEntry() {
             if (cCTLEntry == 0) {
                 return new CTL_ENTRY[0];
             } else {
-                return (CTL_ENTRY[]) Structure.newInstance(
+                CTL_ENTRY[] result = (CTL_ENTRY[]) Structure.newInstance(
                         CTL_ENTRY.class,
                         rgCTLEntry)
                         .toArray(cCTLEntry);
+                result[0].read();
+                return result;
             }
         }
 
-        public CERT_EXTENSION[] getRgCTLEntry() {
+        public CERT_EXTENSION[] getRgExtension() {
             if (cExtension == 0) {
                 return new CERT_EXTENSION[0];
             } else {
-                return (CERT_EXTENSION[]) Structure.newInstance(
+                CERT_EXTENSION[] result = (CERT_EXTENSION[]) Structure.newInstance(
                         CERT_EXTENSION.class,
                         rgExtension)
                         .toArray(cExtension);
+                result[0].read();
+                return result;
             }
         }
     }
@@ -638,14 +644,14 @@ public interface WinCrypt {
         public Pointer rgExtension;
 
         public CERT_EXTENSION[] getRgExtension() {
-            CERT_EXTENSION[] elements = new CERT_EXTENSION[cExtension];
-            for (int i = 0; i < elements.length; i++) {
-                elements[i] = Structure.newInstance(
-                        CERT_EXTENSION.class,
-                        rgExtension.getPointer(i * Native.POINTER_SIZE));
-                elements[i].read();
+            if(cExtension == 0) {
+                return new CERT_EXTENSION[0];
             }
-            return elements;
+            CERT_EXTENSION[] ces = (CERT_EXTENSION[]) Structure
+                .newInstance(CERT_EXTENSION.class, rgExtension)
+                .toArray(cExtension);
+            ces[0].read();
+            return ces;
         }
     }
 
@@ -676,14 +682,14 @@ public interface WinCrypt {
         public Pointer rgExtension;
 
         public CERT_EXTENSION[] getRgExtension() {
-            CERT_EXTENSION[] elements = new CERT_EXTENSION[cExtension];
-            for (int i = 0; i < elements.length; i++) {
-                elements[i] = Structure.newInstance(
-                        CERT_EXTENSION.class,
-                        rgExtension.getPointer(i * Native.POINTER_SIZE));
-                elements[i].read();
+            if(cExtension == 0) {
+                return new CERT_EXTENSION[0];
             }
-            return elements;
+            CERT_EXTENSION[] ces = (CERT_EXTENSION[]) Structure
+                .newInstance(CERT_EXTENSION.class, rgExtension)
+                .toArray(cExtension);
+            ces[0].read();
+            return ces;
         }
     }
 
@@ -743,14 +749,15 @@ public interface WinCrypt {
         public Pointer rgExtension;
 
         public CERT_EXTENSION[] getRgExtension() {
-            CERT_EXTENSION[] elements = new CERT_EXTENSION[cExtension];
-            for (int i = 0; i < elements.length; i++) {
-                elements[i] = Structure.newInstance(
-                        CERT_EXTENSION.class,
-                        rgExtension.getPointer(i * Native.POINTER_SIZE));
-                elements[i].read();
+            if(cExtension == 0) {
+                return new CERT_EXTENSION[0];
+            } else {
+                CERT_EXTENSION[] result = (CERT_EXTENSION[]) Structure
+                        .newInstance(CERT_EXTENSION.class, rgExtension)
+                        .toArray(cExtension);
+                result[0].read();
+                return result;
             }
-            return elements;
         }
     }
 
@@ -778,25 +785,27 @@ public interface WinCrypt {
         public Pointer rgExtension;
 
         public CRL_ENTRY[] getRgCRLEntry() {
-            CRL_ENTRY[] elements = new CRL_ENTRY[cCRLEntry];
-            for (int i = 0; i < elements.length; i++) {
-                elements[i] = Structure.newInstance(
-                        CRL_ENTRY.class,
-                        rgCRLEntry.getPointer(i * Native.POINTER_SIZE));
-                elements[i].read();
+            if (cCRLEntry == 0) {
+                return new CRL_ENTRY[0];
+            } else {
+                CRL_ENTRY[] result = (CRL_ENTRY[]) Structure
+                        .newInstance(CRL_ENTRY.class, rgCRLEntry)
+                        .toArray(cCRLEntry);
+                result[0].read();
+                return result;
             }
-            return elements;
         }
 
         public CERT_EXTENSION[] getRgExtension() {
-            CERT_EXTENSION[] elements = new CERT_EXTENSION[cExtension];
-            for (int i = 0; i < elements.length; i++) {
-                elements[i] = Structure.newInstance(
-                        CERT_EXTENSION.class,
-                        rgExtension.getPointer(i * Native.POINTER_SIZE));
-                elements[i].read();
+            if (cExtension == 0) {
+                return new CERT_EXTENSION[0];
+            } else {
+                CERT_EXTENSION[] result = (CERT_EXTENSION[]) Structure
+                        .newInstance(CERT_EXTENSION.class, rgExtension)
+                        .toArray(cExtension);
+                result[0].read();
+                return result;
             }
-            return elements;
         }
     }
 
@@ -1613,4 +1622,121 @@ public interface WinCrypt {
      * called functions. For details, see Remarks.
      */
     int CERT_CLOSE_STORE_CHECK_FLAG = 0x00000002;
+    /** encoded single certificate */
+    int CERT_QUERY_CONTENT_CERT = 1;
+    /** encoded single CTL */
+    int CERT_QUERY_CONTENT_CTL = 2;
+    /** encoded single CRL */
+    int CERT_QUERY_CONTENT_CRL = 3;
+    /** serialized store */
+    int CERT_QUERY_CONTENT_SERIALIZED_STORE = 4;
+    /** serialized single certificate */
+    int CERT_QUERY_CONTENT_SERIALIZED_CERT = 5;
+    /** serialized single CTL */
+    int CERT_QUERY_CONTENT_SERIALIZED_CTL = 6;
+    /** serialized single CRL */
+    int CERT_QUERY_CONTENT_SERIALIZED_CRL = 7;
+    /** a PKCS#7 signed message */
+    int CERT_QUERY_CONTENT_PKCS7_SIGNED = 8;
+    /** a PKCS#7 message, such as enveloped message. But it is not a signed message,  */
+    int CERT_QUERY_CONTENT_PKCS7_UNSIGNED = 9;
+    /** a PKCS7 signed message embedded in a file */
+    int CERT_QUERY_CONTENT_PKCS7_SIGNED_EMBED = 10;
+    /** an encoded PKCS#10 */
+    int CERT_QUERY_CONTENT_PKCS10 = 11;
+    /** an encoded PFX BLOB */
+    int CERT_QUERY_CONTENT_PFX = 12;
+    /** an encoded CertificatePair (contains forward and/or reverse cross certs) */
+    int CERT_QUERY_CONTENT_CERT_PAIR = 13;
+    /** an encoded PFX BLOB, which was loaded to phCertStore */
+    int CERT_QUERY_CONTENT_PFX_AND_LOAD = 14;
+
+    /** encoded single certificate */
+    int CERT_QUERY_CONTENT_FLAG_CERT = (1 << CERT_QUERY_CONTENT_CERT);
+
+    /** encoded single CTL */
+    int CERT_QUERY_CONTENT_FLAG_CTL = (1 << CERT_QUERY_CONTENT_CTL);
+
+    /** encoded single CRL */
+    int CERT_QUERY_CONTENT_FLAG_CRL = (1 << CERT_QUERY_CONTENT_CRL);
+
+    /** serialized store */
+    int CERT_QUERY_CONTENT_FLAG_SERIALIZED_STORE = (1 << CERT_QUERY_CONTENT_SERIALIZED_STORE);
+
+    /** serialized single certificate */
+    int CERT_QUERY_CONTENT_FLAG_SERIALIZED_CERT = (1 << CERT_QUERY_CONTENT_SERIALIZED_CERT);
+
+    /** serialized single CTL */
+    int CERT_QUERY_CONTENT_FLAG_SERIALIZED_CTL = (1 << CERT_QUERY_CONTENT_SERIALIZED_CTL);
+
+    /** serialized single CRL */
+    int CERT_QUERY_CONTENT_FLAG_SERIALIZED_CRL = (1 << CERT_QUERY_CONTENT_SERIALIZED_CRL);
+
+    /** an encoded PKCS#7 signed message */
+    int CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED = (1 << CERT_QUERY_CONTENT_PKCS7_SIGNED);
+
+    /** an encoded PKCS#7 message.  But it is not a signed message */
+    int CERT_QUERY_CONTENT_FLAG_PKCS7_UNSIGNED = (1 << CERT_QUERY_CONTENT_PKCS7_UNSIGNED);
+
+    /** the content includes an embedded PKCS7 signed message */
+    int CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED = (1 << CERT_QUERY_CONTENT_PKCS7_SIGNED_EMBED);
+
+    /** an encoded PKCS#10 */
+    int CERT_QUERY_CONTENT_FLAG_PKCS10 = (1 << CERT_QUERY_CONTENT_PKCS10);
+
+    /** an encoded PFX BLOB */
+    int CERT_QUERY_CONTENT_FLAG_PFX = (1 << CERT_QUERY_CONTENT_PFX);
+
+    /** an encoded CertificatePair (contains forward and/or reverse cross certs) */
+    int CERT_QUERY_CONTENT_FLAG_CERT_PAIR = (1 << CERT_QUERY_CONTENT_CERT_PAIR);
+
+    /** an encoded PFX BLOB, and we do want to load it (not included in {@link #CERT_QUERY_CONTENT_FLAG_ALL} */
+    int CERT_QUERY_CONTENT_FLAG_PFX_AND_LOAD = (1 << CERT_QUERY_CONTENT_PFX_AND_LOAD);
+
+    /** content can be any type */
+    int CERT_QUERY_CONTENT_FLAG_ALL = CERT_QUERY_CONTENT_FLAG_CERT
+        | CERT_QUERY_CONTENT_FLAG_CTL
+        | CERT_QUERY_CONTENT_FLAG_CRL
+        | CERT_QUERY_CONTENT_FLAG_SERIALIZED_STORE
+        | CERT_QUERY_CONTENT_FLAG_SERIALIZED_CERT
+        | CERT_QUERY_CONTENT_FLAG_SERIALIZED_CTL
+        | CERT_QUERY_CONTENT_FLAG_SERIALIZED_CRL
+        | CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED
+        | CERT_QUERY_CONTENT_FLAG_PKCS7_UNSIGNED
+        | CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED
+        | CERT_QUERY_CONTENT_FLAG_PKCS10
+        | CERT_QUERY_CONTENT_FLAG_PFX
+        | CERT_QUERY_CONTENT_FLAG_CERT_PAIR;
+
+    /** the content is in binary format */
+    int CERT_QUERY_FORMAT_BINARY = 1;
+
+    /** the content is base64 encoded */
+    int CERT_QUERY_FORMAT_BASE64_ENCODED = 2;
+
+    /** the content is ascii hex encoded with "{ASN}" prefix */
+    int CERT_QUERY_FORMAT_ASN_ASCII_HEX_ENCODED = 3;
+
+    /** the content is in binary format */
+    int CERT_QUERY_FORMAT_FLAG_BINARY = ( 1 << CERT_QUERY_FORMAT_BINARY);
+
+    /** the content is base64 encoded */
+    int CERT_QUERY_FORMAT_FLAG_BASE64_ENCODED = ( 1 << CERT_QUERY_FORMAT_BASE64_ENCODED);
+
+    /** the content is ascii hex encoded with "{ASN}" prefix */
+    int CERT_QUERY_FORMAT_FLAG_ASN_ASCII_HEX_ENCODED  = ( 1 << CERT_QUERY_FORMAT_ASN_ASCII_HEX_ENCODED);
+
+    /** the content can be of any format */
+    int CERT_QUERY_FORMAT_FLAG_ALL = CERT_QUERY_FORMAT_FLAG_BINARY
+        | CERT_QUERY_FORMAT_FLAG_BASE64_ENCODED
+        | CERT_QUERY_FORMAT_FLAG_ASN_ASCII_HEX_ENCODED;
+
+    /**
+     * The object is stored in a file.
+     */
+    int CERT_QUERY_OBJECT_FILE = 0x00000001;
+    /**
+     * The object is stored in a structure in memory.
+     */
+    int CERT_QUERY_OBJECT_BLOB = 0x00000002;
 }


### PR DESCRIPTION
The implementations of the rgAttribute, rgCTLEntry and rgExtension
attributes are not in line with the observed behaviour of the API. At
least in part they are documented to be pointers to arrays of pointers
to structures. This is not correct, as segfaults were observed and
testing shows, that they are in fact pointers to arrays of structures.

In addition it was observed, that the bindings of CTL_INFO#getRgCTLEntry
and CTL_INFO#getRgExtension method names were inverted.

The bindings for CERT_EXTENSIONS#getRgExtension and 
CTL_INFO#getRgExtension are untested as but assumed to be implemented
identically to the tested bindings.

The functions 

- CertEnumCertificatesInStore
- CertEnumCTLsInStore
- CertEnumCRLsInStore
- CryptQueryObject

from `c.s.j.p.win32.Crypt32` were bound to be able to excercise the
accessors.