### PR TITLE
Improve clarity of equality tests for INVALID_HANDLE_VALUE

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32Util.java
@@ -692,7 +692,7 @@ public abstract class Advapi32Util {
                     throw new Win32Exception(rc);
             }
         } finally {
-            if (phkKey.getValue() != WinBase.INVALID_HANDLE_VALUE) {
+            if (!WinBase.INVALID_HANDLE_VALUE.equals(phkKey.getValue())) {
                 rc = Advapi32.INSTANCE.RegCloseKey(phkKey.getValue());
                 if (rc != W32Errors.ERROR_SUCCESS) {
                     throw new Win32Exception(rc);
@@ -3303,7 +3303,7 @@ public abstract class Advapi32Util {
             }
             finally {
                 // Always close the thread token
-                if ((phThreadToken.getValue() != WinBase.INVALID_HANDLE_VALUE)
+                if ((!WinBase.INVALID_HANDLE_VALUE.equals(phThreadToken.getValue()))
                         && (phThreadToken.getValue() != null)) {
                     Kernel32.INSTANCE.CloseHandle(phThreadToken.getValue());
                     phThreadToken.setValue(null);
@@ -3339,7 +3339,7 @@ public abstract class Advapi32Util {
             }
             finally {
                 // Close the thread token
-                if ((phThreadToken.getValue() != WinBase.INVALID_HANDLE_VALUE)
+                if ((!WinBase.INVALID_HANDLE_VALUE.equals(phThreadToken.getValue()))
                         && (phThreadToken.getValue() != null)) {
                     Kernel32.INSTANCE.CloseHandle(phThreadToken.getValue());
                     phThreadToken.setValue(null);
@@ -3349,7 +3349,7 @@ public abstract class Advapi32Util {
 
         /**
          * Get a handle to the thread token. May duplicate the process token
-         * and set as the thread token if ther thread has no token.
+         * and set as the thread token if the thread has no token.
          * @return HANDLE to the thread token
          * @throws Win32Exception
          */
@@ -3394,7 +3394,7 @@ public abstract class Advapi32Util {
             }
             catch (Win32Exception ex) {
                 // Close the thread token
-                if ((phThreadToken.getValue() != WinBase.INVALID_HANDLE_VALUE)
+                if ((!WinBase.INVALID_HANDLE_VALUE.equals(phThreadToken.getValue()))
                         && (phThreadToken.getValue() != null)) {
                     Kernel32.INSTANCE.CloseHandle(phThreadToken.getValue());
                     phThreadToken.setValue(null);
@@ -3404,7 +3404,7 @@ public abstract class Advapi32Util {
             finally
             {
                 // Always close the process token
-                if ((phProcessToken.getValue() != WinBase.INVALID_HANDLE_VALUE)
+                if ((!WinBase.INVALID_HANDLE_VALUE.equals(phProcessToken.getValue()))
                         && (phProcessToken.getValue() != null)) {
                     Kernel32.INSTANCE.CloseHandle(phProcessToken.getValue());
                     phProcessToken.setValue(null);

--- a/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Advapi32Test.java
@@ -45,6 +45,7 @@ import static com.sun.jna.platform.win32.WinNT.SE_SECURITY_NAME;
 import static com.sun.jna.platform.win32.WinNT.TOKEN_ADJUST_PRIVILEGES;
 import static com.sun.jna.platform.win32.WinNT.TOKEN_DUPLICATE;
 import static com.sun.jna.platform.win32.WinNT.TOKEN_IMPERSONATE;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -504,7 +505,7 @@ public class Advapi32Test extends TestCase {
         HKEYByReference phKey = new HKEYByReference();
         assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegOpenKeyEx(
                 WinReg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft", 0, WinNT.KEY_READ, phKey));
-        assertTrue(WinBase.INVALID_HANDLE_VALUE != phKey.getValue());
+        assertNotEquals(WinBase.INVALID_HANDLE_VALUE, phKey.getValue());
         assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegCloseKey(phKey.getValue()));
     }
 
@@ -524,7 +525,7 @@ public class Advapi32Test extends TestCase {
         }
 
         assertEquals(W32Errors.ERROR_SUCCESS, connectResult);
-        assertTrue(WinBase.INVALID_HANDLE_VALUE != phkResult.getValue());
+        assertNotEquals(WinBase.INVALID_HANDLE_VALUE, phkResult.getValue());
         assertEquals(W32Errors.ERROR_SUCCESS, Advapi32.INSTANCE.RegCloseKey(phkResult.getValue()));
     }
 
@@ -941,7 +942,7 @@ public class Advapi32Test extends TestCase {
     public void testOpenEventLog() {
         HANDLE h = Advapi32.INSTANCE.OpenEventLog(null, "Application");
         assertNotNull(h);
-        assertFalse(h.equals(WinBase.INVALID_HANDLE_VALUE));
+        assertNotEquals(h, WinBase.INVALID_HANDLE_VALUE);
         assertTrue(Advapi32.INSTANCE.CloseEventLog(h));
     }
 
@@ -981,7 +982,7 @@ public class Advapi32Test extends TestCase {
         IntByReference after = new IntByReference();
         assertTrue(Advapi32.INSTANCE.GetNumberOfEventLogRecords(h, after));
         assertTrue(before.getValue() < after.getValue());
-        assertFalse(h.equals(WinBase.INVALID_HANDLE_VALUE));
+        assertNotEquals(h, WinBase.INVALID_HANDLE_VALUE);
         assertTrue(Advapi32.INSTANCE.DeregisterEventSource(h));
         Advapi32Util.registryDeleteKey(WinReg.HKEY_LOCAL_MACHINE, jnaEventSourceRegistryPath);
 
@@ -1003,7 +1004,7 @@ public class Advapi32Test extends TestCase {
 
     public void testGetNumberOfEventLogRecords() {
         HANDLE h = Advapi32.INSTANCE.OpenEventLog(null, "Application");
-        assertFalse(h.equals(WinBase.INVALID_HANDLE_VALUE));
+        assertNotEquals(h, WinBase.INVALID_HANDLE_VALUE);
         IntByReference n = new IntByReference();
         assertTrue(Advapi32.INSTANCE.GetNumberOfEventLogRecords(h, n));
         assertTrue(n.getValue() >= 0);
@@ -1013,7 +1014,7 @@ public class Advapi32Test extends TestCase {
     /*
     public void testClearEventLog() {
         HANDLE h = Advapi32.INSTANCE.OpenEventLog(null, "Application");
-        assertFalse(h.equals(WinBase.INVALID_HANDLE_VALUE));
+        assertNotEquals(h, WinBase.INVALID_HANDLE_VALUE);
         IntByReference before = new IntByReference();
         assertTrue(Advapi32.INSTANCE.GetNumberOfEventLogRecords(h, before));
         assertTrue(before.getValue() >= 0);
@@ -1337,7 +1338,7 @@ public class Advapi32Test extends TestCase {
                 WinNT.OPEN_EXISTING,
                 WinNT.FILE_ATTRIBUTE_NORMAL,
                 null);
-        assertFalse("Failed to create file handle: " + filePath, WinBase.INVALID_HANDLE_VALUE.equals(hFile));
+        assertNotEquals("Failed to create file handle: " + filePath, WinBase.INVALID_HANDLE_VALUE, hFile);
 
         try {
             try {
@@ -1460,7 +1461,7 @@ public class Advapi32Test extends TestCase {
                                     ppDacl.getValue(),
                                     ppSacl.getValue()));
                 } finally {
-                    if (hFile != WinBase.INVALID_HANDLE_VALUE)
+                    if (!WinBase.INVALID_HANDLE_VALUE.equals(hFile))
                         Kernel32.INSTANCE.CloseHandle(hFile);
                     file.delete();
                 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/NtDllTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/NtDllTest.java
@@ -26,6 +26,7 @@ package com.sun.jna.platform.win32;
 import static com.sun.jna.platform.win32.WinNT.DACL_SECURITY_INFORMATION;
 import static com.sun.jna.platform.win32.WinNT.GROUP_SECURITY_INFORMATION;
 import static com.sun.jna.platform.win32.WinNT.OWNER_SECURITY_INFORMATION;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -89,7 +90,7 @@ public class NtDllTest extends TestCase {
                         WinNT.OPEN_EXISTING,
                         WinNT.FILE_ATTRIBUTE_NORMAL,
                         null);
-            assertFalse("Failed to create file handle: " + filePath, WinBase.INVALID_HANDLE_VALUE.equals(hFile));
+            assertNotEquals("Failed to create file handle: " + filePath, WinBase.INVALID_HANDLE_VALUE, hFile);
 
             int Length = 64 * 1024;
             Memory SecurityDescriptor = new Memory(Length);
@@ -110,7 +111,7 @@ public class NtDllTest extends TestCase {
                             infoType,
                             SecurityDescriptor));
         } finally {
-            if (hFile != WinBase.INVALID_HANDLE_VALUE)
+            if (!WinBase.INVALID_HANDLE_VALUE.equals(hFile))
                 Kernel32.INSTANCE.CloseHandle(hFile);
             file.delete();
         }

--- a/contrib/platform/test/com/sun/jna/platform/win32/SetupApiTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/SetupApiTest.java
@@ -32,6 +32,8 @@ import static com.sun.jna.platform.win32.SetupApi.GUID_DEVINTERFACE_COMPORT;
 import static com.sun.jna.platform.win32.WinBase.INVALID_HANDLE_VALUE;
 import static com.sun.jna.platform.win32.WinError.ERROR_NO_MORE_ITEMS;
 import static com.sun.jna.platform.win32.WinNT.KEY_QUERY_VALUE;
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 import com.sun.jna.platform.win32.SetupApi.SP_DEVINFO_DATA;
@@ -65,7 +67,7 @@ public class SetupApiTest extends TestCase {
         // hDevInfoSet repesents a list of installed devices for all device
         // setup classes or all device interface classes
         HANDLE hDevInfoSet = SetupApi.INSTANCE.SetupDiGetClassDevs(null, null, null, DIGCF_ALLCLASSES);
-        assertTrue(hDevInfoSet != INVALID_HANDLE_VALUE);
+        assertNotEquals(INVALID_HANDLE_VALUE, hDevInfoSet);
 
         SP_DEVINFO_DATA devInfo = new SP_DEVINFO_DATA();
         // there must be least one device (drive,processor,pci,usb,...) on the
@@ -73,7 +75,7 @@ public class SetupApiTest extends TestCase {
         assertTrue(SetupApi.INSTANCE.SetupDiEnumDeviceInfo(hDevInfoSet, FIRST_MEMBER, devInfo));
 
         HKEY hDeviceKey = SetupApi.INSTANCE.SetupDiOpenDevRegKey(hDevInfoSet, devInfo, DICS_FLAG_GLOBAL, 0, DIREG_DEV, KEY_QUERY_VALUE);
-        assertTrue(hDeviceKey != INVALID_HANDLE_VALUE);
+        assertNotEquals(INVALID_HANDLE_VALUE, hDeviceKey);
 
         Advapi32.INSTANCE.RegCloseKey(hDeviceKey);
     }


### PR DESCRIPTION
`WinBase.INVALID_HANDLE_VALUE` is a pointer to the value -1.  In several places, object (reference) equality is ~incorrectly~ used to test return values, ~which are likely a different pointer to -1~ is confusing to those who don't know the internal implementation forcing these equalities.