### PR TITLE
Fix parsing of ant version in Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - export PATH=$JAVA_HOME/bin:$PATH; 
 
 install:
-  - export APACHE_ANT_BASE=$(curl http://apache.mirror.iphh.net/ant/binaries/ | grep "apache-ant-1.9..*-bin.tar.gz" | tail -1 | sed  's/.*href="\(.*\)-bin.tar.gz".*/\1/g')
+  - export APACHE_ANT_BASE=$(curl http://apache.mirror.iphh.net/ant/binaries/ | grep "apache-ant-1.9..*-bin.tar.gz" | tail -1 | sed  's/.*href="\([^"]*\)-bin.tar.gz".*/\1/g')
   - 'echo "Apache Ant ARCHIVE: $APACHE_ANT_BASE"'
   - 'wget http://apache.mirror.iphh.net/ant/binaries/$APACHE_ANT_BASE-bin.tar.gz && tar xzf $APACHE_ANT_BASE-bin.tar.gz && sudo mv $APACHE_ANT_BASE /usr/local/$APACHE_ANT_BASE && sudo rm -f /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE /usr/local/ant && sudo ln -s /usr/local/$APACHE_ANT_BASE/bin/ant /usr/local/bin/ant || true'
   - 'sudo apt-get -y install texinfo || true'


### PR DESCRIPTION
The HTML for the `ant` binaries now repeats the file name in a title field which breaks version parsing, resulting in
> apache-ant-1.9.15-bin.tar.gz" title="apache-ant-1.9.15

Ensuring that the regex capture ends at a quotation mark (ending the href field) properly parses the version.
> apache-ant-1.9.15