### PR TITLE
Fix native conversion for empty CFStringRef.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Bug Fixes
 ---------
 * [#1244](https://github.com/java-native-access/jna/issues/1244): Fix building on GCC 10 - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1252](https://github.com/java-native-access/jna/issues/1252): - Fix bindings of `CTL_ENTRY#getRgAttribute`, `CTL_INFO#getRgCTLEntry`, `CTL_INFO#getRgExtension`, `CERT_EXTENSIONS#getRgExtension`, `CERT_INFO#getRgExtension`, `CRL_INFO#getRgCRLEntry`, `CRL_INFO#getRgExtension`, `CRL_ENTRY#getRgExtension`. Add bindings for `CertEnumCertificatesInStore`, `CertEnumCTLsInStore`, `CertEnumCRLsInStore` and `CryptQueryObject` in `c.s.j.p.win32.Crypt32`.<br> *WARNING:* The signatures for `CTL_INFO#getRgCTLEntry` and `CTL_INFO#getRgExtension` were changed - as the original signatures were obviously wrong and read the wrong attributes, it is not considered an API break - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1275](https://github.com/java-native-access/jna/issues/1275): Fix `CFStringRef#stringValue` for empty Strings - [@dyorgio](https://github.com/dyorgio).
 
 Release 5.6.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/mac/CoreFoundation.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/CoreFoundation.java
@@ -488,15 +488,18 @@ public interface CoreFoundation extends Library {
          */
         public String stringValue() {
             CFIndex length = INSTANCE.CFStringGetLength(this);
+            if (length.longValue() == 0) {
+                return "";
+            }
             CFIndex maxSize = INSTANCE.CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
             if (maxSize.intValue() == kCFNotFound) {
-                return null;
+                throw new StringIndexOutOfBoundsException("CFString maximum number of bytes exceeds LONG_MAX.");
             }
             Memory buf = new Memory(maxSize.longValue());
             if (0 != INSTANCE.CFStringGetCString(this, buf, maxSize, kCFStringEncodingUTF8)) {
                 return buf.getString(0, "UTF8");
             }
-            return null;
+            throw new IllegalArgumentException("CFString conversion fails or the provided buffer is too small.");
         }
     }
 

--- a/contrib/platform/test/com/sun/jna/platform/mac/CoreFoundationTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/mac/CoreFoundationTest.java
@@ -81,6 +81,10 @@ public class CoreFoundationTest {
 
         desc.release();
         cfAwesome.release();
+
+        CFStringRef cfEmpty = CFStringRef.createCFString("");
+        assertTrue(cfEmpty.stringValue().equals(""));
+        cfEmpty.release();
     }
 
     @Test


### PR DESCRIPTION
If you try to convert a CFStringRef with empty string (char[0]) an Exception is throws in com.sun.jna.Memory(long) constructor:
java.lang.IllegalArgumentException: Allocation size must be greater than zero

Issue: https://github.com/java-native-access/jna/issues/1274