### PR TITLE
Load jawt library relative to sun.boot.library.path system on unix OSes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Bug Fixes
 * [#1411](https://github.com/java-native-access/jna/pull/1411): Do not throw `Win32Exception` on success for empty section in `Kernel32Util#getPrivateProfileSection` - [@mkarg](https://github.com/mkarg).
 * [#1414](https://github.com/java-native-access/jna/pull/1414): Fix definition of `c.s.j.p.unix.X11.XK_Shift_R` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1323](https://github.com/java-native-access/jna/issues/1323). Fix crashes in direct callbacks on mac OS aarch64 - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1422](https://github.com/java-native-access/jna/pull/1422): Load jawt library relative to `sun.boot.library.path` system on unix OSes - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.10.0
 ==============


### PR DESCRIPTION
At least Ubuntu builds the JDK with RUNPATH set instead of RPATH. The
two differ in their effect on loading transitive dependencies.

RPATHs effect also covers libraries loaded as transitive dependencies,
while RUNPATH does not. In the case of JNA libjawt is loaded by
libdispatch (the native JNA part), which makes it a transtive load.

The solution is to load the library with the full path based on the
sun.boot.library.path system property, which points to the native
library dirs.