### PR TITLE
Fix unittests for windows 32bit intel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Bug Fixes
 * [#1252](https://github.com/java-native-access/jna/issues/1252): - Fix bindings of `CTL_ENTRY#getRgAttribute`, `CTL_INFO#getRgCTLEntry`, `CTL_INFO#getRgExtension`, `CERT_EXTENSIONS#getRgExtension`, `CERT_INFO#getRgExtension`, `CRL_INFO#getRgCRLEntry`, `CRL_INFO#getRgExtension`, `CRL_ENTRY#getRgExtension`. Add bindings for `CertEnumCertificatesInStore`, `CertEnumCTLsInStore`, `CertEnumCRLsInStore` and `CryptQueryObject` in `c.s.j.p.win32.Crypt32`.<br> *WARNING:* The signatures for `CTL_INFO#getRgCTLEntry` and `CTL_INFO#getRgExtension` were changed - as the original signatures were obviously wrong and read the wrong attributes, it is not considered an API break - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1275](https://github.com/java-native-access/jna/issues/1275): Fix `CFStringRef#stringValue` for empty Strings - [@dyorgio](https://github.com/dyorgio).
 * [#1279](https://github.com/java-native-access/jna/issues/1279): Remove `DLLCallback` import from `CallbackReference` - [@dyorgio](https://github.com/dyorgio).
+* [#1278](https://github.com/java-native-access/jna/pull/1278): Improve compatibility of `c.s.j.p.WindowUtils#getProcessFilePath` and fix unittests for windows 32bit intel  - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.6.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/Psapi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Psapi.java
@@ -226,6 +226,8 @@ public interface Psapi extends StdCallLibrary {
     boolean GetModuleInformation(HANDLE hProcess, HMODULE hModule, MODULEINFO lpmodinfo, int cb);
 
     /**
+     * Retrieves the name of the executable file for the specified process.
+     *
      * @param hProcess
      *            A handle to the process. The handle must have the
      *            PROCESS_QUERY_INFORMATION or PROCESS_QUERY_LIMITED_INFORMATION

--- a/contrib/platform/test/com/sun/jna/platform/mac/XAttrUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/mac/XAttrUtilTest.java
@@ -157,7 +157,7 @@ public class XAttrUtilTest extends TestCase {
 
     public void testWriteAlignedCliTool() throws IOException, InterruptedException {
         Process p = Runtime.getRuntime().exec(new String[] {"xattr", "-w", "JNA", "Java Native Access", testPath});
-        assertTrue(p.waitFor(10, TimeUnit.SECONDS));
+        assertTrue(p.waitFor(30, TimeUnit.SECONDS));
         String resultString = XAttrUtil.getXAttr(testPath, "JNA");
         assertEquals("Java Native Access", resultString);
     }

--- a/contrib/platform/test/com/sun/jna/platform/win32/User32WindowMessagesTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/User32WindowMessagesTest.java
@@ -33,6 +33,7 @@ import org.junit.runner.JUnitCore;
 
 import com.sun.jna.CallbackReference;
 import com.sun.jna.Native;
+import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
@@ -442,8 +443,14 @@ public class User32WindowMessagesTest extends AbstractWin32TestSupport {
         }
 
         SubClassedWindowProc subclass = new SubClassedWindowProc();
-        subclass.oldWindowProc = User32.INSTANCE.SetWindowLongPtr(hwndToSubclass, WinUser.GWL_WNDPROC,
-                CallbackReference.getFunctionPointer(subclass));
+        if(Platform.is64Bit()) {
+            subclass.oldWindowProc = User32.INSTANCE.SetWindowLongPtr(hwndToSubclass, WinUser.GWL_WNDPROC,
+                    CallbackReference.getFunctionPointer(subclass));
+        } else {
+            // From MSDN: When compiling for 32-bit Windows, SetWindowLongPtr is defined as a call to the SetWindowLong function.
+            User32.INSTANCE.SetWindowLong(hwndToSubclass, WinUser.GWL_WNDPROC,
+                (int) Pointer.nativeValue(CallbackReference.getFunctionPointer(subclass)));
+        }
     }
 
     /**


### PR DESCRIPTION
With the improvements done by @tresf in #1264 three failing windows unittests on x86 were identified:

- `GetModuleFileNameExW` can fail on 64bit platforms, if the calling programm is 32bit. I did not find official documentation about this, but the indication I found on the net speculate, that the problem is observed, when the target process is mapped beyon the memory range, that a 32 bit process can observe. `GetProcessImageFileName` can be used as an alternative, but returns a different format (device path) and needs to be converted, to return the expected value.
- `testCreateRemoteThread` creates a thread by writing the binary directly into memory and starting the thread with the memory location. That binary was only valid for 64bit, but nor for 32 bit (different calling convention). The binary for x86 was retrieved by combining observations of binaries and assembler output from mingw and reading the opcode documentation for x86.
- `testWindowMesssages` failed because `SetWindowLongPtr` only exists on x86-64, on x86 it is only present as a header based alias for `SetWindowLong`