### PR TITLE
Do not throw Win32Exception on success for empty section in Kernel32Util#getPrivateProfileSection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,11 @@ Next Release (5.11.0)
 Features
 --------
 * [#1398](https://github.com/java-native-access/jna/pull/1398): Increase `c.s.j.p.win32.Sspi#MAX_TOKEN_SIZE` on Windows 8/Server 2012 and later - [@dbwiddis](https://github.com/dbwiddis).
-* [#1398](https://github.com/java-native-access/jna/pull/1403): Rebuild AIX binaries with libffi 3.4.2 (other architectures were part of 5.10) - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1403](https://github.com/java-native-access/jna/pull/1403): Rebuild AIX binaries with libffi 3.4.2 (other architectures were part of 5.10) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Bug Fixes
 ---------
-
+* [#1411](https://github.com/java-native-access/jna/pull/1411): Do not throw `Win32Exception` on success for empty section in `Kernel32Util#getPrivateProfileSection` - [@mkarg](https://github.com/mkarg).
 
 Release 5.10.0
 ==============

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
@@ -244,9 +244,18 @@ public class Kernel32UtilTest extends TestCase {
         final File tmp = File.createTempFile("testGetPrivateProfileSection", ".ini");
         tmp.deleteOnExit();
 
-        final PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(tmp)));
+        final PrintWriter writer0 = new PrintWriter(new BufferedWriter(new FileWriter(tmp)));
         try {
-            writer.println("[X]");
+            writer0.println("[X]");
+        } finally {
+            writer0.close();
+        }
+
+        final String[] lines0 = Kernel32Util.getPrivateProfileSection("X", tmp.getCanonicalPath());
+        assertEquals(lines0.length, 0);
+
+        final PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(tmp, true)));
+        try {
             writer.println("A=1");
             writer.println("foo=bar");
         } finally {


### PR DESCRIPTION
Fixes #1410

Apparently what the caller in such a situation expects is to get the content of the *existing* section, i. e. an empty String array.

Using a constant object to reduce heap pollution.
