### PR TITLE
Prevent illegal access exceptions, when retrieving options for private library interfaces with an instance field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Bug Fixes
 * [#1275](https://github.com/java-native-access/jna/issues/1275): Fix `CFStringRef#stringValue` for empty Strings - [@dyorgio](https://github.com/dyorgio).
 * [#1279](https://github.com/java-native-access/jna/issues/1279): Remove `DLLCallback` import from `CallbackReference` - [@dyorgio](https://github.com/dyorgio).
 * [#1278](https://github.com/java-native-access/jna/pull/1278): Improve compatibility of `c.s.j.p.WindowUtils#getProcessFilePath` and fix unittests for windows 32bit intel  - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1284](https://github.com/java-native-access/jna/pull/1284): Fix illegal access exceptions, when retrieving options for private library interfaces with an instance field - [@fkistner](https://github.com/fkistner).
 
 Release 5.6.0
 =============

--- a/build.xml
+++ b/build.xml
@@ -1256,7 +1256,7 @@ cd ..
       </and>
     </condition>
     <property name="tests.platform" value=""/>
-    <property name="tests.include" value="com/sun/jna/*Test.java"/>
+    <property name="tests.include" value="com/sun/jna/*Test.java com/sun/jna/different_package/*Test.java"/>
     <property name="tests.exclude" value=""/>
     <property name="tests.exclude-patterns" value=""/>
     <condition property="java.awt.headless" value="true">
@@ -1282,7 +1282,7 @@ cd ..
       <formatter type="xml"/>
       <batchtest todir="${results.junit}">
         <fileset dir="${test.src}" excludes="${tests.exclude-patterns}">
-          <include name="${tests.include}"/>
+          <patternset includes="${tests.include}"/>
           <include name="${tests.platform}"/>
           <exclude name="${tests.exclude}"/>
         </fileset>

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -664,6 +664,7 @@ public final class Native implements Version {
                     if (field.getType() == cls
                         && Modifier.isStatic(field.getModifiers())) {
                         // Ensure the field gets initialized by reading it
+                        field.setAccessible(true); // interface might be private
                         libraries.put(cls, new WeakReference<Object>(field.get(null)));
                         break;
                     }

--- a/test/com/sun/jna/different_package/PrivateDirectCallbacksTest.java
+++ b/test/com/sun/jna/different_package/PrivateDirectCallbacksTest.java
@@ -1,3 +1,26 @@
+/* Copyright (c) 2020 Florian Kistner, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
 package com.sun.jna.different_package;
 
 import com.sun.jna.*;

--- a/test/com/sun/jna/different_package/PrivateDirectCallbacksTest.java
+++ b/test/com/sun/jna/different_package/PrivateDirectCallbacksTest.java
@@ -1,0 +1,82 @@
+package com.sun.jna.different_package;
+
+import com.sun.jna.*;
+import junit.framework.TestCase;
+
+public class PrivateDirectCallbacksTest extends TestCase {
+    private interface PrivateWithCallbackArgumentTestLibrary extends Library {
+        PrivateWithCallbackArgumentTestLibrary INSTANCE = new DirectPrivateWithCallbackArgumentTestLibrary();
+
+        interface VoidCallback extends Callback {
+            void callback();
+        }
+
+        void callVoidCallback(VoidCallback c);
+    }
+
+    private static class DirectPrivateWithCallbackArgumentTestLibrary implements PrivateWithCallbackArgumentTestLibrary {
+        @Override
+        public native void callVoidCallback(VoidCallback c);
+
+        static {
+            Native.register("testlib");
+        }
+    }
+
+    public void testCallVoidCallback() {
+        final boolean[] called = {false};
+        PrivateWithCallbackArgumentTestLibrary.VoidCallback cb = new PrivateWithCallbackArgumentTestLibrary.VoidCallback() {
+            @Override
+            public void callback() {
+                called[0] = true;
+            }
+        };
+        PrivateWithCallbackArgumentTestLibrary.INSTANCE.callVoidCallback(cb);
+        assertTrue("Callback not called", called[0]);
+    }
+
+    private interface PrivateWithCallbackReturnTestLibrary extends Library {
+        PrivateWithCallbackReturnTestLibrary INSTANCE = new DirectPrivateWithCallbackReturnTestLibrary();
+
+        interface Int32CallbackX extends Callback {
+            int callback(int arg);
+        }
+
+        Int32CallbackX returnCallback();
+
+        Int32CallbackX returnCallbackArgument(Int32CallbackX cb);
+    }
+
+    private static class DirectPrivateWithCallbackReturnTestLibrary implements PrivateWithCallbackReturnTestLibrary {
+        @Override
+        public native Int32CallbackX returnCallback();
+
+        @Override
+        public native Int32CallbackX returnCallbackArgument(Int32CallbackX cb);
+
+        static {
+            Native.register("testlib");
+        }
+    }
+
+    public void testInvokeCallback() {
+        PrivateWithCallbackReturnTestLibrary.Int32CallbackX cb = PrivateWithCallbackReturnTestLibrary.INSTANCE.returnCallback();
+        assertNotNull("Callback should not be null", cb);
+        assertEquals("Callback should be callable", 1, cb.callback(1));
+
+        PrivateWithCallbackReturnTestLibrary.Int32CallbackX cb2 = new PrivateWithCallbackReturnTestLibrary.Int32CallbackX() {
+            @Override
+            public int callback(int arg) {
+                return 0;
+            }
+        };
+        assertSame("Java callback should be looked up",
+                cb2, PrivateWithCallbackReturnTestLibrary.INSTANCE.returnCallbackArgument(cb2));
+        assertSame("Existing native function wrapper should be reused",
+                cb, PrivateWithCallbackReturnTestLibrary.INSTANCE.returnCallbackArgument(cb));
+    }
+
+    public static void main(java.lang.String[] argList) {
+        junit.textui.TestRunner.run(PrivateDirectCallbacksTest.class);
+    }
+}

--- a/test/com/sun/jna/different_package/PrivateLibraryInfoTest.java
+++ b/test/com/sun/jna/different_package/PrivateLibraryInfoTest.java
@@ -1,0 +1,31 @@
+package com.sun.jna.different_package;
+
+import com.sun.jna.Callback;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import junit.framework.TestCase;
+
+public class PrivateLibraryInfoTest extends TestCase {
+    private interface TestLibrary extends Library {
+        @SuppressWarnings("unused")
+        TestLibrary INSTANCE = new TestLibrary() {
+        };
+
+        interface VoidCallback extends Callback {
+            void callback();
+        }
+    }
+
+    public void testLibraryInfo() {
+        assertTrue(Native.getLibraryOptions(TestLibrary.class).containsKey(Library.OPTION_TYPE_MAPPER));
+    }
+
+    public void testCallbackLibraryInfo() {
+        TestLibrary.VoidCallback cb = new TestLibrary.VoidCallback() {
+            @Override
+            public void callback() {
+            }
+        };
+        assertTrue(Native.getLibraryOptions(cb.getClass()).containsKey(Library.OPTION_TYPE_MAPPER));
+    }
+}

--- a/test/com/sun/jna/different_package/PrivateLibraryInfoTest.java
+++ b/test/com/sun/jna/different_package/PrivateLibraryInfoTest.java
@@ -1,3 +1,26 @@
+/* Copyright (c) 2020 Florian Kistner, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
 package com.sun.jna.different_package;
 
 import com.sun.jna.Callback;


### PR DESCRIPTION
<details>
  <summary>System info</summary>
  
1. Version of JNA and related jars: latest master
2. Version and vendor of the java virtual machine: Amazon Corretto 11.0.9.1
3. Operating system: macOS 10.15.7 (19H2)
4. System architecture (CPU type, bitness of the JVM): x86_64
</details>

JNA encounters `IllegalAccessException`s, when trying to retrieve library options from `private` `Library` interfaces that contain an instance field. Since direct mapped classes may retrieve options for the first time, only when a callback is passed or returned, this can happen rather unexpectedly.

This change suppresses the `IllegalAccessException`s by calling `setAccessible` like it is already done, when looking up other fields of the library interface via reflection.

<details>
  <summary>Example stack traces (see <code>PrivateLibraryInfoTest.java</code> and <code>PrivateDirectCallbacksTest.java</code>)</summary>
  
```
java.lang.IllegalArgumentException: Could not access instance of interface com.sun.jna.different_package.PrivateDirectCallbacksTest$PrivateWithCallbackArgumentTestLibrary (java.lang.IllegalAccessException: Class com.sun.jna.Native can not access a member of class com.sun.jna.different_package.PrivateDirectCallbacksTest$PrivateWithCallbackArgumentTestLibrary with modifiers "public static final")

	at com.sun.jna.Native.loadLibraryInstance(Native.java:673)
	at com.sun.jna.Native.getLibraryOptions(Native.java:737)
	at com.sun.jna.CallbackReference.getFunctionPointer(CallbackReference.java:455)
	at com.sun.jna.different_package.PrivateDirectCallbacksTest$DirectPrivateWithCallbackArgumentTestLibrary.callVoidCallback(Native Method)

java.lang.ExceptionInInitializerError
	at com.sun.jna.different_package.PrivateDirectCallbacksTest$PrivateWithCallbackReturnTestLibrary.<clinit>(PrivateDirectCallbacksTest.java:39)
	at com.sun.jna.different_package.PrivateDirectCallbacksTest.testInvokeCallback(PrivateDirectCallbacksTest.java:63)
…
Caused by: java.lang.IllegalArgumentException: Could not access instance of interface com.sun.jna.different_package.PrivateDirectCallbacksTest$PrivateWithCallbackReturnTestLibrary (java.lang.IllegalAccessException: Class com.sun.jna.Native can not access a member of class com.sun.jna.different_package.PrivateDirectCallbacksTest$PrivateWithCallbackReturnTestLibrary with modifiers "public static final")
	at com.sun.jna.Native.loadLibraryInstance(Native.java:673)
	at com.sun.jna.Native.getLibraryOptions(Native.java:737)
	at com.sun.jna.Native.getTypeMapper(Native.java:799)
	at com.sun.jna.Structure$FFIType.get(Structure.java:2151)
	at com.sun.jna.Structure$FFIType.get(Structure.java:2146)
	at com.sun.jna.Native.register(Native.java:1793)
```
</details>

