### PR TITLE
Add initial support for `oleacc.dll` and `IAccessible` interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Next Release (5.11.0)
 Features
 --------
 * [#1398](https://github.com/java-native-access/jna/pull/1398): Increase `c.s.j.p.win32.Sspi#MAX_TOKEN_SIZE` on Windows 8/Server 2012 and later - [@dbwiddis](https://github.com/dbwiddis).
-* [#1401](https://github.com/java-native-access/jna/pull/1401): Added initial support for `oleacc.dll` and `IAccessible` interface - [@mobeigi](https://github.com/mobeigi).
+* [#1401](https://github.com/java-native-access/jna/pull/1401): Added initial support for `c.s.j.p.win32.Oleacc` and `c.s.j.p.win32.COM.IAccessible` interfaces - [@mobeigi](https://github.com/mobeigi).
 
 Bug Fixes
 ---------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Next Release (5.11.0)
 Features
 --------
 * [#1398](https://github.com/java-native-access/jna/pull/1398): Increase `c.s.j.p.win32.Sspi#MAX_TOKEN_SIZE` on Windows 8/Server 2012 and later - [@dbwiddis](https://github.com/dbwiddis).
+* [#1401](https://github.com/java-native-access/jna/pull/1401): Added initial support for `oleacc.dll` and `IAccessible` interface - [@mobeigi](https://github.com/mobeigi).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/Accessible.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/Accessible.java
@@ -24,12 +24,10 @@
 package com.sun.jna.platform.win32.COM;
 
 import com.sun.jna.Pointer;
-import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.Variant.VARIANT;
 import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
 import com.sun.jna.ptr.IntByReference;
-import com.sun.jna.ptr.LongByReference;
 
 /**
  * Implementation for {@link IAccessible } interface
@@ -38,12 +36,6 @@ import com.sun.jna.ptr.LongByReference;
  */
 public class Accessible extends Dispatch implements IAccessible
 {
-    public static class ByReference extends Accessible implements
-            Structure.ByReference {
-    }
-
-    public Accessible() {
-    }
 
     public Accessible(Pointer pvInstance) { super(pvInstance); }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/Accessible.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/Accessible.java
@@ -28,6 +28,7 @@ import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.Variant.VARIANT;
 import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
+import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 
 /**
@@ -64,7 +65,7 @@ public class Accessible extends Dispatch implements IAccessible
                 new Object[] { this.getPointer(), varChild, pvarRole }, HRESULT.class);
     }
 
-    public HRESULT get_accChildCount(LongByReference pcountChildren)
+    public HRESULT get_accChildCount(IntByReference pcountChildren)
     {
         return (HRESULT) this._invokeNativeObject(8,
                 new Object[] { this.getPointer(), pcountChildren }, HRESULT.class);

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/Accessible.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/Accessible.java
@@ -1,0 +1,84 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32.COM;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.platform.win32.Variant.VARIANT;
+import com.sun.jna.platform.win32.WTypes.BSTRByReference;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+import com.sun.jna.ptr.LongByReference;
+
+/**
+ * Implementation for {@link IAccessible } interface
+ *
+ * @author Mo Beigi, me@mobeigi.com
+ */
+public class Accessible extends Dispatch implements IAccessible
+{
+    public static class ByReference extends Accessible implements
+            Structure.ByReference {
+    }
+
+    public Accessible() {
+    }
+
+    public Accessible(Pointer pvInstance) { super(pvInstance); }
+
+    public HRESULT get_accName(VARIANT varChild, BSTRByReference pszName)
+    {
+        return (HRESULT) this._invokeNativeObject(10,
+                new Object[] { this.getPointer(), varChild, pszName }, HRESULT.class);
+    }
+
+    public HRESULT get_accValue(VARIANT varChild, BSTRByReference pszName)
+    {
+        return (HRESULT) this._invokeNativeObject(11,
+                new Object[] { this.getPointer(), varChild, pszName }, HRESULT.class);
+    }
+
+    public HRESULT get_accRole(VARIANT varChild, VARIANT.ByReference pvarRole)
+    {
+        return (HRESULT) this._invokeNativeObject(13,
+                new Object[] { this.getPointer(), varChild, pvarRole }, HRESULT.class);
+    }
+
+    public HRESULT get_accChildCount(LongByReference pcountChildren)
+    {
+        return (HRESULT) this._invokeNativeObject(8,
+                new Object[] { this.getPointer(), pcountChildren }, HRESULT.class);
+    }
+
+    public HRESULT get_accDefaultAction(VARIANT varChild, BSTRByReference pszDefaultAction)
+    {
+        return (HRESULT) this._invokeNativeObject(20,
+                new Object[] { this.getPointer(), varChild, pszDefaultAction }, HRESULT.class);
+    }
+
+    public HRESULT accDoDefaultAction(VARIANT varChild)
+    {
+        return (HRESULT) this._invokeNativeObject(25,
+                new Object[] { this.getPointer(), varChild }, HRESULT.class);
+    }
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/AccessibleUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/AccessibleUtil.java
@@ -1,3 +1,26 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
 package com.sun.jna.platform.win32.COM;
 
 import com.sun.jna.platform.win32.OleAuto;
@@ -11,6 +34,11 @@ import static com.sun.jna.platform.win32.COM.COMUtils.S_FALSE;
 import static com.sun.jna.platform.win32.COM.COMUtils.S_OK;
 import static com.sun.jna.platform.win32.WinError.E_INVALIDARG;
 
+/**
+ * {@link Accessible} utility API
+ *
+ * @author Mo Beigi, me@mobeigi.org
+ */
 public class AccessibleUtil
 {
     /** The Accessible **/
@@ -20,7 +48,17 @@ public class AccessibleUtil
         this.accessible = accessible;
     }
 
-    public String get_accName(int childId)
+    /**
+     * The IAccessible::get_accName method retrieves the name of the specified object. All objects support this property.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accname">IAccessible::get_accName method (oleacc.h)</a>
+     *
+     * @param childId This parameter is either {@link com.sun.jna.platform.win32.WinUser#CHILDID_SELF} (to obtain information about the object) or a child ID
+     *                (to obtain information about the object's child element).
+     * @return a string that contains the specified object's name.
+     * @throws COMException If not successful
+     */
+    public String get_accName(int childId) throws COMException
     {
         VARIANT varChild = new VARIANT.ByValue();
         varChild.setValue(Variant.VT_I4, new LONG(childId));

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/AccessibleUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/AccessibleUtil.java
@@ -1,0 +1,50 @@
+package com.sun.jna.platform.win32.COM;
+
+import com.sun.jna.platform.win32.OleAuto;
+import com.sun.jna.platform.win32.Variant;
+import com.sun.jna.platform.win32.Variant.VARIANT;
+import com.sun.jna.platform.win32.WTypes.BSTRByReference;
+import com.sun.jna.platform.win32.WinDef.LONG;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+
+import static com.sun.jna.platform.win32.COM.COMUtils.S_FALSE;
+import static com.sun.jna.platform.win32.COM.COMUtils.S_OK;
+import static com.sun.jna.platform.win32.WinError.E_INVALIDARG;
+
+public class AccessibleUtil
+{
+    /** The Accessible **/
+    final private IAccessible accessible;
+
+    public AccessibleUtil(IAccessible accessible) {
+        this.accessible = accessible;
+    }
+
+    public String get_accName(int childId)
+    {
+        VARIANT varChild = new VARIANT.ByValue();
+        varChild.setValue(Variant.VT_I4, new LONG(childId));
+        BSTRByReference bstr = new BSTRByReference();
+
+        HRESULT hresult = accessible.get_accName(varChild, bstr);
+        String result = "";
+
+        if (hresult.intValue() == S_OK) {
+            result = bstr.getValue().getValue();
+        }
+
+        OleAuto.INSTANCE.VariantClear(varChild);
+        OleAuto.INSTANCE.SysFreeString(bstr.getValue());
+
+        switch (hresult.intValue()) {
+            case S_OK:
+                return result;
+            case S_FALSE:
+                throw new COMException("The specified object does not have a name.", hresult);
+            case E_INVALIDARG:
+                throw new COMException("An argument is not valid.", hresult);
+            default:
+                throw new COMException("An unknown error occurred.", hresult);
+        }
+    }
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IAccessible.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IAccessible.java
@@ -27,7 +27,7 @@ import com.sun.jna.platform.win32.Guid.IID;
 import com.sun.jna.platform.win32.Variant.VARIANT;
 import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
-import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.IntByReference;
 
 /**
  * IAccessible Interface
@@ -95,7 +95,7 @@ public interface IAccessible extends IDispatch
      *                       this value is zero.
      * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
      */
-    HRESULT get_accChildCount(LongByReference pcountChildren);
+    HRESULT get_accChildCount(IntByReference pcountChildren);
 
     /**
      * The IAccessible::get_accDefaultAction method retrieves a string that indicates the object's default action. Not all objects have a default action.

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IAccessible.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IAccessible.java
@@ -1,0 +1,125 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32.COM;
+
+import com.sun.jna.platform.win32.Guid.IID;
+import com.sun.jna.platform.win32.Variant.VARIANT;
+import com.sun.jna.platform.win32.WTypes.BSTRByReference;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+import com.sun.jna.ptr.LongByReference;
+
+/**
+ * IAccessible Interface
+ *
+ * Exposes methods and properties that make a user interface element and its children accessible to client applications.
+ * The IAccessible interface inherits from the IDispatch interface.
+ *
+ * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nn-oleacc-iaccessible">IAccessible interface (oleacc.h)</a>
+ * @author Mo Beigi, me@mobeigi.com
+ */
+public interface IAccessible extends IDispatch
+{
+    /**
+     * The GUID associated with the IAccessible interface
+     */
+    IID IID_IACCESSIBLE = new IID("618736E0-3C3D-11CF-810C-00AA00389B71");
+
+    /**
+     * The IAccessible::get_accName method retrieves the name of the specified object. All objects support this property.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accname">IAccessible::get_accName method (oleacc.h)</a>
+     *
+     * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
+     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 (to obtain information about the object's child element).
+     * @param pszName [out] Address of a BSTR that receives a string that contains the specified object's name.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT get_accName(VARIANT varChild, BSTRByReference pszName);
+
+    /**
+     * The IAccessible::get_accValue method retrieves the value of the specified object. Not all objects have a value.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accvalue">IAccessible::get_accValue method (oleacc.h)</a>
+     *
+     * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
+     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 (to obtain information about the object's child element).
+     * @param pszValue [out] Address of the BSTR that receives a localized string that contains the object's current value.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT get_accValue(VARIANT varChild, BSTRByReference pszValue);
+
+    /**
+     * The IAccessible::get_accRole method retrieves information that describes the role of the specified object. All objects support this property.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accrole">IAccessible::get_accRole method (oleacc.h)</a>
+     *
+     * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
+     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 (to obtain information about the object's child element).
+     * @param pvarRole [out] Address of a VARIANT that receives an object role constant.
+     *                 The vt member must be VT_I4. The lVal member receives an object role constant.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT get_accRole(VARIANT varChild, VARIANT.ByReference pvarRole);
+
+    /**
+     * The IAccessible::get_accChildCount method retrieves the number of children that belong to this object. All objects must support this property.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accchildcount">IAccessible::get_accChildCount method (oleacc.h)</a>
+     *
+     * @param pcountChildren [out] Address of a variable that receives the number of children that belong to this object.
+     *                       The children are accessible objects or child elements. If the object has no children,
+     *                       this value is zero.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT get_accChildCount(LongByReference pcountChildren);
+
+    /**
+     * The IAccessible::get_accDefaultAction method retrieves a string that indicates the object's default action. Not all objects have a default action.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accdefaultaction">IAccessible::get_accDefaultAction method (oleacc.h)</a>
+     *
+     * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
+     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 (to obtain information about the object's child element).
+     * @param pszDefaultAction [out] Address of a BSTR that receives a localized string that describes the default
+     *                         action for the specified object; if this object has no default action, the value is NULL.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT get_accDefaultAction(VARIANT varChild, BSTRByReference pszDefaultAction);
+
+    /**
+     * The IAccessible::accDoDefaultAction method performs the specified object's default action. Not all objects have a default action.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-accdodefaultaction">IAccessible::accDoDefaultAction method (oleacc.h)</a>
+     *
+     * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
+     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 (to obtain information about the object's child element).
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT accDoDefaultAction(VARIANT varChild);
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/IAccessible.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/IAccessible.java
@@ -51,7 +51,7 @@ public interface IAccessible extends IDispatch
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accname">IAccessible::get_accName method (oleacc.h)</a>
      *
      * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
-     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 This parameter is either {@link com.sun.jna.platform.win32.WinUser#CHILDID_SELF} (to obtain information about the object) or a child ID
      *                 (to obtain information about the object's child element).
      * @param pszName [out] Address of a BSTR that receives a string that contains the specified object's name.
      * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
@@ -64,7 +64,7 @@ public interface IAccessible extends IDispatch
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accvalue">IAccessible::get_accValue method (oleacc.h)</a>
      *
      * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
-     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 This parameter is either {@link com.sun.jna.platform.win32.WinUser#CHILDID_SELF} (to obtain information about the object) or a child ID
      *                 (to obtain information about the object's child element).
      * @param pszValue [out] Address of the BSTR that receives a localized string that contains the object's current value.
      * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
@@ -77,7 +77,7 @@ public interface IAccessible extends IDispatch
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accrole">IAccessible::get_accRole method (oleacc.h)</a>
      *
      * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
-     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 This parameter is either {@link com.sun.jna.platform.win32.WinUser#CHILDID_SELF} (to obtain information about the object) or a child ID
      *                 (to obtain information about the object's child element).
      * @param pvarRole [out] Address of a VARIANT that receives an object role constant.
      *                 The vt member must be VT_I4. The lVal member receives an object role constant.
@@ -103,7 +103,7 @@ public interface IAccessible extends IDispatch
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-get_accdefaultaction">IAccessible::get_accDefaultAction method (oleacc.h)</a>
      *
      * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
-     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 This parameter is either {@link com.sun.jna.platform.win32.WinUser#CHILDID_SELF} (to obtain information about the object) or a child ID
      *                 (to obtain information about the object's child element).
      * @param pszDefaultAction [out] Address of a BSTR that receives a localized string that describes the default
      *                         action for the specified object; if this object has no default action, the value is NULL.
@@ -117,7 +117,7 @@ public interface IAccessible extends IDispatch
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-iaccessible-accdodefaultaction">IAccessible::accDoDefaultAction method (oleacc.h)</a>
      *
      * @param varChild [in] Specifies whether the retrieved name belongs to the object or one of the object's child elements.
-     *                 This parameter is either CHILDID_SELF (to obtain information about the object) or a child ID
+     *                 This parameter is either {@link com.sun.jna.platform.win32.WinUser#CHILDID_SELF} (to obtain information about the object) or a child ID
      *                 (to obtain information about the object's child element).
      * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
      */

--- a/contrib/platform/src/com/sun/jna/platform/win32/Oleacc.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Oleacc.java
@@ -29,11 +29,9 @@ import com.sun.jna.platform.win32.Guid.REFIID;
 import com.sun.jna.platform.win32.Variant.VARIANT;
 import com.sun.jna.platform.win32.WTypes.LPWSTR;
 import com.sun.jna.platform.win32.WTypes.LPSTR;
-import com.sun.jna.platform.win32.WinDef.UINT;
-import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
-import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
@@ -140,7 +138,7 @@ public interface Oleacc extends StdCallLibrary
      *                   however, if you request more children than exist, this value will be less than that of cChildren.
      * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
      */
-    HRESULT AccessibleChildren(Pointer paccContainer, long iChildStart, long cChildren, VARIANT[] rgvarChildren, LongByReference pcObtained);
+    HRESULT AccessibleChildren(Pointer paccContainer, int iChildStart, int cChildren, VARIANT[] rgvarChildren, IntByReference pcObtained);
 
     /**
      * Retrieves the address of the specified interface for the object associated with the specified window.
@@ -156,7 +154,7 @@ public interface Oleacc extends StdCallLibrary
      * @param ppvObject [out] Address of a pointer variable that receives the address of the specified interface.
      * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
      */
-    HRESULT AccessibleObjectFromWindow(HWND hwnd, DWORD dwId, REFIID riid, PointerByReference ppvObject);
+    HRESULT AccessibleObjectFromWindow(HWND hwnd, int dwId, REFIID riid, PointerByReference ppvObject);
 
     /**
      * Retrieves the window handle that corresponds to a particular instance of an IAccessible interface.
@@ -185,7 +183,7 @@ public interface Oleacc extends StdCallLibrary
      *         If the string resource does not exist, or if the lpszRole parameter is not a valid pointer, the return value is zero (0).
      *         To get extended error information, call GetLastError.
      */
-    UINT GetRoleTextA(DWORD lRole, LPSTR lpszRole, UINT cchRoleMax);
+    int GetRoleTextA(int lRole, LPSTR lpszRole, int cchRoleMax);
 
     /**
      * Retrieves the localized string that describes the object's role for the specified role value.
@@ -201,5 +199,5 @@ public interface Oleacc extends StdCallLibrary
      *         If the string resource does not exist, or if the lpszRole parameter is not a valid pointer, the return value is zero (0).
      *         To get extended error information, call GetLastError.
      */
-    UINT GetRoleTextW(DWORD lRole, LPWSTR lpszRole, UINT cchRoleMax);
+    int GetRoleTextW(int lRole, LPWSTR lpszRole, int cchRoleMax);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/Oleacc.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Oleacc.java
@@ -1,0 +1,205 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Guid.REFIID;
+import com.sun.jna.platform.win32.Variant.VARIANT;
+import com.sun.jna.platform.win32.WTypes.LPWSTR;
+import com.sun.jna.platform.win32.WTypes.LPSTR;
+import com.sun.jna.platform.win32.WinDef.UINT;
+import com.sun.jna.platform.win32.WinDef.DWORD;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIOptions;
+
+/**
+ * oleacc.dll Interface.
+ *
+ * Provides Windows Accessibility Features
+ * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/">oleacc.h header</a>
+ *
+ * @author Mo Beigi, me@mobeigi.org
+ */
+public interface Oleacc extends StdCallLibrary
+{
+    /** The instance. */
+    Oleacc INSTANCE = Native.load("Oleacc", Oleacc.class, W32APIOptions.DEFAULT_OPTIONS);
+
+    /**
+     * Object Roles
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/winauto/object-roles">Object Roles</a>
+     */
+    int ROLE_SYSTEM_TITLEBAR = 0x1;
+    int ROLE_SYSTEM_MENUBAR = 0x2;
+    int ROLE_SYSTEM_SCROLLBAR = 0x3;
+    int ROLE_SYSTEM_GRIP = 0x4;
+    int ROLE_SYSTEM_SOUND = 0x5;
+    int ROLE_SYSTEM_CURSOR = 0x6;
+    int ROLE_SYSTEM_CARET = 0x7;
+    int ROLE_SYSTEM_ALERT = 0x8;
+    int ROLE_SYSTEM_WINDOW = 0x9;
+    int ROLE_SYSTEM_CLIENT = 0xa;
+    int ROLE_SYSTEM_MENUPOPUP = 0xb;
+    int ROLE_SYSTEM_MENUITEM = 0xc;
+    int ROLE_SYSTEM_TOOLTIP = 0xd;
+    int ROLE_SYSTEM_APPLICATION = 0xe;
+    int ROLE_SYSTEM_DOCUMENT = 0xf;
+    int ROLE_SYSTEM_PANE = 0x10;
+    int ROLE_SYSTEM_CHART = 0x11;
+    int ROLE_SYSTEM_DIALOG = 0x12;
+    int ROLE_SYSTEM_BORDER = 0x13;
+    int ROLE_SYSTEM_GROUPING = 0x14;
+    int ROLE_SYSTEM_SEPARATOR = 0x15;
+    int ROLE_SYSTEM_TOOLBAR = 0x16;
+    int ROLE_SYSTEM_STATUSBAR = 0x17;
+    int ROLE_SYSTEM_TABLE = 0x18;
+    int ROLE_SYSTEM_COLUMNHEADER = 0x19;
+    int ROLE_SYSTEM_ROWHEADER = 0x1a;
+    int ROLE_SYSTEM_COLUMN = 0x1b;
+    int ROLE_SYSTEM_ROW = 0x1c;
+    int ROLE_SYSTEM_CELL = 0x1d;
+    int ROLE_SYSTEM_LINK = 0x1e;
+    int ROLE_SYSTEM_HELPBALLOON = 0x1f;
+    int ROLE_SYSTEM_CHARACTER = 0x20;
+    int ROLE_SYSTEM_LIST = 0x21;
+    int ROLE_SYSTEM_LISTITEM = 0x22;
+    int ROLE_SYSTEM_OUTLINE = 0x23;
+    int ROLE_SYSTEM_OUTLINEITEM = 0x24;
+    int ROLE_SYSTEM_PAGETAB = 0x25;
+    int ROLE_SYSTEM_PROPERTYPAGE = 0x26;
+    int ROLE_SYSTEM_INDICATOR = 0x27;
+    int ROLE_SYSTEM_GRAPHIC = 0x28;
+    int ROLE_SYSTEM_STATICTEXT = 0x29;
+    int ROLE_SYSTEM_TEXT = 0x2a;
+    int ROLE_SYSTEM_PUSHBUTTON = 0x2b;
+    int ROLE_SYSTEM_CHECKBUTTON = 0x2c;
+    int ROLE_SYSTEM_RADIOBUTTON = 0x2d;
+    int ROLE_SYSTEM_COMBOBOX = 0x2e;
+    int ROLE_SYSTEM_DROPLIST = 0x2f;
+    int ROLE_SYSTEM_PROGRESSBAR = 0x30;
+    int ROLE_SYSTEM_DIAL = 0x31;
+    int ROLE_SYSTEM_HOTKEYFIELD = 0x32;
+    int ROLE_SYSTEM_SLIDER = 0x33;
+    int ROLE_SYSTEM_SPINBUTTON = 0x34;
+    int ROLE_SYSTEM_DIAGRAM = 0x35;
+    int ROLE_SYSTEM_ANIMATION = 0x36;
+    int ROLE_SYSTEM_EQUATION = 0x37;
+    int ROLE_SYSTEM_BUTTONDROPDOWN = 0x38;
+    int ROLE_SYSTEM_BUTTONMENU = 0x39;
+    int ROLE_SYSTEM_BUTTONDROPDOWNGRID = 0x3a;
+    int ROLE_SYSTEM_WHITESPACE = 0x3b;
+    int ROLE_SYSTEM_PAGETABLIST = 0x3c;
+    int ROLE_SYSTEM_CLOCK = 0x3d;
+    int ROLE_SYSTEM_SPLITBUTTON = 0x3e;
+    int ROLE_SYSTEM_IPADDRESS = 0x3f;
+    int ROLE_SYSTEM_OUTLINEBUTTON = 0x40;
+
+    /**
+     * Retrieves the child ID or IDispatch of each child within an accessible container object.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-accessiblechildren">AccessibleChildren function (oleacc.h)</a>
+     *
+     * @param paccContainer [in] Pointer to the container object's IAccessible interface.
+     * @param iChildStart [in] Specifies the zero-based index of the first child that is retrieved.
+     *                    This parameter is an index, not a child ID, and it is usually set to zero (0).
+     * @param cChildren [in] Specifies the number of children to retrieve. To retrieve the current number of children,
+     *                  an application calls IAccessible::get_accChildCount.
+     * @param rgvarChildren [out] Pointer to an array of VARIANT structures that receives information about the container's children.
+     *                      If the vt member of an array element is VT_I4, then the lVal member for that element is the child ID.
+     *                      If the vt member of an array element is VT_DISPATCH, then the pdispVal member for that element is
+     *                      the address of the child object's IDispatch interface.
+     * @param pcObtained [out] Address of a variable that receives the number of elements in the rgvarChildren array that is populated
+     *                   by the AccessibleChildren function. This value is the same as that of the cChildren parameter;
+     *                   however, if you request more children than exist, this value will be less than that of cChildren.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT AccessibleChildren(Pointer paccContainer, long iChildStart, long cChildren, VARIANT[] rgvarChildren, LongByReference pcObtained);
+
+    /**
+     * Retrieves the address of the specified interface for the object associated with the specified window.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-accessibleobjectfromwindow">AccessibleObjectFromWindow function (oleacc.h)</a>
+     *
+     * @param hwnd [in] Specifies the handle of a window for which an object is to be retrieved.
+     *             To retrieve an interface pointer to the cursor or caret object, specify NULL and use the appropriate object ID in dwObjectID.
+     * @param dwId [in] Specifies the object ID. This value is one of the standard object identifier constants or a custom object ID such as OBJID_NATIVEOM,
+     *             which is the object ID for the Office native object model.
+     * @param riid [in] Specifies the reference identifier of the requested interface. This value is either IID_IAccessible or
+     *             IID_IDispatch, but it can also be IID_IUnknown, or the IID of any interface that the object is expected to support.
+     * @param ppvObject [out] Address of a pointer variable that receives the address of the specified interface.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT AccessibleObjectFromWindow(HWND hwnd, DWORD dwId, REFIID riid, PointerByReference ppvObject);
+
+    /**
+     * Retrieves the window handle that corresponds to a particular instance of an IAccessible interface.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-windowfromaccessibleobject">WindowFromAccessibleObject function (oleacc.h)</a>
+     *
+     * @param IAccessible [in] Pointer to the IAccessible interface whose corresponding window handle will be retrieved. This parameter must not be NULL.
+     * @param phwnd [out] Address of a variable that receives a handle to the window containing the object specified in pacc.
+     *              If this value is NULL after the call, the object is not contained within a window;
+     *              for example, the mouse pointer is not contained within a window.
+     * @return the HRESULT. If successful, returns S_OK. If not successful, returns one of the error values, or another standard COM error code.
+     */
+    HRESULT WindowFromAccessibleObject(Pointer IAccessible, PointerByReference phwnd);
+
+    /**
+     * Retrieves the localized string that describes the object's role for the specified role value.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-getroletexta">GetRoleTextA function (oleacc.h)</a>
+     *
+     * @param lRole [in] One of the object role constants.
+     * @param lpszRole [out] Address of a buffer that receives the role text string. If this parameter is NULL, the function returns the role string's length, not including the null character.
+     * @param cchRoleMax [in] The size of the buffer that is pointed to by the lpszRole parameter. For ANSI strings, this value is measured in bytes; for Unicode strings, it is measured in characters.
+     * @return If successful, and if lpszRole is non-NULL, the return value is the number of bytes (ANSI strings)
+     *         or characters (Unicode strings) copied into the buffer, not including the terminating null character.
+     *         If lpszRole is NULL, the return value represents the string's length, not including the null character.
+     *         If the string resource does not exist, or if the lpszRole parameter is not a valid pointer, the return value is zero (0).
+     *         To get extended error information, call GetLastError.
+     */
+    UINT GetRoleTextA(DWORD lRole, LPSTR lpszRole, UINT cchRoleMax);
+
+    /**
+     * Retrieves the localized string that describes the object's role for the specified role value.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-getroletextw">GetRoleTextW function (oleacc.h)</a>
+     *
+     * @param lRole [in] One of the object role constants.
+     * @param lpszRole [out] Address of a buffer that receives the role text string. If this parameter is NULL, the function returns the role string's length, not including the null character.
+     * @param cchRoleMax [in] The size of the buffer that is pointed to by the lpszRole parameter. For ANSI strings, this value is measured in bytes; for Unicode strings, it is measured in characters.
+     * @return If successful, and if lpszRole is non-NULL, the return value is the number of bytes (ANSI strings)
+     *         or characters (Unicode strings) copied into the buffer, not including the terminating null character.
+     *         If lpszRole is NULL, the return value represents the string's length, not including the null character.
+     *         If the string resource does not exist, or if the lpszRole parameter is not a valid pointer, the return value is zero (0).
+     *         To get extended error information, call GetLastError.
+     */
+    UINT GetRoleTextW(DWORD lRole, LPWSTR lpszRole, UINT cchRoleMax);
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/Oleacc.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Oleacc.java
@@ -27,8 +27,6 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Guid.REFIID;
 import com.sun.jna.platform.win32.Variant.VARIANT;
-import com.sun.jna.platform.win32.WTypes.LPWSTR;
-import com.sun.jna.platform.win32.WTypes.LPSTR;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
 import com.sun.jna.ptr.IntByReference;
@@ -173,21 +171,6 @@ public interface Oleacc extends StdCallLibrary
      * Retrieves the localized string that describes the object's role for the specified role value.
      *
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-getroletexta">GetRoleTextA function (oleacc.h)</a>
-     *
-     * @param lRole [in] One of the object role constants.
-     * @param lpszRole [out] Address of a buffer that receives the role text string. If this parameter is NULL, the function returns the role string's length, not including the null character.
-     * @param cchRoleMax [in] The size of the buffer that is pointed to by the lpszRole parameter. For ANSI strings, this value is measured in bytes; for Unicode strings, it is measured in characters.
-     * @return If successful, and if lpszRole is non-NULL, the return value is the number of bytes (ANSI strings)
-     *         or characters (Unicode strings) copied into the buffer, not including the terminating null character.
-     *         If lpszRole is NULL, the return value represents the string's length, not including the null character.
-     *         If the string resource does not exist, or if the lpszRole parameter is not a valid pointer, the return value is zero (0).
-     *         To get extended error information, call GetLastError.
-     */
-    int GetRoleTextA(int lRole, LPSTR lpszRole, int cchRoleMax);
-
-    /**
-     * Retrieves the localized string that describes the object's role for the specified role value.
-     *
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-getroletextw">GetRoleTextW function (oleacc.h)</a>
      *
      * @param lRole [in] One of the object role constants.
@@ -199,5 +182,5 @@ public interface Oleacc extends StdCallLibrary
      *         If the string resource does not exist, or if the lpszRole parameter is not a valid pointer, the return value is zero (0).
      *         To get extended error information, call GetLastError.
      */
-    int GetRoleTextW(int lRole, LPWSTR lpszRole, int cchRoleMax);
+    int GetRoleText(int lRole, Pointer lpszRole, int cchRoleMax);
 }

--- a/contrib/platform/src/com/sun/jna/platform/win32/OleaccUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OleaccUtil.java
@@ -1,0 +1,65 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+
+/**
+ * {@link Oleacc} utility API
+ *
+ * @author Mo Beigi, me@mobeigi.org
+ */
+public abstract class OleaccUtil
+{
+    /**
+     * Retrieves the localized string that describes the object's role for the specified role value.
+     * This method will allocate the correct memory based on if you are using the ANSI or UNICODE win32 API.
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-getroletexta">GetRoleTextA function (oleacc.h)</a>
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/oleacc/nf-oleacc-getroletextw">GetRoleTextW function (oleacc.h)</a>
+     *
+     * @param iRole One of the object role constants.
+     * @return The role text string.
+     * @throws Win32Exception Error populated from GetLastError
+     */
+    public static String GetRoleText(int iRole) throws Win32Exception {
+        int result = Oleacc.INSTANCE.GetRoleText(iRole, null, 0);
+        if (result == 0) {
+            throw new Win32Exception(Native.getLastError());
+        }
+        int charToBytes = Boolean.getBoolean("w32.ascii") ? 1 : Native.WCHAR_SIZE;
+        Memory memory = new Memory((long) (result + 1) * charToBytes); // plus 1 for null terminator
+        int result2 = Oleacc.INSTANCE.GetRoleText(iRole, memory, result + 1);
+        if (result2 == 0) {
+            throw new Win32Exception(Native.getLastError());
+        }
+
+        if (Boolean.getBoolean("w32.ascii")) {
+            return memory.getString(0);
+        } else {
+            return memory.getWideString(0);
+        }
+    }
+}

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinUser.java
@@ -2088,4 +2088,10 @@ public interface WinUser extends WinDef {
      * Bitmask for the RESERVED2 key modifier.
      */
     int MODIFIER_RESERVED2_MASK = 32;
+
+    /**
+     * Indicate that information is needed about the object itself.
+     */
+    int CHILDID_SELF = 0;
+
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/AccessibleUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/AccessibleUtilTest.java
@@ -23,10 +23,10 @@
  */
 package com.sun.jna.platform.win32.COM;
 
+import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.Oleacc;
 import com.sun.jna.platform.win32.User32;
-import com.sun.jna.platform.win32.W32Errors;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.Guid.REFIID;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class AccessibleUtilTest
 {
+    private static boolean initialized = false;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -49,19 +50,19 @@ public class AccessibleUtilTest
         Thread.sleep(1000);
 
         // Initialize COM for this thread...
-        HRESULT hr = Ole32.INSTANCE.CoInitialize(null);
-
-        if (W32Errors.FAILED(hr)) {
-            tearDown();
-            throw new COMException("CoInitialize() failed");
-        }
+        COMUtils.checkRC(Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED));
+        initialized = true;
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
         Runtime.getRuntime().exec("taskkill.exe /f /im calculator.exe");
         Thread.sleep(1000);
-        Ole32.INSTANCE.CoUninitialize();
+
+        if (initialized) {
+            Ole32.INSTANCE.CoUninitialize();
+            initialized = false;
+        }
     }
 
     private static HWND getCalculatorHwnd() {

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/AccessibleUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/AccessibleUtilTest.java
@@ -1,0 +1,88 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32.COM;
+
+import com.sun.jna.platform.win32.Ole32;
+import com.sun.jna.platform.win32.Oleacc;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.W32Errors;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.Guid.REFIID;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+import com.sun.jna.ptr.PointerByReference;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.sun.jna.platform.win32.WinError.S_OK;
+import static com.sun.jna.platform.win32.WinUser.CHILDID_SELF;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AccessibleUtilTest
+{
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Runtime.getRuntime().exec("calc");
+        Thread.sleep(1000);
+
+        // Initialize COM for this thread...
+        HRESULT hr = Ole32.INSTANCE.CoInitialize(null);
+
+        if (W32Errors.FAILED(hr)) {
+            tearDown();
+            throw new COMException("CoInitialize() failed");
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Runtime.getRuntime().exec("taskkill.exe /f /im calculator.exe");
+        Thread.sleep(1000);
+        Ole32.INSTANCE.CoUninitialize();
+    }
+
+    private static HWND getCalculatorHwnd() {
+        HWND hwnd = User32.INSTANCE.FindWindow(null, "Calculator");
+        assertNotNull(hwnd);
+        return hwnd;
+    }
+
+    private static Accessible getCalculatorAccessible() {
+        HWND hwnd = getCalculatorHwnd();
+        REFIID riid = new REFIID(IAccessible.IID_IACCESSIBLE);
+        PointerByReference pointer = new PointerByReference();
+        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, 0, riid, pointer);
+        assertEquals(S_OK, hresult);
+        return new Accessible(pointer.getPointer().getPointer(0L));
+    }
+
+    @Test
+    public void test_get_accName() {
+        Accessible accessible = getCalculatorAccessible();
+        String accName = new AccessibleUtil(accessible).get_accName(CHILDID_SELF);
+        assertEquals("Calculator", accName);
+    }
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
@@ -23,6 +23,7 @@
  */
 package com.sun.jna.platform.win32.COM;
 
+import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Ole32;
 import com.sun.jna.platform.win32.Oleacc;
 import com.sun.jna.platform.win32.User32;
@@ -47,6 +48,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class IAccessibleTest
 {
+    private static boolean initialized = false;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -54,19 +56,19 @@ public class IAccessibleTest
         Thread.sleep(1000);
 
         // Initialize COM for this thread...
-        HRESULT hr = Ole32.INSTANCE.CoInitialize(null);
-
-        if (W32Errors.FAILED(hr)) {
-            tearDown();
-            throw new COMException("CoInitialize() failed");
-        }
+        COMUtils.checkRC(Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_MULTITHREADED));
+        initialized = true;
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
         Runtime.getRuntime().exec("taskkill.exe /f /im calculator.exe");
         Thread.sleep(1000);
-        Ole32.INSTANCE.CoUninitialize();
+
+        if (initialized) {
+            Ole32.INSTANCE.CoUninitialize();
+            initialized = false;
+        }
     }
 
     private static HWND getCalculatorHwnd() {

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
@@ -30,11 +30,10 @@ import com.sun.jna.platform.win32.Variant;
 import com.sun.jna.platform.win32.W32Errors;
 import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.platform.win32.WinDef.HWND;
-import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.LONG;
 import com.sun.jna.platform.win32.Guid.REFIID;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
-import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -83,7 +82,7 @@ public class IAccessibleTest
         HWND hwnd = getCalculatorHwnd();
         REFIID riid = new REFIID(IAccessible.IID_IACCESSIBLE);
         PointerByReference pointer = new PointerByReference();
-        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, new DWORD(0L), riid, pointer);
+        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, 0, riid, pointer);
         assertEquals(S_OK, hresult);
         return new Accessible(pointer.getPointer().getPointer(0L));
     }
@@ -130,10 +129,10 @@ public class IAccessibleTest
     public void test_get_accChildCount() {
         Accessible accessible = getCalculatorAccessible();
 
-        LongByReference longByReference = new LongByReference();
-        HRESULT hresult = accessible.get_accChildCount(longByReference);
+        IntByReference intByReference = new IntByReference();
+        HRESULT hresult = accessible.get_accChildCount(intByReference);
         assertEquals(S_OK, hresult);
-        assertEquals(7L, longByReference.getValue());
+        assertEquals(7L, intByReference.getValue());
     }
 
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
@@ -25,10 +25,10 @@ package com.sun.jna.platform.win32.COM;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Ole32;
+import com.sun.jna.platform.win32.OleAuto;
 import com.sun.jna.platform.win32.Oleacc;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.Variant;
-import com.sun.jna.platform.win32.W32Errors;
 import com.sun.jna.platform.win32.WTypes.BSTRByReference;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinDef.LONG;
@@ -97,6 +97,9 @@ public class IAccessibleTest
         HRESULT hresult = accessible.get_accName(varChild, bstr);
         assertEquals(S_OK, hresult);
         assertEquals("Calculator", bstr.getValue().getValue());
+
+        OleAuto.INSTANCE.VariantClear(varChild);
+        OleAuto.INSTANCE.SysFreeString(bstr.getValue());
     }
 
     @Test
@@ -109,6 +112,9 @@ public class IAccessibleTest
 
         HRESULT hresult = accessible.get_accValue(varChild, bstr);
         assertEquals(S_FALSE, hresult); // This object does not have a value
+
+        OleAuto.INSTANCE.VariantClear(varChild);
+        OleAuto.INSTANCE.SysFreeString(bstr.getValue());
     }
 
     @Test
@@ -122,6 +128,9 @@ public class IAccessibleTest
         HRESULT hresult = accessible.get_accRole(varChild, variantByReference);
         assertEquals(S_OK, hresult);
         assertEquals(ROLE_SYSTEM_WINDOW, variantByReference.intValue());
+
+        OleAuto.INSTANCE.VariantClear(varChild);
+        OleAuto.INSTANCE.VariantClear(variantByReference);
     }
 
     @Test
@@ -144,6 +153,9 @@ public class IAccessibleTest
 
         HRESULT hresult = accessible.get_accDefaultAction(varChild, bstr);
         assertEquals(S_FALSE, hresult); // No default action for root object
+
+        OleAuto.INSTANCE.VariantClear(varChild);
+        OleAuto.INSTANCE.SysFreeString(bstr.getValue());
     }
 
     @Test
@@ -155,5 +167,7 @@ public class IAccessibleTest
 
         HRESULT hresult = accessible.accDoDefaultAction(varChild);
         assertEquals(S_FALSE, hresult); // No default action to do for root object
+
+        OleAuto.INSTANCE.VariantClear(varChild);
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
@@ -47,9 +47,6 @@ import static org.junit.Assert.assertNotNull;
 
 public class IAccessibleTest
 {
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
@@ -1,0 +1,161 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32.COM;
+
+import com.sun.jna.platform.win32.Ole32;
+import com.sun.jna.platform.win32.Oleacc;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.Variant;
+import com.sun.jna.platform.win32.W32Errors;
+import com.sun.jna.platform.win32.WTypes.BSTRByReference;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinDef.DWORD;
+import com.sun.jna.platform.win32.WinDef.LONG;
+import com.sun.jna.platform.win32.Guid.REFIID;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.PointerByReference;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.sun.jna.platform.win32.Oleacc.ROLE_SYSTEM_WINDOW;
+import static com.sun.jna.platform.win32.WinError.S_FALSE;
+import static com.sun.jna.platform.win32.WinError.S_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class IAccessibleTest
+{
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Runtime.getRuntime().exec("calc");
+        Thread.sleep(1000);
+
+        // Initialize COM for this thread...
+        HRESULT hr = Ole32.INSTANCE.CoInitialize(null);
+
+        if (W32Errors.FAILED(hr)) {
+            tearDown();
+            throw new COMException("CoInitialize() failed");
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Runtime.getRuntime().exec("taskkill.exe /f /im calculator.exe");
+        Thread.sleep(1000);
+        Ole32.INSTANCE.CoUninitialize();
+    }
+
+    private static HWND getCalculatorHwnd() {
+        HWND hwnd = User32.INSTANCE.FindWindow(null, "Calculator");
+        assertNotNull(hwnd);
+        return hwnd;
+    }
+
+    private static Accessible getCalculatorAccessible() {
+        HWND hwnd = getCalculatorHwnd();
+        REFIID riid = new REFIID(IAccessible.IID_IACCESSIBLE);
+        PointerByReference pointer = new PointerByReference();
+        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, new DWORD(0L), riid, pointer);
+        assertEquals(S_OK, hresult);
+        return new Accessible(pointer.getPointer().getPointer(0L));
+    }
+
+    @Test
+    public void test_get_accName() {
+        Accessible accessible = getCalculatorAccessible();
+
+        Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
+        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        BSTRByReference bstr = new BSTRByReference();
+
+        HRESULT hresult = accessible.get_accName(varChild, bstr);
+        assertEquals(S_OK, hresult);
+        assertEquals("Calculator", bstr.getValue().getValue());
+    }
+
+    @Test
+    public void test_get_accValue() {
+        Accessible accessible = getCalculatorAccessible();
+
+        Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
+        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        BSTRByReference bstr = new BSTRByReference();
+
+        HRESULT hresult = accessible.get_accValue(varChild, bstr);
+        assertEquals(S_FALSE, hresult); // This object does not have a value
+    }
+
+    @Test
+    public void test_get_accRole() {
+        Accessible accessible = getCalculatorAccessible();
+
+        Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
+        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        Variant.VARIANT.ByReference variantByReference = new Variant.VARIANT.ByReference();
+
+        HRESULT hresult = accessible.get_accRole(varChild, variantByReference);
+        assertEquals(S_OK, hresult);
+        assertEquals(ROLE_SYSTEM_WINDOW, variantByReference.intValue());
+    }
+
+    @Test
+    public void test_get_accChildCount() {
+        Accessible accessible = getCalculatorAccessible();
+
+        LongByReference longByReference = new LongByReference();
+        HRESULT hresult = accessible.get_accChildCount(longByReference);
+        assertEquals(S_OK, hresult);
+        assertEquals(7L, longByReference.getValue());
+    }
+
+    @Test
+    public void test_get_accDefaultAction() {
+        Accessible accessible = getCalculatorAccessible();
+
+        Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
+        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        BSTRByReference bstr = new BSTRByReference();
+
+        HRESULT hresult = accessible.get_accDefaultAction(varChild, bstr);
+        assertEquals(S_FALSE, hresult); // No default action for root object
+    }
+
+    @Test
+    public void test_accDoDefaultAction() {
+        Accessible accessible = getCalculatorAccessible();
+
+        Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
+        varChild.setValue(Variant.VT_I4, new LONG(0L));
+
+        HRESULT hresult = accessible.accDoDefaultAction(varChild);
+        assertEquals(S_FALSE, hresult); // No default action to do for root object
+    }
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import static com.sun.jna.platform.win32.Oleacc.ROLE_SYSTEM_WINDOW;
 import static com.sun.jna.platform.win32.WinError.S_FALSE;
 import static com.sun.jna.platform.win32.WinError.S_OK;
+import static com.sun.jna.platform.win32.WinUser.CHILDID_SELF;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -91,7 +92,7 @@ public class IAccessibleTest
         Accessible accessible = getCalculatorAccessible();
 
         Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
-        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        varChild.setValue(Variant.VT_I4, new LONG(CHILDID_SELF));
         BSTRByReference bstr = new BSTRByReference();
 
         HRESULT hresult = accessible.get_accName(varChild, bstr);
@@ -107,7 +108,7 @@ public class IAccessibleTest
         Accessible accessible = getCalculatorAccessible();
 
         Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
-        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        varChild.setValue(Variant.VT_I4, new LONG(CHILDID_SELF));
         BSTRByReference bstr = new BSTRByReference();
 
         HRESULT hresult = accessible.get_accValue(varChild, bstr);
@@ -122,7 +123,7 @@ public class IAccessibleTest
         Accessible accessible = getCalculatorAccessible();
 
         Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
-        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        varChild.setValue(Variant.VT_I4, new LONG(CHILDID_SELF));
         Variant.VARIANT.ByReference variantByReference = new Variant.VARIANT.ByReference();
 
         HRESULT hresult = accessible.get_accRole(varChild, variantByReference);
@@ -148,7 +149,7 @@ public class IAccessibleTest
         Accessible accessible = getCalculatorAccessible();
 
         Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
-        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        varChild.setValue(Variant.VT_I4, new LONG(CHILDID_SELF));
         BSTRByReference bstr = new BSTRByReference();
 
         HRESULT hresult = accessible.get_accDefaultAction(varChild, bstr);
@@ -163,7 +164,7 @@ public class IAccessibleTest
         Accessible accessible = getCalculatorAccessible();
 
         Variant.VARIANT varChild = new Variant.VARIANT.ByValue();
-        varChild.setValue(Variant.VT_I4, new LONG(0L));
+        varChild.setValue(Variant.VT_I4, new LONG(CHILDID_SELF));
 
         HRESULT hresult = accessible.accDoDefaultAction(varChild);
         assertEquals(S_FALSE, hresult); // No default action to do for root object

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/IAccessibleTest.java
@@ -132,7 +132,7 @@ public class IAccessibleTest
         IntByReference intByReference = new IntByReference();
         HRESULT hresult = accessible.get_accChildCount(intByReference);
         assertEquals(S_OK, hresult);
-        assertEquals(7L, intByReference.getValue());
+        assertEquals(7, intByReference.getValue());
     }
 
     @Test

--- a/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
@@ -101,7 +101,7 @@ public class OleaccTest
                 pcObtained
         );
         assertEquals(S_OK, hresult2);
-        assertEquals(7L, pcObtained.getValue());
+        assertEquals(7, pcObtained.getValue());
 
         for (int i = 0; i < pcObtained.getValue(); ++i) {
             assertEquals(Variant.VT_DISPATCH, rgvarChildren[i].getVarType().intValue());

--- a/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
@@ -26,7 +26,6 @@ package com.sun.jna.platform.win32;
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.COM.Accessible;
-import com.sun.jna.platform.win32.COM.COMException;
 import com.sun.jna.platform.win32.COM.COMUtils;
 import com.sun.jna.platform.win32.COM.IAccessible;
 import com.sun.jna.ptr.IntByReference;
@@ -109,6 +108,7 @@ public class OleaccTest
 
         for (int i = 0; i < pcObtained.getValue(); ++i) {
             assertEquals(Variant.VT_DISPATCH, rgvarChildren[i].getVarType().intValue());
+            OleAuto.INSTANCE.VariantClear(rgvarChildren[i]);
         }
     }
 

--- a/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
@@ -24,14 +24,13 @@
 package com.sun.jna.platform.win32;
 
 import com.sun.jna.Memory;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.COM.Accessible;
 import com.sun.jna.platform.win32.COM.COMUtils;
 import com.sun.jna.platform.win32.COM.IAccessible;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
-import com.sun.jna.platform.win32.WTypes.LPSTR;
-import com.sun.jna.platform.win32.WTypes.LPWSTR;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.Guid.REFIID;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
@@ -135,22 +134,20 @@ public class OleaccTest
     }
 
     @Test
-    public void testGetRoleTextA() {
-        int result = Oleacc.INSTANCE.GetRoleTextA(Oleacc.ROLE_SYSTEM_TITLEBAR, null, 0);
-        assertEquals(9, result);
-        LPSTR lptstr = new LPSTR(new Memory(result + 1)); // plus 1 for null terminator
-        int result2 = Oleacc.INSTANCE.GetRoleTextA(Oleacc.ROLE_SYSTEM_TITLEBAR, lptstr, result + 1);
-        assertEquals(result, result2);
-        assertEquals("title bar", lptstr.toString());
-    }
+    public void testGetRoleText() {
+        int charToBytes = Boolean.getBoolean("w32.ascii") ? 1 : Native.WCHAR_SIZE;
 
-    @Test
-    public void testGetRoleTextW() {
-        int result = Oleacc.INSTANCE.GetRoleTextW(Oleacc.ROLE_SYSTEM_TITLEBAR, null, 0);
+        int result = Oleacc.INSTANCE.GetRoleText(Oleacc.ROLE_SYSTEM_TITLEBAR, null, 0);
         assertEquals(9, result);
-        LPWSTR lpwstr = new LPWSTR(new Memory(result + 1)); // plus 1 for null terminator
-        int result2 = Oleacc.INSTANCE.GetRoleTextW(Oleacc.ROLE_SYSTEM_TITLEBAR, lpwstr, result + 1);
+        Memory memory = new Memory((long) (result + 1) * charToBytes); // plus 1 for null terminator
+
+        int result2 = Oleacc.INSTANCE.GetRoleText(Oleacc.ROLE_SYSTEM_TITLEBAR, memory, result + 1);
         assertEquals(result, result2);
-        assertEquals("title bar", lpwstr.toString());
+
+        if (Boolean.getBoolean("w32.ascii")) {
+            assertEquals("title bar", memory.getString(0));
+        } else {
+            assertEquals("title bar", memory.getWideString(0));
+        }
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
@@ -27,13 +27,11 @@ import com.sun.jna.Memory;
 import com.sun.jna.platform.win32.COM.Accessible;
 import com.sun.jna.platform.win32.COM.COMException;
 import com.sun.jna.platform.win32.COM.IAccessible;
-import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.platform.win32.WTypes.LPSTR;
 import com.sun.jna.platform.win32.WTypes.LPWSTR;
-import com.sun.jna.platform.win32.WinDef.UINT;
 import com.sun.jna.platform.win32.WinDef.HWND;
-import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.Guid.REFIID;
 import com.sun.jna.platform.win32.WinNT.HRESULT;
 import org.junit.AfterClass;
@@ -77,7 +75,7 @@ public class OleaccTest
         HWND hwnd = getCalculatorHwnd();
         REFIID riid = new REFIID(IAccessible.IID_IACCESSIBLE);
         PointerByReference pointer = new PointerByReference();
-        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, new DWORD(0L), riid, pointer);
+        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, 0, riid, pointer);
         assertEquals(S_OK, hresult);
         return new Accessible(pointer.getPointer().getPointer(0L));
     }
@@ -88,16 +86,16 @@ public class OleaccTest
         Accessible accessible = getCalculatorAccessible();
 
         // Call AccessibleChildren
-        LongByReference cChildren = new LongByReference();
+        IntByReference cChildren = new IntByReference();
         HRESULT hresult1 = accessible.get_accChildCount(cChildren);
         assertEquals(S_OK, hresult1);
 
         Variant.VARIANT[] rgvarChildren = new Variant.VARIANT[(int) cChildren.getValue()];
-        LongByReference pcObtained = new LongByReference();
+        IntByReference pcObtained = new IntByReference();
 
         HRESULT hresult2 = Oleacc.INSTANCE.AccessibleChildren(
                 accessible.getPointer(),
-                0L,
+                0,
                 cChildren.getValue(),
                 rgvarChildren,
                 pcObtained
@@ -115,7 +113,7 @@ public class OleaccTest
         HWND hwnd = getCalculatorHwnd();
         REFIID riid = new REFIID(IAccessible.IID_IACCESSIBLE);
         PointerByReference pointer = new PointerByReference();
-        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, new DWORD(0L), riid, pointer);
+        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, 0, riid, pointer);
         assertEquals(S_OK, hresult);
     }
 
