### PR TITLE
Update native encoding detection for JEP400

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 16, 17-ea]
+        java: [8, 11, 17, 18-ea]
         os: [ubuntu-latest, macos-latest]
       # Run all tests even if one fails
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ pom-jna-platform.xml.asc
 /contrib/platform/nbproject/private/
 /nbproject/private/
 /native/.ccls-cache/
+/contrib/ntservice/nbproject/private/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 * [#1093](https://github.com/java-native-access/jna/issues/1093): Add `OpenFileMapping` to `c.s.j.p.win32.Kernel32` - [@lmitusinski](https://github.com/lmitusinski).
 * [#1388](https://github.com/java-native-access/jna/issues/1388): Map the arch `zarch_64` as reported by SAPJVM8 to `s390x` - [@MBaesken](https://github.com/MBaesken).
 * [#1381](https://github.com/java-native-access/jna/issues/1381): Update embedded libffi to 3.4.2 - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1393](https://github.com/java-native-access/jna/issues/1393): Update native encoding detection for JEP400 / JDK 18 (`file.encoding` now defaults to `UTF-8`) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------

--- a/build.xml
+++ b/build.xml
@@ -768,6 +768,8 @@ osname=macosx;processor=aarch64
       <property name="file.reference.jna.build" location="${build}"/>
       <property name="file.reference.jna.jar" location="${build}/${jar}"/>
       <property name="libs.junit.classpath" refid="test.libs"/>
+      <property name="javac.source" value="${compatibility}" />
+      <property name="javac.target" value="${compatibility}" />
       <fileset dir="${contrib}" includes="*/build.xml" excludes="platform/build.xml"/>
     </subant>
   </target>

--- a/contrib/alphamaskdemo/build.xml
+++ b/contrib/alphamaskdemo/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.alphamaskdemo" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.alphamaskdemo.</description>
     <!-- Locations -->
-    <property name="src"                location="."/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-alphamask.jar"/>
+    <property name="src"                    location="."/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-alphamask.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"			value="com.sun.jna.contrib.demo.AlphaMaskDemo" />
+    <property name="main-class"	            value="com.sun.jna.contrib.demo.AlphaMaskDemo" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/balloonmanagerdemo/build.xml
+++ b/contrib/balloonmanagerdemo/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.balloonmanagerdemo" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.balloonmanagerdemo.</description>
     <!-- Locations -->
-    <property name="src"                location="."/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-balloonmanager.jar"/>
+    <property name="src"                    location="."/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-balloonmanager.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"			value="com.sun.jna.contrib.demo.BalloonManagerDemo" />
+    <property name="main-class"             value="com.sun.jna.contrib.demo.BalloonManagerDemo" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/balloontips/build.xml
+++ b/contrib/balloontips/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.balloontipsdemo" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.balloontipsdemo.</description>
     <!-- Locations -->
-    <property name="src"                location="."/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-balloontips.jar"/>
+    <property name="src"                    location="."/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-balloontips.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"		value="com.sun.jna.contrib.demo.FilteredTextField" />
+    <property name="main-class"		    value="com.sun.jna.contrib.demo.FilteredTextField" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,8 +38,9 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
-               encoding="UTF-8" debug="on" includeantruntime="false"> 
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
+               encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>
             </classpath>

--- a/contrib/dnddemo/build.xml
+++ b/contrib/dnddemo/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.dnddemo" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.dnddemo.</description>
     <!-- Locations -->
-    <property name="src"                location="."/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-dnd.jar"/>
+    <property name="src"                    location="."/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-dnd.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"			value="com.sun.jna.contrib.demo.GhostedDragImageDemo" />
+    <property name="main-class"             value="com.sun.jna.contrib.demo.GhostedDragImageDemo" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/monitordemo/build.xml
+++ b/contrib/monitordemo/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.monitordemo" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.monitordemo.</description>
     <!-- Locations -->
-    <property name="src"                location="./src"/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-monitordemo.jar"/>
+    <property name="src"                    location="./src"/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-monitordemo.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"			value="com.sun.jna.contrib.demo.MonitorInfoDemo" />
+    <property name="main-class"             value="com.sun.jna.contrib.demo.MonitorInfoDemo" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/msoffice/build.xml
+++ b/contrib/msoffice/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.msoffice" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.msoffice.</description>
     <!-- Locations -->
-    <property name="src"                location="./src"/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-msoffice.jar"/>
+    <property name="src"                    location="./src"/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-msoffice.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"			value="" />
+    <property name="main-class"             value="" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/native_window_msg/build.xml
+++ b/contrib/native_window_msg/build.xml
@@ -9,6 +9,8 @@
     <property name="jar"                    location="${build}/demo-nativewindowmsg.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
     <property name="main-class"             value="com.sun.jna.platform.win32.Win32WindowDemo" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -36,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/shapedwindowdemo/build.xml
+++ b/contrib/shapedwindowdemo/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.shapedwindowdemo" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.shapedwindowdemo.</description>
     <!-- Locations -->
-    <property name="src"                location="."/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-shapedwindow.jar"/>
+    <property name="src"                    location="."/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-shapedwindow.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"		value="com.sun.jna.contrib.demo.ShapedWindowDemo" />
+    <property name="main-class"             value="com.sun.jna.contrib.demo.ShapedWindowDemo" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/w32printing/build.xml
+++ b/contrib/w32printing/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.w32printing" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.w32printing.</description>
     <!-- Locations -->
-    <property name="src"                location="./src"/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-w32printing.jar"/>
+    <property name="src"                    location="./src"/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-w32printing.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"			value="com.sun.jna.platform.win32.Win32SpoolMonitor" />
+    <property name="main-class"             value="com.sun.jna.platform.win32.Win32SpoolMonitor" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -27,7 +28,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/w32windowhooks/build.xml
+++ b/contrib/w32windowhooks/build.xml
@@ -2,14 +2,15 @@
 <project name="jnacontrib.w32windowhooks" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.w32windowhooks.</description>
     <!-- Locations -->
-    <property name="src"                location="."/>
-    <property name="build"              location="build"/>
-    <property name="jna-dist"           location="../../../dist"/>
-
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-w32windowhooks.jar"/>
+    <property name="src"                    location="."/>
+    <property name="build"                  location="build"/>
+    <property name="jna-dist"               location="../../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-w32windowhooks.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
-    <property name="main-class"		value="com.sun.jna.contrib.demo.WindowHooks" />
+    <property name="main-class"		    value="com.sun.jna.contrib.demo.WindowHooks" />
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -37,7 +38,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/contrib/x11/build.xml
+++ b/contrib/x11/build.xml
@@ -2,13 +2,15 @@
 <project name="jnacontrib.x11" default="jar" basedir=".">
     <description>Builds, tests, and runs the project jnacontrib.x11.</description>
     <!-- Locations -->
-    <property name="src"                location="src"/>
-    <property name="build"              location="build"/>
-    <property name="jna-src"            location="../../src"/>
-    <property name="jna-dist"           location="../../dist"/>
-    <property name="classes"       location="${build}/classes"/>
-    <property name="jar"           location="${build}/demo-x11.jar"/>
+    <property name="src"                    location="src"/>
+    <property name="build"                  location="build"/>
+    <property name="jna-src"                location="../../src"/>
+    <property name="jna-dist"               location="../../dist"/>
+    <property name="classes"                location="${build}/classes"/>
+    <property name="jar"                    location="${build}/demo-x11.jar"/>
     <property name="file.reference.jna.jar" location="../../build/jna.jar"/>
+    <property name="javac.target"           value="1.6" />
+    <property name="javac.source"           value="1.6" />
 
     <path id="classpath">
         <fileset file="${file.reference.jna.jar}"/>
@@ -46,7 +48,8 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <!-- Compile the project. -->
-        <javac srcdir="${src}" destdir="${classes}" target="1.6" source="1.6"
+        <javac srcdir="${src}" destdir="${classes}"
+               target="${javac.target}" source="${javac.source}"
                encoding="UTF-8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="classpath"/>

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -113,8 +113,34 @@ public final class Native implements Version {
 
     private static final Logger LOG = Logger.getLogger(Native.class.getName());
 
-    public static final Charset DEFAULT_CHARSET = Charset.defaultCharset();
-    public static final String DEFAULT_ENCODING = Native.DEFAULT_CHARSET.name();
+    public static final Charset DEFAULT_CHARSET;
+    public static final String DEFAULT_ENCODING;
+    static {
+        // JNA used the defaultCharset to determine which encoding to use when
+        // converting strings to native char*. The defaultCharset is set from
+        // the system property file.encoding. Up to JDK 17 its value defaulted
+        // to the system default encoding. From JDK 18 onwards its default value
+        // changed to UTF-8.
+        // JDK 18+ exposes the native encoding as the new system property
+        // native.encoding, prior versions don't have that property and will
+        // report NULL for it.
+        // The algorithm is simple: If native.encoding is set, it will be used
+        // else the original implementation of Charset#defaultCharset is used
+        String nativeEncoding = System.getProperty("native.encoding");
+        Charset nativeCharset = null;
+        if (nativeEncoding != null) {
+            try {
+                nativeCharset = Charset.forName(nativeEncoding);
+            } catch (Exception ex) {
+                LOG.log(Level.WARNING, "Failed to get charset for native.encoding value : '" + nativeEncoding + "'", ex);
+            }
+        }
+        if (nativeCharset == null) {
+            nativeCharset = Charset.defaultCharset();
+        }
+        DEFAULT_CHARSET = nativeCharset;
+        DEFAULT_ENCODING = nativeCharset.name();
+    }
     public static final boolean DEBUG_LOAD = Boolean.getBoolean("jna.debug_load");
     public static final boolean DEBUG_JNA_LOAD = Boolean.getBoolean("jna.debug_load.jna");
     private final static Level DEBUG_JNA_LOAD_LEVEL = DEBUG_JNA_LOAD ? Level.INFO : Level.FINE;


### PR DESCRIPTION
JEP 400 will make UTF-8 the default value for `file.encoding` for java:

https://openjdk.java.net/jeps/400

For JNA this means on windows (on mac OS and Linux the encoding for native can be expected to be UTF-8 already) the native codepage would not be used anymore.

See the comments of the first commit for an explanation how it will be reworked.