### PR TITLE
Free BSTR and SAFEARRAY allocations when done

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/COMLateBindingObject.java
@@ -397,6 +397,7 @@ public class COMLateBindingObject extends COMBindingBaseObject {
     /**
      * @deprecated Use {@link #invokeNoReply(java.lang.String, com.sun.jna.platform.win32.Variant.VARIANT)}
      */
+    @Deprecated
     protected void invokeNoReply(String methodName,
             COMLateBindingObject comObject, VARIANT arg) {
         this.oleMethod(OleAuto.DISPATCH_METHOD, null, comObject.getIDispatch(),
@@ -558,6 +559,13 @@ public class COMLateBindingObject extends COMBindingBaseObject {
 
     /**
      * Sets the property.
+     * <p>
+     * <i>Implementation note:</i> the string is wrapped as a BSTR value, that is
+     * allocated using {@link com.sun.jna.platform.win32.OleAuto#SysAllocString} and
+     * will no longer be accessible to the user to free using
+     * {@link com.sun.jna.platform.win32.OleAuto#SysFreeString}. Consider using
+     * {@link #setProperty(String, VARIANT)} to allow later clearing of the VARIANT.
+     * </p>
      *
      * @param propertyName
      *            the property name

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/ComEventCallbacks_Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/ComEventCallbacks_Test.java
@@ -273,10 +273,12 @@ public class ComEventCallbacks_Test {
             return new HRESULT(WinError.E_NOINTERFACE);
         }
 
+        @Override
         public int AddRef() {
             return 0;
         }
 
+        @Override
         public int Release() {
             return 0;
         }
@@ -341,6 +343,7 @@ public class ComEventCallbacks_Test {
             }
             Thread.sleep(1000);
         }
+        OleAuto.INSTANCE.VariantClear(arguments[0]);
 
         // At this point the call to Navigate before should be complete
         Assert.assertTrue(listener.navigateComplete2Called);
@@ -364,6 +367,7 @@ public class ComEventCallbacks_Test {
             }
             Thread.sleep(1000);
         }
+        OleAuto.INSTANCE.VariantClear(arguments[0]);
 
         // Naviation will be blocked - so NavigateComplete can't be called
         Assert.assertFalse("NavigateComplete Handler was called although it should be blocked", listener.navigateComplete2Called);

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
@@ -31,6 +31,7 @@ import com.sun.jna.platform.win32.COM.util.annotation.ComObject;
 import com.sun.jna.platform.win32.OaIdl.DATE;
 import com.sun.jna.platform.win32.OaIdl.VARIANT_BOOL;
 import com.sun.jna.platform.win32.Ole32;
+import com.sun.jna.platform.win32.OleAuto;
 import com.sun.jna.platform.win32.Variant;
 import com.sun.jna.platform.win32.Variant.VARIANT;
 import com.sun.jna.platform.win32.WTypes.BSTR;
@@ -84,18 +85,17 @@ public class ConvertTest {
 
     @Test
     public void testConvertString() {
-        // This test leaks the allocated BSTR -- this is tollerated here, as memory usage is minimal
         String testString = "Hallo";
-        BSTR testValue = new BSTR(testString);
+        BSTR testValue = OleAuto.INSTANCE.SysAllocString(testString);
         VARIANT resultVariant = Convert.toVariant(testValue);
         assertEquals(testString, resultVariant.stringValue());
         assertEquals(testString, Convert.toJavaObject(resultVariant, Object.class, fact, false, false));
-        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, false, false));
+        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, false, true));
 
         resultVariant = Convert.toVariant(testString);
         assertEquals(testString, resultVariant.stringValue());
         assertEquals(testString, Convert.toJavaObject(resultVariant, Object.class, fact, false, false));
-        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, false, false));
+        assertEquals(testString, Convert.toJavaObject(resultVariant, String.class, fact, false, true));
     }
 
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/SAFEARRAYTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/SAFEARRAYTest.java
@@ -96,6 +96,7 @@ public class SAFEARRAYTest {
     public void testCreateVarArray() {
         SAFEARRAY varArray = SAFEARRAY.createSafeArray(1);
         Assert.assertTrue(varArray != null);
+        varArray.destroy();
     }
 
     @Test
@@ -133,6 +134,7 @@ public class SAFEARRAYTest {
                 OleAuto.INSTANCE.VariantClear(element);
             }
         }
+        varArray.destroy();
     }
 
     @Ignore("Only for live testing")
@@ -266,7 +268,7 @@ public class SAFEARRAYTest {
         Assert.assertEquals(6, sa.getUBound(1));
 
         // requery the moved array and compare with basic array
-        Object[][] relocated = (Object[][]) OaIdlUtil.toPrimitiveArray(sa, false);
+        Object[][] relocated = (Object[][]) OaIdlUtil.toPrimitiveArray(sa, true);
         Assert.assertArrayEquals( basic, relocated);
     }
 
@@ -665,10 +667,13 @@ public class SAFEARRAYTest {
         SAFEARRAY arr = SAFEARRAY.createSafeArray(1);
         arr.putElement(new VARIANT("System.ItemUrl"), 0);
         boolean exceptionCaught = false;
+        VARIANT itemName = new VARIANT("System.ItemName");
         try {
-            arr.putElement(new VARIANT("System.ItemName"), 1);
+            arr.putElement(itemName, 1);
         } catch (COMException ex) {
             exceptionCaught = true;
+        } finally {
+            OleAuto.INSTANCE.VariantClear(itemName);
         }
         assertTrue("Array is initialized to a size of one - it can't hold a second item.", exceptionCaught);
         arr.redim(2, 0);


### PR DESCRIPTION
Reviewed all internal allocations of `BSTR` (as `VARIANT`) and `SAFEARRAY`.  Added code to free the allocations when possible.  While these are test methods, and one was clearly intentional, it's better to correctly free; users sometimes use tests methods as examples.

The `COMLateBindingObject.setProperty(String propertyName, String value)` method allocates a `BSTR` which becomes inaccessible to the user.   Its implementation eventually reaches a deprecated method, and probably should be considered for deprecation:

- setProperty(String propertyName, String value)
  - oleMethod(int nType, VARIANT.ByReference pvResult, String name, VARIANT pArg)
    - oleMethod(int nType, VARIANT.ByReference pvResult, String name, VARIANT[] pArgs)
      - (deprecated) oleMethod(int nType, VARIANT.ByReference pvResult, IDispatch pDisp, DISPID dispId, VARIANT[] pArgs)