### PR TITLE
Remove the need for dos2unix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+*             text=auto
+Makefile*     text eol=lf
+*.am          text eol=lf
+*.m4          text eol=lf
+*.sh          text eol=lf
+*.sub         text eol=lf
+*.guess       text eol=lf
+*.host        text eol=lf
+libtool*      text eol=lf


### PR DESCRIPTION
Force automake files to use `eol=lf` on clone, avoiding the [painstaking `dos2unix` workarounds](https://github.com/java-native-access/jna/blame/3996d47ef55c2ab99834ef9817a989c87d8a85ee/www/WindowsDevelopmentEnvironment.md#L55).

Related #1264, since the request may lead to a modification of `www/WindowsDevelopmentEnvironment.md` for ARM64 support, which specifically mentions:

> If you get errors such as `'\r': command not found`, run `dos2unix -f [filename]` for each file that it's complaining about.

In my experience, the error is much more vague and obscure, e.g. `AC_CONFIG_MACRO_DIRS([m4]) conflicts with ACLOCAL_AMFLAGS=-I m4` (and dozens of other confusing automake-generated errors) sending developers on a wild goose chase. 🍻 

Another alternative is to set the following:

```bash
# LAST RESORT, DON'T USE
git config --global core.autocrlf false
git config --global core.eol lf
```

... but this has the disadvantage of affecting non-jna projects, so it's ill advised.