### PR TITLE
Fix some windows test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Java Native Access - JNA](https://github.com/java-native-access/jna/raw/master/www/images/jnalogo.jpg "Java Native Access - JNA")
 
-[![Github Actions Build Status](https://github.com/java-native-access/jna/workflows/Java%20CI/badge.svg)](https://github.com/ojava-native-access/jna/actions?query=workflow%3A%22Java+CI%22)
+[![Github Actions Build Status](https://github.com/java-native-access/jna/workflows/Java%20CI/badge.svg)](https://github.com/java-native-access/jna/actions?query=workflow%3A%22Java+CI%22)
 [![Travis Build Status](https://travis-ci.org/java-native-access/jna.svg?branch=master)](https://travis-ci.org/java-native-access/jna)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/j6vmpjrw5iktb8iu/branch/master?svg=true)](https://ci.appveyor.com/project/dblock/jna-gsxuq/branch/master)
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/IPHlpAPITest.java
@@ -26,6 +26,7 @@ package com.sun.jna.platform.win32;
 import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET;
 import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET6;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
@@ -66,25 +67,18 @@ public class IPHlpAPITest {
                 MIB_IFROW ifRow = new MIB_IFROW();
                 ifRow.dwIndex = netint.getIndex();
                 assertEquals(WinError.NO_ERROR, IPHLP.GetIfEntry(ifRow));
-                // Bytes should exceed packets
                 // These originate from unsigned ints. Use standard Java
                 // widening conversion to long which does sign-extension,
                 // then drop any copies of the sign bit, to prevent the value
                 // being considered a negative one by Java if it is set
-                long bytesSent = (ifRow.dwOutOctets) & 0xffffffffL;
-                long packetsSent = (ifRow.dwOutUcastPkts) & 0xffffffffL;
-                if (packetsSent > 0) {
-                    assertTrue(bytesSent > packetsSent);
-                } else {
-                    assertEquals(0, bytesSent);
-                }
-                long bytesRecv = (ifRow.dwInOctets) & 0xffffffffL;
-                long packetsRecv = (ifRow.dwInUcastPkts) & 0xffffffffL;
-                if (packetsRecv > 0) {
-                    assertTrue(bytesRecv > packetsRecv);
-                } else {
-                    assertEquals(0, bytesRecv);
-                }
+                long bytesSent = ifRow.dwOutOctets & 0xffffffffL;
+                long packetsSent = ifRow.dwOutUcastPkts & 0xffffffffL;
+                long bytesRecv = ifRow.dwInOctets & 0xffffffffL;
+                long packetsRecv = ifRow.dwInUcastPkts & 0xffffffffL;
+                // Bytes should match or exceed minimum packet size of 20.
+                // It is possible to have bytes not part of a packet but not vice versa.
+                assertTrue(bytesSent >= packetsSent * 20L);
+                assertTrue(bytesRecv >= packetsRecv * 20L);
             }
         }
 
@@ -105,18 +99,11 @@ public class IPHlpAPITest {
                     // These originate from unsigned longs.
                     BigInteger bytesSent = new BigInteger(Long.toHexString(ifRow.OutOctets), 16);
                     BigInteger packetsSent = new BigInteger(Long.toHexString(ifRow.OutUcastPkts), 16);
-                    if (packetsSent.longValue() > 0) {
-                        assertEquals(1, bytesSent.compareTo(packetsSent));
-                    } else {
-                        assertEquals(0, bytesSent.compareTo(packetsSent));
-                    }
                     BigInteger bytesRecv = new BigInteger(Long.toHexString(ifRow.InOctets), 16);
                     BigInteger packetsRecv = new BigInteger(Long.toHexString(ifRow.InUcastPkts), 16);
-                    if (packetsRecv.longValue() > 0) {
-                        assertEquals(1, bytesRecv.compareTo(packetsRecv));
-                    } else {
-                        assertEquals(0, bytesRecv.compareTo(packetsRecv));
-                    }
+                    BigInteger minPacketSize = BigInteger.valueOf(20);
+                    assertNotEquals(-1, bytesSent.compareTo(packetsSent.multiply(minPacketSize)));
+                    assertNotEquals(-1, bytesRecv.compareTo(packetsRecv.multiply(minPacketSize)));
                 }
             }
         } else {
@@ -199,7 +186,7 @@ public class IPHlpAPITest {
     }
 
     @Test
-    void testTCPv4Connections() {
+    public void testTCPv4Connections() {
         // Get size needed
         IntByReference sizePtr = new IntByReference();
         assertEquals(WinError.ERROR_INSUFFICIENT_BUFFER,
@@ -230,7 +217,7 @@ public class IPHlpAPITest {
     }
 
     @Test
-    void testTCPv6Connections() {
+    public void testTCPv6Connections() {
         // Get size needed
         IntByReference sizePtr = new IntByReference();
         assertEquals(WinError.ERROR_INSUFFICIENT_BUFFER,
@@ -261,7 +248,7 @@ public class IPHlpAPITest {
     }
 
     @Test
-    void testUDPv4Connections() {
+    public void testUDPv4Connections() {
         // Get size needed
         IntByReference sizePtr = new IntByReference();
         assertEquals(WinError.ERROR_INSUFFICIENT_BUFFER,
@@ -289,7 +276,7 @@ public class IPHlpAPITest {
     }
 
     @Test
-    void testUDPv6Connections() {
+    public void testUDPv6Connections() {
         // Get size needed
         IntByReference sizePtr = new IntByReference();
         assertEquals(WinError.ERROR_INSUFFICIENT_BUFFER,

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -1811,7 +1811,8 @@ public class Kernel32Test extends TestCase {
         // Set bit flags to 0x0001
         int previousMode = Kernel32.INSTANCE.SetErrorMode(0x0001);
         // Restore to previous state; 0x0001 is now "previous"
-        assertEquals(Kernel32.INSTANCE.SetErrorMode(previousMode), 0x0001);
+        // Since 0x0004 bit is sticky previous may be 0x0005
+        assertEquals(0x0001, Kernel32.INSTANCE.SetErrorMode(previousMode) & ~0x0004);
     }
 
 // Testcase is disabled, as kernel32 ordinal values are not stable.

--- a/contrib/platform/test/com/sun/jna/platform/win32/SAFEARRAYTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/SAFEARRAYTest.java
@@ -198,11 +198,11 @@ public class SAFEARRAYTest {
         wrap.lock();
         int rowMax = wrap.getUBound(2);
         int columnMax = wrap.getUBound(1);
-        Object[][] result = new Object[(int) (rowMax + 1)][(int) (columnMax + 1)];
+        Object[][] result = new Object[rowMax + 1][columnMax + 1];
         for(int i = 0; i <= rowMax; i++) {
             for(int j = 0; j <= columnMax; j++) {
                 VARIANT cell = (VARIANT) wrap.getElement(i, j);
-                result[(int)i][(int) j] = cell.getValue();
+                result[i][j] = cell.getValue();
                 OleAuto.INSTANCE.VariantClear(cell);
             }
         }
@@ -214,11 +214,11 @@ public class SAFEARRAYTest {
         wrap.lock();
         int rowMax = wrap.getUBound(2);
         int columnMax = wrap.getUBound(1);
-        Object[][] result = new Object[(int) (rowMax + 1)][(int) (columnMax + 1)];
+        Object[][] result = new Object[rowMax + 1][columnMax + 1];
         for(int i = 0; i <= rowMax; i++) {
             for(int j = 0; j <= columnMax; j++) {
                 VARIANT cell = new VARIANT(wrap.ptrOfIndex(i, j));
-                result[(int)i][(int) j] = cell.getValue();
+                result[i][j] = cell.getValue();
             }
         }
         wrap.unlock();
@@ -498,6 +498,7 @@ public class SAFEARRAYTest {
      * Test assumption: The windows search provider is present and holds at least
      * five entries. If this assumption is not met, this test fails.
      */
+    @Ignore("Assumes windows search provider present with five entries")
     @Test
     public void testADODB() {
         ObjectFactory fact = new ObjectFactory();
@@ -770,6 +771,7 @@ public class SAFEARRAYTest {
         }
         private long value;
 
+        @Override
         public long getValue() {
             return this.value;
         }
@@ -791,6 +793,7 @@ public class SAFEARRAYTest {
         }
         private long value;
 
+        @Override
         public long getValue() {
             return this.value;
         }


### PR DESCRIPTION
I tried to get windows tests running on Github Actions.  I've fixed some of the failures that I identified but there are still several failures in Advapi32 and Advapi32Util test classes that I can't seem to fix, and can't figure out how to suppress in ant using test excludes.

Committing the fixes for now.