### PR TITLE
Optimize license information in pom.xml

### DIFF
--- a/pom-jna-jpms.xml
+++ b/pom-jna-jpms.xml
@@ -14,16 +14,26 @@
   <url>https://github.com/java-native-access/jna</url>
 
   <licenses>
-      <license>
-          <name>LGPL, version 2.1</name>
-          <url>http://www.gnu.org/licenses/licenses.html</url>
-          <distribution>repo</distribution>
-      </license>
-      <license>
-          <name>Apache License v2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-          <distribution>repo</distribution>
-      </license>
+    <license>
+      <name>LGPL-2.1-or-later</name>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
   </licenses>
 
   <scm>

--- a/pom-jna-platform-jpms.xml
+++ b/pom-jna-platform-jpms.xml
@@ -14,16 +14,26 @@
   <url>https://github.com/java-native-access/jna</url>
 
   <licenses>
-      <license>
-          <name>LGPL, version 2.1</name>
-          <url>http://www.gnu.org/licenses/licenses.html</url>
-          <distribution>repo</distribution>
-      </license>
-      <license>
-          <name>Apache License v2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-          <distribution>repo</distribution>
-      </license>
+    <license>
+      <name>LGPL-2.1-or-later</name>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
   </licenses>
 
   <scm>

--- a/pom-jna-platform.xml
+++ b/pom-jna-platform.xml
@@ -14,16 +14,26 @@
   <url>https://github.com/java-native-access/jna</url>
 
   <licenses>
-      <license>
-          <name>LGPL, version 2.1</name>
-          <url>http://www.gnu.org/licenses/licenses.html</url>
-          <distribution>repo</distribution>
-      </license>
-      <license>
-          <name>Apache License v2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-          <distribution>repo</distribution>
-      </license>
+    <license>
+      <name>LGPL-2.1-or-later</name>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
   </licenses>
 
   <scm>

--- a/pom-jna.xml
+++ b/pom-jna.xml
@@ -14,16 +14,26 @@
   <url>https://github.com/java-native-access/jna</url>
 
   <licenses>
-      <license>
-          <name>LGPL, version 2.1</name>
-          <url>http://www.gnu.org/licenses/licenses.html</url>
-          <distribution>repo</distribution>
-      </license>
-      <license>
-          <name>Apache License v2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-          <distribution>repo</distribution>
-      </license>
+    <license>
+      <name>LGPL-2.1-or-later</name>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>
+        Java Native Access (JNA) is licensed under the LGPL, version 2.1 or
+        later, or the Apache License, version 2.0. You can freely decide which
+        license you want to apply to the project.
+      </comments>
+    </license>
   </licenses>
 
   <scm>


### PR DESCRIPTION
- the maven pom.xml documentation recommends to use the SPDX identifier
  as license name
- the link to the LGPL 2.1 license should point to license itself, not
  to an overview page (reported by @TorstenKruse)

Closes: #1355