### PR TITLE
Crypt32Util.cryptProtectData fails on zero-length array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@ Bug Fixes
 ---------
 * [#1343](https://github.com/java-native-access/jna/issues/1343): `c.s.j.p.mac.CoreFoundation.CFStringRef#stringValue` buffer needs space for a null byte - [@dbwiddis](https://github.com/dbwiddis).
 * [#1351](https://github.com/java-native-access/jna/issues/1351): Define `c.s.j.p.unix.size_t.ByReference` and fix macOS sysctl `size_t *` parameters - [@dbwiddis](https://github.com/dbwiddis).
-* [#1362](https://github.com/java-native-access/jna/issues/1362): Clear security sensitive data after usage in c.s.j.p.win32.Crypt32Util#cryptUnprotectData and #cryptUnprotectData - [@dmytro-sheyko](https://github.com/dmytro-sheyko).
+* [#1362](https://github.com/java-native-access/jna/issues/1362): Clear security sensitive data after usage in c.s.j.p.win32.Crypt32Util#cryptProtectData and #cryptUnprotectData - [@dmytro-sheyko](https://github.com/dmytro-sheyko).
+* [#1361](https://github.com/java-native-access/jna/issues/1361): Make c.s.j.p.win32.Crypt32Util#cryptProtectData and #cryptUnprotectData properly handle 0-length array as input - [@dmytro-sheyko](https://github.com/dmytro-sheyko).
 
 Release 5.8.0
 =============

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinCrypt.java
@@ -72,10 +72,19 @@ public interface WinCrypt {
         }
 
         public DATA_BLOB(byte [] data) {
-            pbData = new Memory(data.length);
-            pbData.write(0, data, 0, data.length);
-            cbData = data.length;
-            allocateMemory();
+            super();
+            if (data.length > 0) {
+                pbData = new Memory(data.length);
+                pbData.write(0, data, 0, data.length);
+                cbData = data.length;
+            } else {
+                // We allocate 1 byte memory region because `malloc` may return `NULL` if requested size is 0.
+                // However, `CryptProtectData` and `CryptUnprotectData` consider `NULL` as invalid data.
+                // The fact that we allocate 1 byte does not affect the final result because
+                // we pass the correct size explicitly on `cbData` field.
+                pbData = new Memory(1);
+                cbData = 0;
+            }
         }
 
         public DATA_BLOB(String s) {

--- a/contrib/platform/test/com/sun/jna/platform/win32/Crypt32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Crypt32UtilTest.java
@@ -36,6 +36,13 @@ public class Crypt32UtilTest extends TestCase {
         junit.textui.TestRunner.run(Crypt32UtilTest.class);
     }
 
+    public void testCryptProtectUnprotectZeroLengthData() {
+        byte[] data = new byte[0];
+        byte[] protectedData = Crypt32Util.cryptProtectData(data);
+        byte[] unprotectedData = Crypt32Util.cryptUnprotectData(protectedData);
+        assertEquals(0, unprotectedData.length);
+    }
+
     public void testCryptProtectUnprotectData() {
         byte[] data = new byte[2];
         data[0] = 42;


### PR DESCRIPTION
Allocated 1-byte array in case when 0-length array is supplied in order to avoid IllegalArgumentException
Generally speaking `LocalAlloc` accepts size=0, by `malloc` (which is used in this place) may return `null` in this case, which is indistinguishable from OOM condition.