### PR TITLE
Split jpms modules into independet artifacts instead of classifier based solution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,15 @@ Features
 
 Bug Fixes
 ---------
+* [#1317](https://github.com/java-native-access/jna/pull/1317): Change the maven coordinates of the JPMS artifacts from classifier `jpms` to custom artifact ids `jna-jpms` and `jna-platform-jpms` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
+Important Changes
+-----------------
+* The maven coordinates of the experimental JPMS (java module system) artifacts
+  were moved from using the classifier `jpms` to custom artifact ids `jna-jpms`
+  and `jna-platform-jpms`, without an classifier. The reason for this is, that
+  the platform artifacts depend on the jna artifacts and need to pull in the
+  right variant. This is not possible if the classifier is used.
 
 Release 5.7.0
 =============

--- a/build.xml
+++ b/build.xml
@@ -152,9 +152,13 @@
 
   <property name="pom-base" value="pom-jna.xml" />
   <property name="pom-platform-base" value="pom-jna-platform.xml" />
+  <property name="pom-jpms-base" value="pom-jna-jpms.xml" />
+  <property name="pom-platform-jpms-base" value="pom-jna-platform-jpms.xml" />
 
   <property name="pom" value="${build}/pom-jna.xml" />
   <property name="pom-platform" value="${build}/pom-jna-platform.xml" />
+  <property name="pom-jpms" value="${build}/pom-jna-jpms.xml" />
+  <property name="pom-platform-jpms" value="${build}/pom-jna-platform-jpms.xml" />
 
   <target name="default" depends="test" description="Build and Test."/>
 
@@ -195,7 +199,7 @@
     <property name="build.os.family" value="other"/>
     <property name="build.os.arch" value="${os.arch}" />
     <property name="build.os.endianess" value="${sun.cpu.endian}" />
-    
+
     <condition property="-native" value="true">
       <not><isset property="build-native"/></not>
     </condition>
@@ -203,17 +207,30 @@
       <isset property="-native"/>
     </condition>
 
-    <copy file="${pom-base}" todir="${build}" />
-    <copy file="${pom-platform-base}" todir="${build}" />
+    <copy file="${pom-base}" tofile="${pom}" />
+    <copy file="${pom-platform-base}" tofile="${pom-platform}" />
+    <copy file="${pom-jpms-base}" tofile="${pom-jpms}" />
+    <copy file="${pom-platform-jpms-base}" tofile="${pom-platform-jpms}" />
 
     <replaceregexp match="(&lt;version&gt;).*(&lt;/version&gt;)"
                    replace="\1${jna.version}\2"
+                   flags="g"
                    file="${pom}"/>
 
     <replaceregexp match="(&lt;version&gt;).*(&lt;/version&gt;)"
                    replace="\1${jna.version}\2"
                    flags="g"
                    file="${pom-platform}"/>
+
+    <replaceregexp match="(&lt;version&gt;).*(&lt;/version&gt;)"
+                   replace="\1${jna.version}\2"
+                   flags="g"
+                   file="${pom-jpms}"/>
+
+    <replaceregexp match="(&lt;version&gt;).*(&lt;/version&gt;)"
+                 replace="\1${jna.version}\2"
+                 flags="g"
+                 file="${pom-platform-jpms}"/>
 
     <condition property="jar.omitted" value="**/*jnidispatch*" else="jnilib-included">
       <isset property="omit-jnilib"/>
@@ -1553,10 +1570,10 @@ cd ..
 
     <artifact:mvn failonerror="true">
       <arg value="org.apache.maven.plugins:maven-install-plugin:2.5:install-file"/>
-      <arg value="-DpomFile=${pom}"/>
+      <arg value="-DpomFile=${pom-jpms}"/>
       <arg value="-Dfile=${dist-jar-jpms}"/>
-      <arg value="-Dclassifier=jpms"/>
-      <arg value="-Dpackaging=jar"/>
+      <arg value="-Dsources=${maven-sources-jar}"/>
+      <arg value="-Djavadoc=${maven-javadoc-jar}"/>
     </artifact:mvn>
 
     <artifact:mvn failonerror="true">
@@ -1569,10 +1586,10 @@ cd ..
 
     <artifact:mvn failonerror="true">
       <arg value="org.apache.maven.plugins:maven-install-plugin:2.5:install-file"/>
-      <arg value="-DpomFile=${pom-platform}"/>
+      <arg value="-DpomFile=${pom-platform-jpms}"/>
       <arg value="-Dfile=${platform-jpms-jar}"/>
-      <arg value="-Dclassifier=jpms"/>
-      <arg value="-Dpackaging=jar"/>
+      <arg value="-Dsources=${platform-sources-jar}"/>
+      <arg value="-Djavadoc=${platform-javadoc-jar}"/>
     </artifact:mvn>
   </target>
 
@@ -1584,9 +1601,9 @@ cd ..
       <arg value="-DrepositoryId=${maven-snapshots-repository-id}"/>
       <arg value="-DpomFile=${pom}"/>
       <arg value="-Dfile=${dist-jar}"/>
-      <arg value="-Dfiles=${maven-sources-jar},${maven-javadoc-jar},${dist-jar-jpms},${dist-aar}"/>
-      <arg value="-Dtypes=jar,jar,jar,aar"/>
-      <arg value="-Dclassifiers=sources,javadoc,jpms,"/>
+      <arg value="-Dfiles=${maven-sources-jar},${maven-javadoc-jar},${dist-aar}"/>
+      <arg value="-Dtypes=jar,jar,aar"/>
+      <arg value="-Dclassifiers=sources,javadoc,"/>
     </artifact:mvn>
 
     <artifact:mvn failonerror="true">
@@ -1595,9 +1612,31 @@ cd ..
       <arg value="-DrepositoryId=${maven-snapshots-repository-id}"/>
       <arg value="-DpomFile=${pom-platform}"/>
       <arg value="-Dfile=${platform-jar}"/>
-      <arg value="-Dfiles=${platform-sources-jar},${platform-javadoc-jar},${platform-jpms-jar}"/>
+      <arg value="-Dfiles=${platform-sources-jar},${platform-javadoc-jar}"/>
       <arg value="-Dtypes=jar,jar,jar"/>
-      <arg value="-Dclassifiers=sources,javadoc,jpms"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
+    </artifact:mvn>
+
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
+      <arg value="-Durl=${maven-snapshots-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-snapshots-repository-id}"/>
+      <arg value="-DpomFile=${pom-jpms}"/>
+      <arg value="-Dfile=${dist-jar-jpms}"/>
+      <arg value="-Dfiles=${maven-sources-jar},${maven-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
+    </artifact:mvn>
+
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
+      <arg value="-Durl=${maven-snapshots-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-snapshots-repository-id}"/>
+      <arg value="-DpomFile=${pom-platform-jpms}"/>
+      <arg value="-Dfile=${platform-jpms-jar}"/>
+      <arg value="-Dfiles=${platform-sources-jar},${platform-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
     </artifact:mvn>
   </target>
 
@@ -1628,6 +1667,32 @@ cd ..
       <arg value="-Dfiles=${platform-sources-jar},${platform-javadoc-jar},${platform-jpms-jar}"/>
       <arg value="-Dclassifiers=sources,javadoc,jpms"/>
       <arg value="-Dtypes=jar,jar,jar"/>
+      <arg value="-Dgpg.useagent=true"/>
+    </artifact:mvn>
+
+    <!-- sign and deploy the jna,  artifact -->
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:${version-maven-gpg-plugin}:sign-and-deploy-file"/>
+      <arg value="-Durl=${maven-staging-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-staging-repository-id}"/>
+      <arg value="-DpomFile=${pom-jpms}"/>
+      <arg value="-Dfile=${dist-jar-jpms}"/>
+      <arg value="-Dfiles=${maven-sources-jar},${maven-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
+      <arg value="-Dgpg.useagent=true"/>
+    </artifact:mvn>
+
+    <!-- sign and deploy the platform artifact -->
+    <artifact:mvn failonerror="true">
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:${version-maven-gpg-plugin}:sign-and-deploy-file"/>
+      <arg value="-Durl=${maven-staging-repository-url}"/>
+      <arg value="-DrepositoryId=${maven-staging-repository-id}"/>
+      <arg value="-DpomFile=${pom-platform-jpms}"/>
+      <arg value="-Dfile=${platform-jpms-jar}"/>
+      <arg value="-Dfiles=${platform-sources-jar},${platform-javadoc-jar}"/>
+      <arg value="-Dtypes=jar,jar"/>
+      <arg value="-Dclassifiers=sources,javadoc"/>
       <arg value="-Dgpg.useagent=true"/>
     </artifact:mvn>
   </target>

--- a/pom-jna-jpms.xml
+++ b/pom-jna-jpms.xml
@@ -1,16 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
   http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>net.java.dev.jna</groupId>
-  <artifactId>jna-platform</artifactId>
+  <artifactId>jna-jpms</artifactId>
   <version>TEMPLATE</version>
   <packaging>jar</packaging>
 
-  <name>Java Native Access Platform</name>
-  <description>Java Native Access Platform</description>
+  <name>Java Native Access</name>
+  <description>Java Native Access</description>
   <url>https://github.com/java-native-access/jna</url>
 
   <licenses>
@@ -49,13 +49,5 @@
       </roles>
     </developer>
   </developers>
-
-  <dependencies>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <version>TEMPLATE</version>
-    </dependency>
-  </dependencies>
 
 </project>

--- a/pom-jna-platform-jpms.xml
+++ b/pom-jna-platform-jpms.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>net.java.dev.jna</groupId>
-  <artifactId>jna-platform</artifactId>
+  <artifactId>jna-platform-jpms</artifactId>
   <version>TEMPLATE</version>
   <packaging>jar</packaging>
 
@@ -53,7 +53,7 @@
   <dependencies>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
+      <artifactId>jna-jpms</artifactId>
       <version>TEMPLATE</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The jna-platform artifact depends on jna - this leads to problems when
the JPMS artifacts are used, as the pom.xml for the classifier based
artifacts are identical to the base artifacts. This leads to

```xml
  <dependency>
    <groupId>net.java.dev.jna</groupId>
    <artifactId>jna-platform</artifactId>
    <version>5.7.0</version>
    <classifier>jpms</classifier>
  </dependency>
```

depending on

```xml
  <dependency>
    <groupId>net.java.dev.jna</groupId>
    <artifactId>jna</artifactId>
    <version>5.7.0</version>
  </dependency>
```

so the jna-platform JPMS artifacts pulls in the non-JPMS jna artifact.

To solve this, both artifacts are moved into their own groupId. So

```xml
  <dependency>
    <groupId>net.java.dev.jna</groupId>
    <artifactId>jna-platform</artifactId>
    <version>5.8.0</version>
    <classifier>jpms</classifier>
  </dependency>
```

becomes

```xml
  <dependency>
    <groupId>net.java.dev.jna.jpms</groupId>
    <artifactId>jna-platform</artifactId>
    <version>5.8.0</version>
  </dependency>
```