### PR TITLE
Add partial support for future values of LOGICAL_PROCESSOR_RELATIONSHIP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features
 --------
 * [#1313](https://github.com/java-native-access/jna/issues/1313): Normalize `RESOURCE_PREFIX` for darwin to `darwin-$arch` and split jnidispatch library per architecture - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1318](https://github.com/java-native-access/jna/pull/1318): Add support for linux-risc64 - [@thentschel](https://github.com/thentschel).
+* [#1327](https://github.com/java-native-access/jna/pull/1327): Add partial support for future values of `c.s.j.p.win32.WinNT.LOGICAL_PROCESSOR_RELATIONSHIP` enum present in Windows Insider builds - [@dbwiddis](https://github.com/dbwiddis).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -32,7 +32,6 @@ import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
-import com.sun.jna.platform.win32.WinNT.PSID;
 import com.sun.jna.Union;
 import com.sun.jna.ptr.ByReference;
 import com.sun.jna.win32.StdCallLibrary.StdCallCallback;
@@ -3018,9 +3017,15 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
             switch (relationship) {
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore:
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorPackage:
+                    // Placeholder values. Pending documentation updates
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorDie:
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorModule:
                     result = new PROCESSOR_RELATIONSHIP(memory);
                     break;
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationNumaNode:
+                    // Placeholder value. NUMA_NODE_RELATIONSHIP structure must be updated to permit
+                    // variable sized array
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationNumaNodeEx:
                     result = new NUMA_NODE_RELATIONSHIP(memory);
                     break;
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationCache:
@@ -3358,6 +3363,30 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
          * <p>Not supported until Windows Server 2008 R2.</p>
          */
         int RelationGroup = 4;
+
+        /**
+         * <p>
+         * Upcoming value of this enum added for forward compatibility. Documentation
+         * will be added when available.
+         * </p>
+         */
+        int RelationProcessorDie = 5;
+
+        /**
+         * <p>
+         * Upcoming value of this enum added for forward compatibility. Documentation
+         * will be added when available.
+         * </p>
+         */
+        int RelationNumaNodeEx = 6;
+
+        /**
+         * <p>
+         * Upcoming value of this enum added for forward compatibility. Documentation
+         * will be added when available.
+         * </p>
+         */
+        int RelationProcessorModule = 7;
 
         /**
          * <p>On input, retrieves information about all possible relation types. This value is not used on output.</p>

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -3017,15 +3017,9 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
             switch (relationship) {
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore:
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorPackage:
-                    // Placeholder values. Pending documentation updates
-                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorDie:
-                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorModule:
                     result = new PROCESSOR_RELATIONSHIP(memory);
                     break;
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationNumaNode:
-                    // Placeholder value. NUMA_NODE_RELATIONSHIP structure must be updated to permit
-                    // variable sized array
-                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationNumaNodeEx:
                     result = new NUMA_NODE_RELATIONSHIP(memory);
                     break;
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationCache:
@@ -3035,7 +3029,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
                     result = new GROUP_RELATIONSHIP(memory);
                     break;
                 default:
-                    throw new IllegalStateException("Unmapped relationship: " + relationship);
+                    result = new UNKNOWN_RELATIONSHIP(memory);
             }
             result.read();
             return result;
@@ -3255,6 +3249,24 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
             readField("activeGroupCount");
             groupInfo = new PROCESSOR_GROUP_INFO[activeGroupCount];
             super.read();
+        }
+    }
+
+    /**
+     * Represents information associated with a
+     * {@link LOGICAL_PROCESSOR_RELATIONSHIP} enum value which has not yet been
+     * mapped. Only the fields from {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX}
+     * are populated.
+     */
+    @FieldOrder({})
+    public static class UNKNOWN_RELATIONSHIP extends SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
+
+        public UNKNOWN_RELATIONSHIP() {
+            super();
+        }
+
+        public UNKNOWN_RELATIONSHIP(Pointer memory) {
+            super(memory);
         }
     }
 


### PR DESCRIPTION
See #1324 for more details.

This PR implements new `LOGICAL_PROCESSOR_RELATIONSHIP` enum values which are present in current Windows Insider builds and currently throw an `IllegalStateException` when instantiating a `SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX` structure from a pointer.

A complete implementation will require updating the `NUMA_NODE_RELATIONSHIP` structure and javadocs, and will be submitted later once the new API documentation is available.