### PR TITLE
Allow defining a ComInterface by name

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/IDispatch.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/IDispatch.java
@@ -23,13 +23,17 @@
  */
 package com.sun.jna.platform.win32.COM.util;
 
+import com.sun.jna.platform.win32.COM.ITypeInfo;
+import com.sun.jna.platform.win32.COM.util.annotation.ComInterface;
 import com.sun.jna.platform.win32.OaIdl.DISPID;
 
 /**
  * Java friendly version of {@link com.sun.jna.platform.win32.COM.IDispatch}.
  *
  */
+@ComInterface(iid = "00020400-0000-0000-C000-000000000046")
 public interface IDispatch extends IUnknown {
+    ITypeInfo getTypeInfo();
     <T> void setProperty(String name, T value);
     <T> T getProperty(Class<T> returnType, String name, Object... args);
     <T> T invokeMethod(Class<T> returnType, String name, Object... args);

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/annotation/ComInterface.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/annotation/ComInterface.java
@@ -34,4 +34,5 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface ComInterface {
     String iid() default "";
+    String name() default "";
 }


### PR DESCRIPTION
Allow name based binding to interfaces, like the name bases binding to methods. This is needed to create version independent bindings to COM interfaces. This change allows to access type infos from the Java friendly IDispose interface, this helps debugging, but might be made private if desired.