### PR TITLE
Add additional calling convention support for Win x86

### DIFF
--- a/native/dispatch.c
+++ b/native/dispatch.c
@@ -629,6 +629,22 @@ dispatch(JNIEnv *env, void* func, jint flags, jobjectArray args,
     abi = FFI_STDCALL;
 #endif
     break;
+  case CALLCONV_THISCALL:
+#if defined(_WIN64) || defined(_WIN32_WCE)
+    // Ignore requests for thiscall on win64/wince
+    abi = FFI_DEFAULT_ABI;
+#else
+    abi = FFI_THISCALL;
+#endif
+    break;
+  case CALLCONV_FASTCALL:
+#if defined(_WIN64) || defined(_WIN32_WCE)
+    // Ignore requests for fastcall on win64/wince
+    abi = FFI_DEFAULT_ABI;
+#else
+    abi = FFI_FASTCALL;
+#endif
+    break;
 #endif // _WIN32
   default:
     abi = (int)callconv;
@@ -3412,6 +3428,8 @@ Java_com_sun_jna_Native_registerMethod(JNIEnv *env, jclass UNUSED(ncls),
   jint* cvts = conversions ? (*env)->GetIntArrayElements(env, conversions, NULL) : NULL;
 #if defined(_WIN32) && !defined(_WIN64) && !defined(_WIN32_WCE)
   if (cc == CALLCONV_STDCALL) abi = FFI_STDCALL;
+  else if (cc == CALLCONV_THISCALL) abi = FFI_THISCALL;
+  else if (cc == CALLCONV_FASTCALL) abi = FFI_FASTCALL;
 #endif
   if (!(abi > FFI_FIRST_ABI && abi < FFI_LAST_ABI)) {
     char msg[MSG_SIZE];

--- a/native/dispatch.h
+++ b/native/dispatch.h
@@ -82,6 +82,8 @@ typedef enum _callconv {
     CALLCONV_C = com_sun_jna_Function_C_CONVENTION,
 #ifdef _WIN32
     CALLCONV_STDCALL = com_sun_jna_Function_ALT_CONVENTION,
+    CALLCONV_THISCALL = com_sun_jna_Function_THISCALL_CONVENTION,
+    CALLCONV_FASTCALL = com_sun_jna_Function_FASTCALL_CONVENTION,
 #endif
 } callconv_t;
 

--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -70,6 +70,12 @@ public class Function extends Pointer {
     /** First alternate convention (currently used only for w32 stdcall). */
     @java.lang.annotation.Native
     public static final int ALT_CONVENTION = 0x3F;
+    /** thiscall alternate convention (used only for w32 thiscall). */
+    @java.lang.annotation.Native
+    public static final int THISCALL_CONVENTION = 0x1F;
+    /** fastcall alternate convention (used only for w32 fastcall). */
+    @java.lang.annotation.Native
+    public static final int FASTCALL_CONVENTION = 0xF;
 
     @java.lang.annotation.Native
     private static final int MASK_CC = 0x3F;


### PR DESCRIPTION
I need to use some native code compiled for windows x86 and some of the code I am calling include __thiscall and __fastcall calling conventions. I see the support is not built-in for JNA so I decided to contribute some of my changes. I welcome all feedback and will happily adjust as needed.

Thanks