### PR TITLE
checked properly that exception is thrown

### DIFF
--- a/test/com/sun/jna/VMCrashProtectionTest.java
+++ b/test/com/sun/jna/VMCrashProtectionTest.java
@@ -24,7 +24,6 @@
 package com.sun.jna;
 
 import junit.framework.TestCase;
-import org.junit.Assume;
 
 public class VMCrashProtectionTest extends TestCase {
 
@@ -52,12 +51,14 @@ public class VMCrashProtectionTest extends TestCase {
         else
             m.setLong(0, 1);
         Pointer p = m.getPointer(0);
+        Throwable actual = null;
         try {
             p.setInt(0, 0);
-            fail("Exception should be thrown");
         }
         catch(Throwable e) {
+            actual = e;
         }
+        assertNotNull("Exception should be thrown", actual);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Just noticed the issue in `VMCrashProtectionTest`.
The code below never fails because the `AssertionFailedError` is swallowed in the catch block (which seems intended for an exception from `setInt` method).
```
        try {
            p.setInt(0, 0);
            fail("Exception should be thrown");
        }
        catch(Throwable e) {
        }
```
Most likely that in case of VM crash the execution will never reach the line with `fail(...)` call, so any attempt to do "the right thing" here is unnecessary. But anyway I believe the original code with the `fail(...)` call is more confusing than the code that checks thrown exceptions properly or at least comment that explains why it's not necessary checks thrown exceptions.