### PR TITLE
CFStringRef#stringValue buffer needs space for null byte

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Features
 
 Bug Fixes
 ---------
-
+* [#1343](https://github.com/java-native-access/jna/issues/1343): `c.s.j.p.mac.CoreFoundation.CFStringRef#stringValue` buffer needs space for null byte - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.8.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/mac/CoreFoundation.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/CoreFoundation.java
@@ -487,14 +487,18 @@ public interface CoreFoundation extends Library {
          *         failed.
          */
         public String stringValue() {
+            // Get number of characters
             CFIndex length = INSTANCE.CFStringGetLength(this);
             if (length.longValue() == 0) {
                 return "";
             }
+            // Calculate maximum possible size in UTF8 bytes
             CFIndex maxSize = INSTANCE.CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
             if (maxSize.intValue() == kCFNotFound) {
                 throw new StringIndexOutOfBoundsException("CFString maximum number of bytes exceeds LONG_MAX.");
             }
+            // Increment size by 1 for a null byte
+            maxSize.setValue(maxSize.longValue() + 1);
             Memory buf = new Memory(maxSize.longValue());
             if (0 != INSTANCE.CFStringGetCString(this, buf, maxSize, kCFStringEncodingUTF8)) {
                 return buf.getString(0, "UTF8");


### PR DESCRIPTION
Fixes #1342 

Existing test case changed to fail by providing a unicode string that uses the max number of bytes.  Fixed by adding a byte for null.  