### PR TITLE
Reduce Travis CI Build Matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,9 @@ jobs:
           brew install libtool --force
       - name: Checkstyle
         if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '8')
-        run: ant checkstyle
+        run: |
+          ant checkstyle
+          ant dist
       - name: Build with Ant
         run: |
           ant test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,37 +3,32 @@ dist: trusty
 
 language: java
 
+# disable shallow clone
 git:
   depth: false
 
-install:
-  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then 
-      sudo apt-get -m install openjdk-11-jdk libltdl-dev;
-      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64;
-      export PATH=$JAVA_HOME/bin:$PATH; 
+before_install:
+  - |
+    if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)'
+    then
+      echo "Not running CI since only docs were changed."
+      travis_terminate 0
     fi
+  - sudo apt-get -m install openjdk-11-jdk libltdl-dev;
+  - export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64;
+  - export PATH=$JAVA_HOME/bin:$PATH; 
+
+install:
   - export APACHE_ANT_BASE=$(curl http://apache.mirror.iphh.net/ant/binaries/ | grep "apache-ant-1.9..*-bin.tar.gz" | tail -1 | sed  's/.*href="\(.*\)-bin.tar.gz".*/\1/g')
   - 'echo "Apache Ant ARCHIVE: $APACHE_ANT_BASE"'
-  - '[ "${TRAVIS_OS_NAME}" = "linux" ] && wget http://apache.mirror.iphh.net/ant/binaries/$APACHE_ANT_BASE-bin.tar.gz && tar xzf $APACHE_ANT_BASE-bin.tar.gz && sudo mv $APACHE_ANT_BASE /usr/local/$APACHE_ANT_BASE && sudo rm -f /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE/bin/ant /usr/local/bin/ant || true'
-  - '[ "${TRAVIS_OS_NAME}" = "linux" ] && sudo apt-get -y install texinfo || true'
-  - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew update || true'
-  - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew uninstall libtool && brew install libtool || true'
-  - '[ "${TRAVIS_OS_NAME}" = "osx" ] && brew install ant || true'
+  - 'wget http://apache.mirror.iphh.net/ant/binaries/$APACHE_ANT_BASE-bin.tar.gz && tar xzf $APACHE_ANT_BASE-bin.tar.gz && sudo mv $APACHE_ANT_BASE /usr/local/$APACHE_ANT_BASE && sudo rm -f /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE/bin/ant /usr/local/bin/ant || true'
+  - 'sudo apt-get -y install texinfo || true'
 
 script:
-  - if [[ "${TRAVIS_CPU_ARCH}" != "arm64" && "x$JDK" != "xdefault" ]]; then wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh && export JAVA_HOME=$(bash install-jdk.sh --feature $JDK --emit-java-home | tail -1); export PATH=$JAVA_HOME/bin:$PATH; fi || true
   - ant test
   - ant test-platform
-  - if [ "x$JDK" == "xdefault" ]; then ant checkstyle; fi
-  - if [ "x$JDK" == "xdefault" ]; then ant dist; fi
 
 jobs:
-    include:
-        - env: JDK=default
-        - env: JDK=11
-        - env: JDK=ea
-        - env: JDK=11
-          arch: arm64
-        - env: JDK=11
-          os: osx
- 
+  include:
+    - name: "Linux JDK11 ARM"
+      arch: arm64

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ![Java Native Access - JNA](https://github.com/java-native-access/jna/raw/master/www/images/jnalogo.jpg "Java Native Access - JNA")
 
-[![Build Status](https://travis-ci.org/java-native-access/jna.svg?branch=master)](https://travis-ci.org/java-native-access/jna)
-[![Build status](https://ci.appveyor.com/api/projects/status/j6vmpjrw5iktb8iu/branch/master?svg=true)](https://ci.appveyor.com/project/dblock/jna-gsxuq/branch/master)
+[![Github Actions Build Status](https://github.com/java-native-access/jna/workflows/Java%20CI/badge.svg)](https://github.com/ojava-native-access/jna/actions?query=workflow%3A%22Java+CI%22)
+[![Travis Build Status](https://travis-ci.org/java-native-access/jna.svg?branch=master)](https://travis-ci.org/java-native-access/jna)
+[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/j6vmpjrw5iktb8iu/branch/master?svg=true)](https://ci.appveyor.com/project/dblock/jna-gsxuq/branch/master)
 
 Java Native Access (JNA)
 ========================


### PR DESCRIPTION
As noted in #1282 sometime in the next few weeks, travis-ci.org will go away and accounts will be migrated to travis-ci.com.
![image](https://user-images.githubusercontent.com/9291703/103107661-457c2500-45f5-11eb-9263-1e0319f0d7ed.png)

While Travis CI has announced that they will still permit free builds for open source projects, they require a manual allocation of CI minutes (after an initial free 1000 minutes).  To reduce the rate at which we use these minutes, I've removed builds which have already been migrated to Github Actions. Presently that leaves only the Linux ARM build on Travis.