### PR TITLE
Handle 0-length domain names in Advapi32Util#getAccountBySid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Features
 Bug Fixes
 ---------
 * [#1317](https://github.com/java-native-access/jna/pull/1317): Change the maven coordinates of the JPMS artifacts from classifier `jpms` to custom artifact ids `jna-jpms` and `jna-platform-jpms` - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1322](https://github.com/java-native-access/jna/pull/1322): Handle 0-length domain names in `c.s.j.p.win32.Advapi32Util#getAccountBySid` - [@dbwiddis](https://github.com/dbwiddis).
 
 Important Changes
 -----------------


### PR DESCRIPTION
In rare/transient situations, such as UAC elevation or other SYSTEM account situations, the domain name can be an empty string. In this case `cchDomainName` is set to 0 and a zero-length array causes the function call to fail with an incorrect parameter.  See https://github.com/oshi/oshi/issues/1551 and https://github.com/oshi/oshi/issues/637 for examples of failure symptoms.

Rather than adding code to handle the special case, we can simplify the code to avoid the initial call to get length, and prevent this error by using the max possible string lengths.  

[`GetUserName`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getusernamea) docs indicate:
>  A buffer size of (UNLEN + 1) characters will hold the maximum length user name including the terminating null character. UNLEN is defined in Lmcons.h.

UNLEN is 256.   The max local domain length (DNLEN) is 15, but to be conservative I used the [max FQDN length](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou) of 255.