@@ -134,21 +132,21 @@ public class OleaccTest
 
     @Test
     public void testGetRoleTextA() {
-        UINT result = Oleacc.INSTANCE.GetRoleTextA(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), null, new UINT(0L));
-        assertEquals(9, result.intValue());
-        LPSTR lptstr = new LPSTR(new Memory(result.intValue() + 1)); // plus 1 for null terminator
-        UINT result2 = Oleacc.INSTANCE.GetRoleTextA(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), lptstr, new UINT(result.intValue() + 1));
-        assertEquals(result.intValue(), result2.intValue());
+        int result = Oleacc.INSTANCE.GetRoleTextA(Oleacc.ROLE_SYSTEM_TITLEBAR, null, 0);
+        assertEquals(9, result);
+        LPSTR lptstr = new LPSTR(new Memory(result + 1)); // plus 1 for null terminator
+        int result2 = Oleacc.INSTANCE.GetRoleTextA(Oleacc.ROLE_SYSTEM_TITLEBAR, lptstr, result + 1);
+        assertEquals(result, result2);
         assertEquals("title bar", lptstr.toString());
     }
 
     @Test
     public void testGetRoleTextW() {
-        UINT result = Oleacc.INSTANCE.GetRoleTextW(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), null, new UINT(0L));
-        assertEquals(9, result.intValue());
-        LPWSTR lpwstr = new LPWSTR(new Memory(result.intValue() + 1)); // plus 1 for null terminator
-        UINT result2 = Oleacc.INSTANCE.GetRoleTextW(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), lpwstr, new UINT(result.intValue() + 1));
-        assertEquals(result.intValue(), result2.intValue());
+        int result = Oleacc.INSTANCE.GetRoleTextW(Oleacc.ROLE_SYSTEM_TITLEBAR, null, 0);
+        assertEquals(9, result);
+        LPWSTR lpwstr = new LPWSTR(new Memory(result + 1)); // plus 1 for null terminator
+        int result2 = Oleacc.INSTANCE.GetRoleTextW(Oleacc.ROLE_SYSTEM_TITLEBAR, lpwstr, result + 1);
+        assertEquals(result, result2);
         assertEquals("title bar", lpwstr.toString());
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/OleaccTest.java
@@ -1,0 +1,154 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32;
+
+import com.sun.jna.Memory;
+import com.sun.jna.platform.win32.COM.Accessible;
+import com.sun.jna.platform.win32.COM.COMException;
+import com.sun.jna.platform.win32.COM.IAccessible;
+import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.platform.win32.WTypes.LPSTR;
+import com.sun.jna.platform.win32.WTypes.LPWSTR;
+import com.sun.jna.platform.win32.WinDef.UINT;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinDef.DWORD;
+import com.sun.jna.platform.win32.Guid.REFIID;
+import com.sun.jna.platform.win32.WinNT.HRESULT;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.sun.jna.platform.win32.WinError.S_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class OleaccTest
+{
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Runtime.getRuntime().exec("calc");
+        Thread.sleep(1000);
+
+        // Initialize COM for this thread...
+        WinNT.HRESULT hr = Ole32.INSTANCE.CoInitialize(null);
+
+        if (W32Errors.FAILED(hr)) {
+            tearDown();
+            throw new COMException("CoInitialize() failed");
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Runtime.getRuntime().exec("taskkill.exe /f /im calculator.exe");
+        Thread.sleep(1000);
+        Ole32.INSTANCE.CoUninitialize();
+    }
+
+    private static HWND getCalculatorHwnd() {
+        HWND hwnd = User32.INSTANCE.FindWindow(null, "Calculator");
+        assertNotNull(hwnd);
+        return hwnd;
+    }
+
+    private static Accessible getCalculatorAccessible() {
+        HWND hwnd = getCalculatorHwnd();
+        REFIID riid = new REFIID(IAccessible.IID_IACCESSIBLE);
+        PointerByReference pointer = new PointerByReference();
+        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, new DWORD(0L), riid, pointer);
+        assertEquals(S_OK, hresult);
+        return new Accessible(pointer.getPointer().getPointer(0L));
+    }
+
+    @Test
+    public void testAccessibleChildren() {
+        // Get accessible from hwnd first
+        Accessible accessible = getCalculatorAccessible();
+
+        // Call AccessibleChildren
+        LongByReference cChildren = new LongByReference();
+        HRESULT hresult1 = accessible.get_accChildCount(cChildren);
+        assertEquals(S_OK, hresult1);
+
+        Variant.VARIANT[] rgvarChildren = new Variant.VARIANT[(int) cChildren.getValue()];
+        LongByReference pcObtained = new LongByReference();
+
+        HRESULT hresult2 = Oleacc.INSTANCE.AccessibleChildren(
+                accessible.getPointer(),
+                0L,
+                cChildren.getValue(),
+                rgvarChildren,
+                pcObtained
+        );
+        assertEquals(S_OK, hresult2);
+        assertEquals(7L, pcObtained.getValue());
+
+        for (int i = 0; i < pcObtained.getValue(); ++i) {
+            assertEquals(Variant.VT_DISPATCH, rgvarChildren[i].getVarType().intValue());
+        }
+    }
+
+    @Test
+    public void testAccessibleObjectFromWindow() {
+        HWND hwnd = getCalculatorHwnd();
+        REFIID riid = new REFIID(IAccessible.IID_IACCESSIBLE);
+        PointerByReference pointer = new PointerByReference();
+        HRESULT hresult = Oleacc.INSTANCE.AccessibleObjectFromWindow(hwnd, new DWORD(0L), riid, pointer);
+        assertEquals(S_OK, hresult);
+    }
+
+    @Test
+    public void testWindowFromAccessibleObject() {
+        // Get accessible from hwnd first
+        HWND originalHwnd = getCalculatorHwnd();
+        Accessible accessible = getCalculatorAccessible();
+
+        // Then attempt to get same hwnd from accessible
+        PointerByReference phwnd = new PointerByReference();
+        HRESULT hresult2 = Oleacc.INSTANCE.WindowFromAccessibleObject(accessible.getPointer(), phwnd);
+        assertEquals(S_OK, hresult2);
+        assertEquals(originalHwnd, new HWND(phwnd.getPointer().getPointer(0L)));
+    }
+
+    @Test
+    public void testGetRoleTextA() {
+        UINT result = Oleacc.INSTANCE.GetRoleTextA(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), null, new UINT(0L));
+        assertEquals(9, result.intValue());
+        LPSTR lptstr = new LPSTR(new Memory(result.intValue() + 1)); // plus 1 for null terminator
+        UINT result2 = Oleacc.INSTANCE.GetRoleTextA(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), lptstr, new UINT(result.intValue() + 1));
+        assertEquals(result.intValue(), result2.intValue());
+        assertEquals("title bar", lptstr.toString());
+    }
+
+    @Test
+    public void testGetRoleTextW() {
+        UINT result = Oleacc.INSTANCE.GetRoleTextW(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), null, new UINT(0L));
+        assertEquals(9, result.intValue());
+        LPWSTR lpwstr = new LPWSTR(new Memory(result.intValue() + 1)); // plus 1 for null terminator
+        UINT result2 = Oleacc.INSTANCE.GetRoleTextW(new DWORD(Oleacc.ROLE_SYSTEM_TITLEBAR), lpwstr, new UINT(result.intValue() + 1));
+        assertEquals(result.intValue(), result2.intValue());
+        assertEquals("title bar", lpwstr.toString());
+    }
+}

