### PR TITLE
Remove DLLCallback import from CallbackReference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Bug Fixes
 * [#1244](https://github.com/java-native-access/jna/issues/1244): Fix building on GCC 10 - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1252](https://github.com/java-native-access/jna/issues/1252): - Fix bindings of `CTL_ENTRY#getRgAttribute`, `CTL_INFO#getRgCTLEntry`, `CTL_INFO#getRgExtension`, `CERT_EXTENSIONS#getRgExtension`, `CERT_INFO#getRgExtension`, `CRL_INFO#getRgCRLEntry`, `CRL_INFO#getRgExtension`, `CRL_ENTRY#getRgExtension`. Add bindings for `CertEnumCertificatesInStore`, `CertEnumCTLsInStore`, `CertEnumCRLsInStore` and `CryptQueryObject` in `c.s.j.p.win32.Crypt32`.<br> *WARNING:* The signatures for `CTL_INFO#getRgCTLEntry` and `CTL_INFO#getRgExtension` were changed - as the original signatures were obviously wrong and read the wrong attributes, it is not considered an API break - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1275](https://github.com/java-native-access/jna/issues/1275): Fix `CFStringRef#stringValue` for empty Strings - [@dyorgio](https://github.com/dyorgio).
+* [#1279](https://github.com/java-native-access/jna/issues/1279): Remove `DLLCallback` import from `CallbackReference` - [@dyorgio](https://github.com/dyorgio).
 
 Release 5.6.0
 =============

--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -68,14 +68,14 @@ public class CallbackReference extends WeakReference<Callback> {
         }
     }
     
-    private static final Class<Callback> DLL_CALLBACK_CLASS;
+    private static final Class<?> DLL_CALLBACK_CLASS;
     
     static {
         if (Platform.isWindows()) {
             try {
                 DLL_CALLBACK_CLASS = Class.forName("com.sun.jna.win32.DLLCallback");
-            } catch(Exception e) {
-                throw new Error("Error loading DLLCallback class");
+            } catch(ClassNotFoundException e) {
+                throw new Error("Error loading DLLCallback class", e);
             }
         } else {
             DLL_CALLBACK_CLASS = null;

--- a/src/com/sun/jna/CallbackReference.java
+++ b/src/com/sun/jna/CallbackReference.java
@@ -41,8 +41,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 
-import com.sun.jna.win32.DLLCallback;
-
 /**
  * Provides a reference to an association between a native callback closure and
  * a Java {@link Callback} closure.
@@ -67,6 +65,20 @@ public class CallbackReference extends WeakReference<Callback> {
             PROXY_CALLBACK_METHOD = CallbackProxy.class.getMethod("callback", new Class[] { Object[].class });
         } catch(Exception e) {
             throw new Error("Error looking up CallbackProxy.callback() method");
+        }
+    }
+    
+    private static final Class<Callback> DLL_CALLBACK_CLASS;
+    
+    static {
+        if (Platform.isWindows()) {
+            try {
+                DLL_CALLBACK_CLASS = Class.forName("com.sun.jna.win32.DLLCallback");
+            } catch(Exception e) {
+                throw new Error("Error loading DLLCallback class");
+            }
+        } else {
+            DLL_CALLBACK_CLASS = null;
         }
     }
 
@@ -215,7 +227,8 @@ public class CallbackReference extends WeakReference<Callback> {
             nativeParamTypes = method.getParameterTypes();
             returnType = method.getReturnType();
             int flags = Native.CB_OPTION_DIRECT;
-            if (callback instanceof DLLCallback) {
+            if (DLL_CALLBACK_CLASS != null
+                && DLL_CALLBACK_CLASS.isInstance(callback)) {
                 flags |= Native.CB_OPTION_IN_DLL;
             }
             peer = Native.createNativeCallback(callback, method,
@@ -261,7 +274,8 @@ public class CallbackReference extends WeakReference<Callback> {
                     + " requires custom type conversion";
                 throw new IllegalArgumentException(msg);
             }
-            int flags = callback instanceof DLLCallback
+            int flags = DLL_CALLBACK_CLASS != null
+                && DLL_CALLBACK_CLASS.isInstance(callback)
                 ? Native.CB_OPTION_IN_DLL : 0;
             peer = Native.createNativeCallback(proxy, PROXY_CALLBACK_METHOD,
                                                nativeParamTypes, returnType,


### PR DESCRIPTION
This pull request solves opened issue https://github.com/java-native-access/jna/issues/1279.
The idea is remove a static dependency of win32 package on parent package (generic/multi).