### PR TITLE
Revert #1345, clarify comments and add tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Features
 
 Bug Fixes
 ---------
-* [#1343](https://github.com/java-native-access/jna/issues/1343), [#1345](https://github.com/java-native-access/jna/issues/1345): `c.s.j.p.mac.CoreFoundation.CFStringRef#stringValue` buffer needs space for 4 UTF8 bytes plus a null byte - [@dbwiddis](https://github.com/dbwiddis).
+* [#1343](https://github.com/java-native-access/jna/issues/1343): `c.s.j.p.mac.CoreFoundation.CFStringRef#stringValue` buffer needs space for a null byte - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.8.0
 =============

--- a/contrib/platform/test/com/sun/jna/platform/mac/CoreFoundationTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/mac/CoreFoundationTest.java
@@ -63,27 +63,37 @@ public class CoreFoundationTest {
 
     @Test
     public void testCFStringRef() throws UnsupportedEncodingException {
-        // Create a unicode string of a single 4-byte character
-        byte[] smileEmoji = { (byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0x83 };
-        String utf8Str = new String(smileEmoji, StandardCharsets.UTF_8);
-        CFStringRef cfStr = CFStringRef.createCFString(utf8Str);
-        assertEquals(utf8Str.length(), CF.CFStringGetLength(cfStr).intValue());
-        assertEquals(utf8Str, cfStr.stringValue());
-        assertEquals(CoreFoundation.STRING_TYPE_ID, cfStr.getTypeID());
+        // Generate strings with different UTF8 byte lengths
+        byte[] pound = { (byte) 0xc2, (byte) 0xa3 };
+        byte[] euro = { (byte) 0xe2, (byte) 0x82, (byte) 0xac };
+        byte[] smileEmoji = { (byte) 0xf0, (byte) 0x9f, (byte) 0x98, (byte) 0x83 };
+        String[] testStrings = new String[4];
+        testStrings[0] = "ascii";
+        testStrings[1] = new String(pound, StandardCharsets.UTF_8);
+        testStrings[2] = new String(euro, StandardCharsets.UTF_8);
+        testStrings[3] = new String(smileEmoji, StandardCharsets.UTF_8);
+        for (String utf8Str : testStrings) {
+            CFStringRef cfStr = CFStringRef.createCFString(utf8Str);
+            // Length matches length of char array
+            // 2 for code points > 0xffff, 1 otherwise
+            assertEquals(utf8Str.length(), CF.CFStringGetLength(cfStr).intValue());
+            assertEquals(utf8Str, cfStr.stringValue());
+            assertEquals(CoreFoundation.STRING_TYPE_ID, cfStr.getTypeID());
 
-        byte[] utf8Arr = utf8Str.getBytes("UTF-8");
-        Memory mem = new Memory(utf8Arr.length + 1);
-        mem.clear();
-        assertNotEquals(0,
-                CF.CFStringGetCString(cfStr, mem, new CFIndex(mem.size()), CoreFoundation.kCFStringEncodingUTF8));
-        byte[] utf8Bytes = mem.getByteArray(0, (int) mem.size() - 1);
-        assertArrayEquals(utf8Arr, utf8Bytes);
-        // Essentially a toString, can't rely on format but should contain the string
-        CFStringRef desc = CF.CFCopyDescription(cfStr);
-        assertTrue(desc.stringValue().contains(utf8Str));
+            byte[] utf8Arr = utf8Str.getBytes("UTF-8");
+            Memory mem = new Memory(utf8Arr.length + 1);
+            mem.clear();
+            assertNotEquals(0,
+                    CF.CFStringGetCString(cfStr, mem, new CFIndex(mem.size()), CoreFoundation.kCFStringEncodingUTF8));
+            byte[] utf8Bytes = mem.getByteArray(0, (int) mem.size() - 1);
+            assertArrayEquals(utf8Arr, utf8Bytes);
+            // Essentially a toString, can't rely on format but should contain the string
+            CFStringRef desc = CF.CFCopyDescription(cfStr);
+            assertTrue(desc.stringValue().contains(utf8Str));
 
-        desc.release();
-        cfStr.release();
+            desc.release();
+            cfStr.release();
+        }
 
         CFStringRef cfEmpty = CFStringRef.createCFString("");
         assertTrue(cfEmpty.stringValue().equals(""));


### PR DESCRIPTION
The code fix from #1343 was correct.  I reverted the change in #1345, added more comments to clarify what is happening, and added tests for 1-, 2-, 3-, and 4-byte UTF8 characters.

Java uses one `char` for Unicode code points under 0xffff and two chars (with a leading [high-surrogate code unit](https://docs.oracle.com/javase/8/docs/api/java/lang/Character.html#isHighSurrogate-char-)) for code points 0x10000 and higher, which correspond to the same number of "UTF-16 characters" in the Apple docs.