--- a/contrib/platform/test/com/sun/jna/platform/win32/OleaccUtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/OleaccUtilTest.java
@@ -1,0 +1,44 @@
+/* Copyright (c) 2021 Mo Beigi, All Rights Reserved
+ *
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.platform.win32;
+
+import org.junit.Test;
+
+
+import static com.sun.jna.platform.win32.Oleacc.ROLE_SYSTEM_TITLEBAR;
+import static org.junit.Assert.assertEquals;
+
+public class OleaccUtilTest
+{
+    @Test
+    public void testGetRoleText() {
+        String roleText = OleaccUtil.GetRoleText(ROLE_SYSTEM_TITLEBAR);
+        assertEquals("title bar", roleText);
+    }
+
+    @Test(expected = Win32Exception.class)
+    public void testGetRoleTextInvalidRoleThrowsException() {
+        OleaccUtil.GetRoleText(-1);
+    }
+}


### PR DESCRIPTION
## Context
When searching for `oleacc.dll` support for JNA I came across this Stack Overflow post: https://stackoverflow.com/questions/62047366/oleacc-dll-support-in-jna

Which led me to this issue:
https://github.com/java-native-access/jna/issues/401

Within this thread is a working implementation albeit all clustered within one file and with some questionable parameter choices. So I thought I'd be a good citizen and contribute my work after I polished it up.

## Reference Documentation
See: https://docs.microsoft.com/en-us/windows/win32/api/oleacc/

## My work

- Write `oleacc.dll` interface
- Write `IAccessible` interface
- Write unit tests for `oleacc` and `IAccessible` (based on opening Widows Calculator UWP app)
- Write Javadoc for interfaces
- Test usage as consumer in my own project

During implementation I essentially mimicked the official docs exactly (var names, function names, documentation).

## My questions

1. The `contributing.md` mention the Javadoc pages, can someone confirm if I have to do something for that as part of this PR?
2. How exactly do the tests work with CI/CD? I saw many of the tests spawn `iexplorer.exe`, I opted to spawn `calc.exe`, is that fine?
