### PR TITLE
OpenFileMapping method added to Kernel32 (issue #1093)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Next Release (5.10.0)
 Features
 --------
 * [#1377](https://github.com/java-native-access/jna/pull/1377): Add `RegLoadAppKey` to `c.s.j.p.win32.Advapi32` and `registryLoadAppKey` to `c.s.j.p.win32.Advapi32Util` - [@mfilippov](https://github.com/mfilippov).
+* [#1093](https://github.com/java-native-access/jna/issues/1093): Add `OpenFileMapping` to `c.s.j.p.win32.Kernel32` - [@lmitusinski](https://github.com/lmitusinski).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Kernel32.java
@@ -1108,6 +1108,25 @@ public interface Kernel32 extends StdCallLibrary, WinNT, Wincon {
             int dwMaximumSizeHigh, int dwMaximumSizeLow, String lpName);
 
     /**
+     * Opens a named file mapping object.
+     *
+     * @param dwDesiredAccess
+     *            The access to the file mapping object. This access is checked
+     *            against any security descriptor on the target file mapping object.
+     *            For a list of values, see File Mapping Security and Access Rights.
+     * @param bInheritHandle
+     *            If this parameter is true, a process created by the CreateProcess
+     *            function can inherit the handle; otherwise,
+     *            the handle cannot be inherited.
+     * @param lpName
+     *            The name of the file mapping object to be opened.
+     * @return If the function succeeds, the return value is an open handle to
+     *         the specified file mapping object. If the function fails, the
+     *         return value is NULL. To get extended error information, call GetLastError.
+     */
+    HANDLE OpenFileMapping(int dwDesiredAccess, boolean bInheritHandle, String lpName);
+
+    /**
      * Maps a view of a file mapping into the address space of a calling
      * process.
      *


### PR DESCRIPTION
Added missing mapping for ``Kernel32:OpenFileMapping`.

Original issue reportred in [#1093](https://github.com/java-native-access/jna/issues/1093)