### PR TITLE
Add missing PRINTER_INFO_X structs

### DIFF
--- a/contrib/platform/src/com/sun/jna/platform/win32/WinGDI.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinGDI.java
@@ -36,9 +36,87 @@ import com.sun.jna.platform.win32.WinDef.RECT;
  * Microsoft Windows SDK 6.0A.
  * @author dblock[at]dblock.org
  * @author Andreas "PAX" L&uuml;ck, onkelpax-git[at]yahoo.de
+ * @author SSHTOOLS Limited, support@sshtools.com
  */
 public interface WinGDI {
     int RDH_RECTANGLES = 1;
+
+    @FieldOrder({ "dmDeviceName", "dmSpecVersion", "dmDriverVersion", "dmSize", "dmDriverExtra", "dmFields", "dmUnion1", "dmColor",
+            "dmDuplex", "dmYResolution", "dmTTOption", "dmCollate", "dmFormName", "dmLogPixels", "dmBitsPerPel", "dmPelsWidth",
+            "dmPelsHeight", "dummyunionname2", "dmDisplayFrequency", "dmICMMethod", "dmICMIntent", "dmMediaType", "dmDitherType",
+            "dmReserved1", "dmReserved2", "dmPanningWidth", "dmPanningHeight" })
+
+    public static class DEVMODE extends Structure {
+        public byte[] dmDeviceName = new byte[Winspool.CCHDEVICENAME];
+        public WORD dmSpecVersion;
+        public WORD dmDriverVersion;
+        public WORD dmSize;
+        public WORD dmDriverExtra;
+        public DWORD dmFields;
+        public DUMMYUNIONNAME dmUnion1;
+
+        public static class DUMMYUNIONNAME extends Union {
+            public DUMMYSTRUCTNAME dummystructname;
+
+            @FieldOrder({ "dmOrientation", "dmPaperSize", "dmPaperLength", "dmPaperWidth", "dmScale", "dmCopies", "dmDefaultSource",
+                    "dmPrintQuality" })
+            public static class DUMMYSTRUCTNAME extends Structure {
+                public short dmOrientation;
+                public short dmPaperSize;
+                public short dmPaperLength;
+                public short dmPaperWidth;
+                public short dmScale;
+                public short dmCopies;
+                public short dmDefaultSource;
+                public short dmPrintQuality;
+
+                public DUMMYSTRUCTNAME() {
+                    super();
+                }
+            }
+
+            public POINT dmPosition;
+            public DUMMYSTRUCTNAME2 dummystructname2;
+
+            @FieldOrder({ "dmPosition", "dmDisplayOrientation", "dmDisplayFixedOutput" })
+            public static class DUMMYSTRUCTNAME2 extends Structure {
+                public POINT dmPosition;
+                public DWORD dmDisplayOrientation;
+                public DWORD dmDisplayFixedOutput;
+
+                public DUMMYSTRUCTNAME2() {
+                    super();
+                }
+            }
+        }
+
+        public short dmColor;
+        public short dmDuplex;
+        public short dmYResolution;
+        public short dmTTOption;
+        public short dmCollate;
+        public byte[] dmFormName = new byte[Winspool2.CCHFORMNAME];
+        public WORD dmLogPixels;
+        public DWORD dmBitsPerPel;
+        public DWORD dmPelsWidth;
+        public DWORD dmPelsHeight;
+        public DUMMYUNIONNAME2 dummyunionname2;
+
+        public static class DUMMYUNIONNAME2 extends Union {
+            public DWORD dmDisplayFlags;
+            public DWORD dmNup;
+        }
+
+        public DWORD dmDisplayFrequency;
+        public DWORD dmICMMethod;
+        public DWORD dmICMIntent;
+        public DWORD dmMediaType;
+        public DWORD dmDitherType;
+        public DWORD dmReserved1;
+        public DWORD dmReserved2;
+        public DWORD dmPanningWidth;
+        public DWORD dmPanningHeight;
+    }
 
     @FieldOrder({"dwSize", "iType", "nCount", "nRgnSize", "rcBound"})
     class RGNDATAHEADER extends Structure {

--- a/contrib/platform/src/com/sun/jna/platform/win32/Winspool.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Winspool.java
@@ -51,6 +51,7 @@ public interface Winspool extends StdCallLibrary {
     Winspool INSTANCE = Native.load("Winspool.drv", Winspool.class, W32APIOptions.DEFAULT_OPTIONS);
 
     public static final int CCHDEVICENAME = 32;
+    public static final int CCHFORMNAME = 32;
 
     public static final int PRINTER_STATUS_PAUSED = 0x00000001;
     public static final int PRINTER_STATUS_ERROR = 0x00000002;
@@ -509,6 +510,20 @@ public interface Winspool extends StdCallLibrary {
     }
 
     /**
+     * The PRINTER_INFO_3 structure specifies printer security information.
+     */
+    @FieldOrder({"pSecurityDescriptor"})
+    public static class PRINTER_INFO_3 extends Structure {
+        public WinNT.SECURITY_DESCRIPTOR_RELATIVE pSecurityDescriptor;
+
+        public PRINTER_INFO_3() {}
+
+        public PRINTER_INFO_3(int size) {
+            super(new Memory((long)size));
+        }
+    }
+
+    /**
      * The PRINTER_INFO_4 structure specifies general printer information.
      * <p>
      * The structure can be used to retrieve minimal printer information on a
@@ -543,6 +558,81 @@ public interface Winspool extends StdCallLibrary {
 
         public PRINTER_INFO_4(int size) {
             super(new Memory(size));
+        }
+    }
+
+    /**
+     * The PRINTER_INFO_5 structure specifies detailed printer information.
+     */
+    @FieldOrder({"pPrinterName", "pPortName", "Attributes", "DeviceNotSelectedTimeout", "TransmissionRetryTimeout" })
+    public static class PRINTER_INFO_5 extends Structure {
+        public String pPrinterName;
+        public String pPortName;
+        public DWORD Attributes;
+        public DWORD DeviceNotSelectedTimeout;
+        public DWORD TransmissionRetryTimeout;
+
+        public PRINTER_INFO_5() {}
+
+        public PRINTER_INFO_5(int size) {
+            super(new Memory((long)size));
+        }
+    }
+
+    /**
+     * The PRINTER_INFO_6 structure specifies the status value of a printer.
+     */
+    @FieldOrder({"dwStatus"})
+    public static class PRINTER_INFO_6 extends Structure {
+        public DWORD dwStatus;
+
+        public PRINTER_INFO_6() {}
+
+        public PRINTER_INFO_6(int size) {
+            super(new Memory((long)size));
+        }
+    }
+
+    /**
+     * The PRINTER_INFO_7 structure specifies directory services printer information.
+     */
+    @FieldOrder({"pszObjectGUID", "dwAction"})
+    public static class PRINTER_INFO_7 extends Structure {
+        public String pszObjectGUID;
+        public DWORD dwAction;
+
+        public PRINTER_INFO_7() {}
+
+        public PRINTER_INFO_7(int size) {
+            super(new Memory((long)size));
+        }
+    }
+
+    /**
+     * The PRINTER_INFO_8 structure specifies the global default printer settings.
+     */
+    @FieldOrder({"pDevMode"})
+    public static class PRINTER_INFO_8 extends Structure {
+        public DEVMODE pDevMode;
+
+        public PRINTER_INFO_8() {}
+
+        public PRINTER_INFO_8(int size) {
+            super(new Memory((long)size));
+        }
+    }
+
+    /**
+     * The PRINTER_INFO_9 structure specifies the per-user default printer settings.
+     */
+    @FieldOrder({"pDevMode"})
+    public static class PRINTER_INFO_9 extends Structure {
+        public DEVMODE pDevMode;
+
+        public PRINTER_INFO_9() {}
+
+        public PRINTER_INFO_9(int size) {
+            super(new Memory((long)size));
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinspoolUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinspoolUtil.java
@@ -37,92 +37,46 @@ import com.sun.jna.ptr.IntByReference;
  * Winspool Utility API.
  *
  * @author dblock[at]dblock.org, Ivan Ridao Freitas, Padrus, Artem Vozhdayenko
+ * @author Tres Finocchiaro, tres.finocchiaro@gmail.com
  */
 public abstract class WinspoolUtil {
 
-    public static PRINTER_INFO_1[] getPrinterInfo1() {
-        IntByReference pcbNeeded = new IntByReference();
-        IntByReference pcReturned = new IntByReference();
-        Winspool.INSTANCE.EnumPrinters(Winspool.PRINTER_ENUM_LOCAL, null, 1,
-                null, 0, pcbNeeded, pcReturned);
-        if (pcbNeeded.getValue() <= 0) {
-            return new PRINTER_INFO_1[0];
-        }
-
-        PRINTER_INFO_1 pPrinterEnum = new PRINTER_INFO_1(pcbNeeded.getValue());
-        if (!Winspool.INSTANCE.EnumPrinters(Winspool.PRINTER_ENUM_LOCAL, null,
-                1, pPrinterEnum.getPointer(), pcbNeeded.getValue(), pcbNeeded,
-                pcReturned)) {
-            throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-        }
-
-        pPrinterEnum.read();
-
-        return (PRINTER_INFO_1[]) pPrinterEnum.toArray(pcReturned.getValue());
-    }
-
-    public static PRINTER_INFO_2[] getPrinterInfo2() {
-        return getPrinterInfo2(Winspool.PRINTER_ENUM_LOCAL);
-    }
-
     /**
-     * Returns printers that are physically attached to the local machine as
-     * well as remote printers to which it has a network connection.
+     * Helper for getting printer info struct by number, e.g. PRINTER_INFO_1 = 1, etc.
      */
-    public static PRINTER_INFO_2[] getAllPrinterInfo2() {
-        // When Name is NULL, setting Flags to PRINTER_ENUM_LOCAL | PRINTER_ENUM_CONNECTIONS
-        // enumerates printers that are installed on the local machine.
-        // These printers include those that are physically attached to the local machine
-        // as well as remote printers to which it has a network connection.
-        // See https://msdn.microsoft.com/en-us/library/windows/desktop/dd162692(v=vs.85).aspx
-        return getPrinterInfo2(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
-    }
-
-    private static PRINTER_INFO_2[] getPrinterInfo2(int flags) {
-        IntByReference pcbNeeded = new IntByReference();
-        IntByReference pcReturned = new IntByReference();
-        Winspool.INSTANCE.EnumPrinters(flags, null, 2, null, 0, pcbNeeded, pcReturned);
-        if (pcbNeeded.getValue() <= 0) {
-            return new PRINTER_INFO_2[0];
-        }
-
-        PRINTER_INFO_2 pPrinterEnum = new PRINTER_INFO_2(pcbNeeded.getValue());
-        if (!Winspool.INSTANCE.EnumPrinters(flags, null, 2, pPrinterEnum.getPointer(), pcbNeeded.getValue(), pcbNeeded,
-                pcReturned)) {
-            throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-        }
-
-        pPrinterEnum.read();
-        return (PRINTER_INFO_2[]) pPrinterEnum.toArray(pcReturned.getValue());
-    }
-
-    public static PRINTER_INFO_2 getPrinterInfo2(String printerName) {
+    static Structure getPrinterInfoByStruct(String printerName, int structType) {
         IntByReference pcbNeeded = new IntByReference();
         IntByReference pcReturned = new IntByReference();
         HANDLEByReference pHandle = new HANDLEByReference();
 
+        // Get printer handle
         if (!Winspool.INSTANCE.OpenPrinter(printerName, pHandle, null)) {
             throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
         }
 
         Win32Exception we = null;
-        PRINTER_INFO_2 pinfo2 = null;
+        Structure struct = null;
 
         try {
-            Winspool.INSTANCE.GetPrinter(pHandle.getValue(), 2, null, 0, pcbNeeded);
+            // First pass: Get page size
+            Winspool.INSTANCE.GetPrinter(pHandle.getValue(), structType, null, 0, pcbNeeded);
+
+            struct = initStructByType(structType, pcbNeeded.getValue());
             if (pcbNeeded.getValue() <= 0) {
-                return new PRINTER_INFO_2();
+                return struct;
             }
 
-            pinfo2 = new PRINTER_INFO_2(pcbNeeded.getValue());
-            if (!Winspool.INSTANCE.GetPrinter(pHandle.getValue(), 2, pinfo2.getPointer(), pcbNeeded.getValue(), pcReturned)) {
+            // Second pass: Get printer information
+            if (!Winspool.INSTANCE.GetPrinter(pHandle.getValue(), structType, struct.getPointer(), pcbNeeded.getValue(), pcReturned)) {
                 throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
             }
 
-            pinfo2.read();
-        } catch (Win32Exception e) {
+            struct.read();
+        }
+        catch(Win32Exception e) {
             we = e;
-        } finally {
+        }
+        finally {
             if (!Winspool.INSTANCE.ClosePrinter(pHandle.getValue())) {
                 Win32Exception ex = new Win32Exception(Kernel32.INSTANCE.GetLastError());
                 if (we != null) {
@@ -135,59 +89,307 @@ public abstract class WinspoolUtil {
             throw we;
         }
 
-        return pinfo2;
+        return struct;
     }
 
-    public static PRINTER_INFO_4[] getPrinterInfo4() {
+    /**
+     * Helper for getting array of printer info
+     * PRINTER_ENUM_LOCAL | PRINTER_ENUM_CONNECTIONS
+     */
+    static Structure[] getPrinterInfoByStruct(int flags, int structType) {
         IntByReference pcbNeeded = new IntByReference();
         IntByReference pcReturned = new IntByReference();
-        Winspool.INSTANCE.EnumPrinters(Winspool.PRINTER_ENUM_LOCAL, null, 4,
-                null, 0, pcbNeeded, pcReturned);
+        // When Name is NULL, setting Flags to PRINTER_ENUM_LOCAL | PRINTER_ENUM_CONNECTIONS
+        // enumerates printers that are installed on the local machine.
+        // These printers include those that are physically attached to the local machine
+        // as well as remote printers to which it has a network connection.
+        // See https://msdn.microsoft.com/en-us/library/windows/desktop/dd162692(v=vs.85).aspx
+        Winspool.INSTANCE.EnumPrinters(flags, null, structType, null, 0, pcbNeeded, pcReturned);
+        Structure struct = initStructByType(structType, pcbNeeded.getValue());
         if (pcbNeeded.getValue() <= 0) {
-            return new PRINTER_INFO_4[0];
+            return emptyStructArrayByType(structType);
         }
-
-        PRINTER_INFO_4 pPrinterEnum = new PRINTER_INFO_4(pcbNeeded.getValue());
-        if (!Winspool.INSTANCE.EnumPrinters(Winspool.PRINTER_ENUM_LOCAL, null,
-                4, pPrinterEnum.getPointer(), pcbNeeded.getValue(), pcbNeeded,
+        if (!Winspool.INSTANCE.EnumPrinters(flags, null, structType, struct.getPointer(), pcbNeeded.getValue(), pcbNeeded,
                 pcReturned)) {
             throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
         }
 
-        pPrinterEnum.read();
-
-        return (PRINTER_INFO_4[]) pPrinterEnum.toArray(pcReturned.getValue());
+        struct.read();
+        return struct.toArray(pcReturned.getValue());
     }
 
-    public static JOB_INFO_1[] getJobInfo1(HANDLEByReference phPrinter) {
-        IntByReference pcbNeeded = new IntByReference();
-        IntByReference pcReturned = new IntByReference();
-        Winspool.INSTANCE.EnumJobs(phPrinter.getValue(), 0, 255, 1, null, 0,
-                pcbNeeded, pcReturned);
-        if (pcbNeeded.getValue() <= 0) {
-            return new JOB_INFO_1[0];
+    private static Structure[] emptyStructArrayByType(int structType) {
+        switch(structType) {
+            case 1:
+                return new PRINTER_INFO_1[0];
+            case 2:
+                return new PRINTER_INFO_2[0];
+            case 3:
+                return new PRINTER_INFO_3[0];
+            case 4:
+                return new PRINTER_INFO_4[0];
+            case 5:
+                return new PRINTER_INFO_5[0];
+            case 6:
+                return new PRINTER_INFO_6[0];
+            case 7:
+                return new PRINTER_INFO_7[0];
+            case 8:
+                return new PRINTER_INFO_8[0];
+            case 9:
+                return new PRINTER_INFO_9[0];
+            default:
+                throw new UnsupportedOperationException("PRINTER_INFO_" + structType + " doesn't exist or has not been implemented");
         }
-
-        int lastError = ERROR_SUCCESS;
-        JOB_INFO_1 pJobEnum;
-        do {
-            pJobEnum = new JOB_INFO_1(pcbNeeded.getValue());
-            if (!Winspool.INSTANCE.EnumJobs(phPrinter.getValue(), 0, 255, 1,
-                    pJobEnum.getPointer(), pcbNeeded.getValue(), pcbNeeded,
-                    pcReturned)) {
-                lastError = Kernel32.INSTANCE.GetLastError();
-            }
-        } while (lastError == ERROR_INSUFFICIENT_BUFFER);
-        if (lastError != ERROR_SUCCESS) {
-            throw new Win32Exception(lastError);
-        }
-        if (pcReturned.getValue() <= 0) {
-            return new JOB_INFO_1[0];
-        }
-
-        pJobEnum.read();
-
-        return (JOB_INFO_1[]) pJobEnum.toArray(pcReturned.getValue());
     }
 
+    private static Structure initStructByType(int structType, int size) {
+        switch(structType) {
+            case 1:
+                return size <= 0 ? new PRINTER_INFO_1() : new PRINTER_INFO_1(size);
+            case 2:
+                return size <= 0 ? new PRINTER_INFO_2() : new PRINTER_INFO_2(size);
+            case 3:
+                return size <= 0 ? new PRINTER_INFO_3() : new PRINTER_INFO_3(size);
+            case 4:
+                return size <= 0 ? new PRINTER_INFO_4() : new PRINTER_INFO_4(size);
+            case 5:
+                return size <= 0 ? new PRINTER_INFO_5() : new PRINTER_INFO_5(size);
+            case 6:
+                return size <= 0 ? new PRINTER_INFO_6() : new PRINTER_INFO_6(size);
+            case 7:
+                return size <= 0 ? new PRINTER_INFO_7() : new PRINTER_INFO_7(size);
+            case 8:
+                return size <= 0 ? new PRINTER_INFO_8() : new PRINTER_INFO_8(size);
+            case 9:
+                return size <= 0 ? new PRINTER_INFO_9() : new PRINTER_INFO_9(size);
+            default:
+                throw new UnsupportedOperationException("PRINTER_INFO_" + structType + " doesn't exist or has not been implemented");
+        }
+    }
+
+    public static PRINTER_INFO_1[] getAllPrinterInfo1() {
+        return getPrinterInfo1(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_2[] getAllPrinterInfo2() {
+        return getPrinterInfo2(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_3[] getAllPrinterInfo3() {
+        return getPrinterInfo3(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_4[] getAllPrinterInfo4() {
+        return getPrinterInfo4(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_5[] getAllPrinterInfo5() {
+        return getPrinterInfo5(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_6[] getAllPrinterInfo6() {
+        return getPrinterInfo6(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_7[] getAllPrinterInfo7() {
+        return getPrinterInfo7(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_8[] getAllPrinterInfo8() {
+        return getPrinterInfo8(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    public static PRINTER_INFO_9[] getAllPrinterInfo9() {
+        return getPrinterInfo9(Winspool.PRINTER_ENUM_LOCAL | Winspool.PRINTER_ENUM_CONNECTIONS);
+    }
+
+    /**
+     * The PRINTER_INFO_1 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_1[] getPrinterInfo1() {
+        return getPrinterInfo1(Winspool.PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_1 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_1 getPrinterInfo1(String printerName) {
+        return (PRINTER_INFO_1)getPrinterInfoByStruct(printerName, 1);
+    }
+
+    /**
+     * The PRINTER_INFO_1 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_1[] getPrinterInfo1(int flags) {
+        return (PRINTER_INFO_1[])getPrinterInfoByStruct(flags, 1);
+    }
+
+    /**
+     * The PRINTER_INFO_2 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_2 getPrinterInfo2(String printerName) {
+        return (PRINTER_INFO_2)getPrinterInfoByStruct(printerName, 2);
+    }
+
+    /**
+     * The PRINTER_INFO_2 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_2[] getPrinterInfo2(int flags) {
+        return (PRINTER_INFO_2[])getPrinterInfoByStruct(flags, 2);
+    }
+
+    /**
+     * The PRINTER_INFO_2 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_2[] getPrinterInfo2() {
+        return getPrinterInfo2(Winspool.PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_3 structure specifies printer security information.
+     */
+    public static PRINTER_INFO_3 getPrinterInfo3(String printerName) {
+        return (PRINTER_INFO_3)getPrinterInfoByStruct(printerName, 3);
+    }
+
+    /**
+     * The PRINTER_INFO_3 structure specifies printer security information.
+     */
+    public static PRINTER_INFO_3[] getPrinterInfo3(int flags) {
+        return (PRINTER_INFO_3[])getPrinterInfoByStruct(flags, 3);
+    }
+
+    /**
+     * The PRINTER_INFO_3 structure specifies printer security information.
+     */
+    public static PRINTER_INFO_3[] getPrinterInfo3() {
+        return getPrinterInfo3(Winspool.PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_4 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_4 getPrinterInfo4(String printerName) {
+        return (PRINTER_INFO_4)getPrinterInfoByStruct(printerName, 4);
+    }
+
+    /**
+     * The PRINTER_INFO_4 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_4[] getPrinterInfo4(int flags) {
+        return (PRINTER_INFO_4[])getPrinterInfoByStruct(flags, 4);
+    }
+
+    /**
+     * The PRINTER_INFO_4 structure specifies general printer information.
+     */
+    public static PRINTER_INFO_4[] getPrinterInfo4() {
+        return getPrinterInfo4(PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_5 structure specifies detailed printer information.
+     */
+    public static PRINTER_INFO_5 getPrinterInfo5(String printerName) {
+        return (PRINTER_INFO_5)getPrinterInfoByStruct(printerName, 5);
+    }
+
+    /**
+     * The PRINTER_INFO_5 structure specifies detailed printer information.
+     */
+    public static PRINTER_INFO_5[] getPrinterInfo5(int flags) {
+        return (PRINTER_INFO_5[])getPrinterInfoByStruct(flags, 5);
+    }
+
+    /**
+     * The PRINTER_INFO_5 structure specifies detailed printer information.
+     */
+    public static PRINTER_INFO_5[] getPrinterInfo5() {
+        return getPrinterInfo5(PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_6 specifies the status value of a printer.
+     */
+    public static PRINTER_INFO_6 getPrinterInfo6(String printerName) {
+        return (PRINTER_INFO_6)getPrinterInfoByStruct(printerName, 6);
+    }
+
+    /**
+     * The PRINTER_INFO_6 specifies the status value of a printer.
+     */
+    public static PRINTER_INFO_6[] getPrinterInfo6(int flags) {
+        return (PRINTER_INFO_6[])getPrinterInfoByStruct(flags, 6);
+    }
+
+    /**
+     * The PRINTER_INFO_6 specifies the status value of a printer.
+     */
+    public static PRINTER_INFO_6[] getPrinterInfo6() {
+        return getPrinterInfo6(PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_7 structure specifies directory services printer information.
+     */
+    public static PRINTER_INFO_7 getPrinterInfo7(String printerName) {
+        return (PRINTER_INFO_7)getPrinterInfoByStruct(printerName, 7);
+    }
+
+    /**
+     * The PRINTER_INFO_7 structure specifies directory services printer information.
+     */
+    public static PRINTER_INFO_7[] getPrinterInfo7(int flags) {
+        return (PRINTER_INFO_7[])getPrinterInfoByStruct(flags, 7);
+    }
+
+    /**
+     * The PRINTER_INFO_7 structure specifies directory services printer information.
+     */
+    public static PRINTER_INFO_7[] getPrinterInfo7() {
+        return getPrinterInfo7(PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_8 structure specifies the global default printer settings.
+     */
+    public static PRINTER_INFO_8 getPrinterInfo8(String printerName) {
+        return (PRINTER_INFO_8)getPrinterInfoByStruct(printerName, 8);
+    }
+
+    /**
+     * The PRINTER_INFO_8 structure specifies the global default printer settings.
+     */
+    public static PRINTER_INFO_8[] getPrinterInfo8(int flags) {
+        return (PRINTER_INFO_8[])getPrinterInfoByStruct(flags, 8);
+    }
+
+    /**
+     * The PRINTER_INFO_8 structure specifies the global default printer settings.
+     */
+    public static PRINTER_INFO_8[] getPrinterInfo8() {
+        return getPrinterInfo8(PRINTER_ENUM_LOCAL);
+    }
+
+    /**
+     * The PRINTER_INFO_9 Structure specifies the per-user default printer settings.\
+     */
+    public static PRINTER_INFO_9 getPrinterInfo9(String printerName) {
+        return (PRINTER_INFO_9)getPrinterInfoByStruct(printerName, 9);
+    }
+
+    /**
+     * The PRINTER_INFO_9 Structure specifies the per-user default printer settings.\
+     */
+    public static PRINTER_INFO_9[] getPrinterInfo9(int flags) {
+        return (PRINTER_INFO_9[])getPrinterInfoByStruct(flags, 9);
+    }
+
+    /**
+     * The PRINTER_INFO_9 Structure specifies the per-user default printer settings.\
+     */
+    public static PRINTER_INFO_9[] getPrinterInfo9() {
+        return getPrinterInfo9(PRINTER_ENUM_LOCAL);
+    }
 }


### PR DESCRIPTION
Adds to Winspool.java:
* Structs: `PRINTER_INFO_3`, `PRINTER_INFO_5`, `PRINTER_INFO_7`, `PRINTER_INFO_8`, `PRINTER_INFO_9`

Adds to WinGDI.java:
* Const: `CCHFORMNAME=32`
* Structs: `DEVMODE` (see comments)

TODO:
* [ ] Compose newly added `PRINTER_INFO_` Javadocs in similar style to existing class
* [ ] Determine naming, e.g. `DEVMODE` versus `DEVMODEA`
* [ ] Determine if struct types should use native types (e.g. `DWORD`) or Java types (e.g. 'int`)
* [ ] Fix any build errors as a result of copy/paste :)
* [ ] Update changelog
