### PR TITLE
Increase Sspi#MAX_TOKEN_SIZE on Windows 8/Server 2012 and later

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Next Release (5.11.0)
 
 Features
 --------
+* [#1398](https://github.com/java-native-access/jna/pull/1398): Increase `c.s.j.p.win32.Sspi#MAX_TOKEN_SIZE` on Windows 8/Server 2012 and later - [@dbwiddis](https://github.com/dbwiddis).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Sspi.java
@@ -37,9 +37,19 @@ import com.sun.jna.win32.W32APITypeMapper;
 public interface Sspi {
 
     /**
-     * Maximum size in bytes of a security token.
+     * Maximum size in bytes of a security token. {@code MAX_TOKEN_SIZE} has the
+     * following default value, depending on the version of Windows that builds the
+     * token:
+     * <p>
+     * Windows Server 2008 R2 and earlier versions, and Windows 7 and earlier
+     * versions: 12,000 bytes. Windows Server 2012 and later versions, and Windows 8
+     * and later versions: 48,000 bytes
+     *
+     * @see <a href=
+     *      "https://docs.microsoft.com/en-us/troubleshoot/windows-server/windows-security/kerberos-authentication-problems-if-user-belongs-to-groups">Problems
+     *      with Kerberos authentication when a user belongs to many groups</a>
      */
-    int MAX_TOKEN_SIZE = 12288;
+    int MAX_TOKEN_SIZE = VersionHelpers.IsWindows8OrGreater() ? 48000 : 12000;
 
     // Flags for the fCredentialUse parameter of AcquireCredentialsHandle
 


### PR DESCRIPTION
Fixes #1396. See also #291.

Alternately, we could read the `MaxTokenSize` registry entry value at `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\Kerberos\Parameters` if it exists, and default to these values otherwise, but that's way too complex to put in an initialization.