### PR TITLE
CFStringRef#stringValue buffer needs space for 4 UTF8 bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Features
 
 Bug Fixes
 ---------
-* [#1343](https://github.com/java-native-access/jna/issues/1343): `c.s.j.p.mac.CoreFoundation.CFStringRef#stringValue` buffer needs space for null byte - [@dbwiddis](https://github.com/dbwiddis).
+* [#1343](https://github.com/java-native-access/jna/issues/1343), [#1345](https://github.com/java-native-access/jna/issues/1345): `c.s.j.p.mac.CoreFoundation.CFStringRef#stringValue` buffer needs space for 4 UTF8 bytes plus a null byte - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.8.0
 =============

--- a/contrib/platform/test/com/sun/jna/platform/mac/CoreFoundationTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/mac/CoreFoundationTest.java
@@ -63,9 +63,9 @@ public class CoreFoundationTest {
 
     @Test
     public void testCFStringRef() throws UnsupportedEncodingException {
-        // Create a unicode string of a single 3-byte character
-        byte[] alaf = { (byte) 0xe0, (byte) 0xa0, (byte) 0x80 };
-        String utf8Str = new String(alaf, StandardCharsets.UTF_8);
+        // Create a unicode string of a single 4-byte character
+        byte[] smileEmoji = { (byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0x83 };
+        String utf8Str = new String(smileEmoji, StandardCharsets.UTF_8);
         CFStringRef cfStr = CFStringRef.createCFString(utf8Str);
         assertEquals(utf8Str.length(), CF.CFStringGetLength(cfStr).intValue());
         assertEquals(utf8Str, cfStr.stringValue());


### PR DESCRIPTION
Fixes #1342 (again)

macOS incorrectly uses a 3 byte per character conversion when determining the maximum byte size of a UTF8 encoded string.  Changing the buffer size calculation to use 4 bytes (plus a null byte) actually produces an appropriately sized buffer.