### PR TITLE
[GITHUB-1286] Fix DBT Bindings and Win32WindowDemo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Features
 
 Bug Fixes
 ---------
+* [#1286](https://github.com/java-native-access/jna/pull/1286): Fix bindings of `c.s.j.p.win32.DBT` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#326](https://github.com/java-native-access/jna/issues/326): Fix loading library that re-uses pointers for different callbacks - [@fpapai](https://github.com/fpapai).
 * [#1244](https://github.com/java-native-access/jna/issues/1244): Fix building on GCC 10 - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1252](https://github.com/java-native-access/jna/issues/1252): - Fix bindings of `CTL_ENTRY#getRgAttribute`, `CTL_INFO#getRgCTLEntry`, `CTL_INFO#getRgExtension`, `CERT_EXTENSIONS#getRgExtension`, `CERT_INFO#getRgExtension`, `CRL_INFO#getRgCRLEntry`, `CRL_INFO#getRgExtension`, `CRL_ENTRY#getRgExtension`. Add bindings for `CertEnumCertificatesInStore`, `CertEnumCTLsInStore`, `CertEnumCRLsInStore` and `CryptQueryObject` in `c.s.j.p.win32.Crypt32`.<br> *WARNING:* The signatures for `CTL_INFO#getRgCTLEntry` and `CTL_INFO#getRgExtension` were changed - as the original signatures were obviously wrong and read the wrong attributes, it is not considered an API break - [@matthiasblaesing](https://github.com/matthiasblaesing).

--- a/contrib/native_window_msg/build.xml
+++ b/contrib/native_window_msg/build.xml
@@ -2,14 +2,13 @@
 <project name="jnacontrib.native_window_msg" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.native_window_msg.</description>
     <!-- Locations -->
-    <property name="src"                location="./src"/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-nativewindowmsg.jar"/>
+    <property name="src"                    location="./src"/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-nativewindowmsg.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"			value="com.sun.jna.platform.win32.Win32WindowDemo.java" />
+    <property name="main-class"             value="com.sun.jna.platform.win32.Win32WindowDemo" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>

--- a/contrib/native_window_msg/src/com/sun/jna/platform/win32/Win32WindowDemo.java
+++ b/contrib/native_window_msg/src/com/sun/jna/platform/win32/Win32WindowDemo.java
@@ -51,7 +51,7 @@ public class Win32WindowDemo implements WindowProc {
      */
     public Win32WindowDemo() {
         // define new window class
-        String windowClass = new String("MyWindowClass");
+        String windowClass = "MyWindowClass";
         HMODULE hInst = Kernel32.INSTANCE.GetModuleHandle("");
 
         WNDCLASSEX wClass = new WNDCLASSEX();
@@ -123,6 +123,7 @@ public class Win32WindowDemo implements WindowProc {
      * .win32.WinDef.HWND, int, com.sun.jna.platform.win32.WinDef.WPARAM,
      * com.sun.jna.platform.win32.WinDef.LPARAM)
      */
+    @Override
     public LRESULT callback(HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam) {
         switch (uMsg) {
             case WinUser.WM_CREATE: {
@@ -152,7 +153,7 @@ public class Win32WindowDemo implements WindowProc {
      *
      * @return the last error
      */
-    public int getLastError() {
+    public final int getLastError() {
         int rc = Kernel32.INSTANCE.GetLastError();
 
         if (rc != 0)
@@ -294,9 +295,8 @@ public class Win32WindowDemo implements WindowProc {
                 DEV_BROADCAST_DEVICEINTERFACE bdif = new DEV_BROADCAST_DEVICEINTERFACE(bhdr.getPointer());
                 System.out.println("BROADCAST_DEVICEINTERFACE: " + action);
                 System.out.println("dbcc_devicetype: " + bdif.dbcc_devicetype);
-                System.out.println("dbcc_name: " + bdif.getDbcc_name());
-                System.out.println("dbcc_classguid: "
-                        + bdif.dbcc_classguid.toGuidString());
+                System.out.println("dbcc_name:       " + bdif.getDbcc_name());
+                System.out.println("dbcc_classguid:  " + bdif.dbcc_classguid.toGuidString());
                 break;
             }
             case DBT.DBT_DEVTYP_HANDLE: {
@@ -314,7 +314,9 @@ public class Win32WindowDemo implements WindowProc {
             case DBT.DBT_DEVTYP_PORT: {
                 // see http://msdn.microsoft.com/en-us/library/windows/desktop/aa363248.aspx
                 DEV_BROADCAST_PORT bpt = new DEV_BROADCAST_PORT(bhdr.getPointer());
-                System.out.println("BROADCAST_PORT: " + action);
+                System.out.println("BROADCAST_PORT:  " + action);
+                System.out.println("dbcp_devicetype: " + bpt.dbcp_devicetype);
+                System.out.println("dbcp_name:       " + bpt.getDbcpName());
                 break;
             }
             case DBT.DBT_DEVTYP_VOLUME: {
@@ -380,6 +382,7 @@ public class Win32WindowDemo implements WindowProc {
      * @param args
      *            the arguments
      */
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
     public static void main(String[] args) {
         new Win32WindowDemo();
     }

--- a/contrib/platform/test/com/sun/jna/platform/win32/DBTTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/DBTTest.java
@@ -1,0 +1,50 @@
+/* Copyright (c) 2020 Matthias Bläsing
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32;
+
+import com.sun.jna.Structure;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_DEVICEINTERFACE;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_DEVNODE;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_HANDLE;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_HDR;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_NET;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_OEM;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_PORT;
+import com.sun.jna.platform.win32.DBT.DEV_BROADCAST_VOLUME;
+import org.junit.Test;
+
+public class DBTTest {
+    @Test
+    public void testInstantiation() {
+        // Ensure, that the structures can be instantiated
+        Structure.newInstance(DEV_BROADCAST_DEVICEINTERFACE.class);
+        Structure.newInstance(DEV_BROADCAST_DEVNODE.class);
+        Structure.newInstance(DEV_BROADCAST_HANDLE.class);
+        Structure.newInstance(DEV_BROADCAST_HDR.class);
+        Structure.newInstance(DEV_BROADCAST_NET.class);
+        Structure.newInstance(DEV_BROADCAST_OEM.class);
+        Structure.newInstance(DEV_BROADCAST_PORT.class);
+        Structure.newInstance(DEV_BROADCAST_VOLUME.class);
+    }
+}


### PR DESCRIPTION
- Ensure all structures defined in com.sun.jna.platform.win32.DBT can be
  instantiated
- Use correct mapping for DEV_BROADCAST_PORT#dbcp_name. And add accessor
  for the string value of that property. This is an API incompatible
  change, but the class could not be instantiated, so it is assumed,
  that it is a safe change
- Prevent potential out-of-bounds read in DEV_BROADCAST_DEVICEINTERFACE
- Make demo-nativewindowmsg.jar runnable

Closes: #1286