### PR TITLE
Handle arrays in structures with differing size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Features
 
 Bug Fixes
 ---------
+* [#1438](https://github.com/java-native-access/jna/pull/1438): Handle arrays in structures with differing size - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Important Changes
 -----------------

--- a/native/testlib.c
+++ b/native/testlib.c
@@ -1058,6 +1058,26 @@ returnClass(JNIEnv *env, jobject arg) {
   return (*env)->GetObjectClass(env, arg);
 }
 
+typedef struct{
+  double t1[3];
+  double t2[4];
+  double t3[5];
+} DemoStructureDifferentArrayLengths;
+
+EXPORT DemoStructureDifferentArrayLengths
+returnLastElementOfComponentsDSDAL(DemoStructureDifferentArrayLengths ts, int debug) {
+  DemoStructureDifferentArrayLengths result;
+  result.t1[2] = ts.t1[2];
+  result.t2[3] = ts.t2[3];
+  result.t3[4] = ts.t3[4];
+  if(debug) {
+    printf("DemoStructureDifferentArrayLengths.t1[2]: %1.3f\n", result.t1[2]);
+    printf("DemoStructureDifferentArrayLengths.t2[3]: %1.3f\n", result.t2[3]);
+    printf("DemoStructureDifferentArrayLengths.t3[4]: %1.3f\n", result.t3[4]);
+  }
+  return result;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/com/sun/jna/DirectStructureByValueTest.java
+++ b/test/com/sun/jna/DirectStructureByValueTest.java
@@ -36,6 +36,7 @@ public class DirectStructureByValueTest extends StructureByValueTest {
         public native int testStructureByValueArgument32(ByValue32 arg);
         public native long testStructureByValueArgument64(ByValue64 arg);
         public native long testStructureByValueArgument128(ByValue128 arg);
+        public native DemoStructureDifferentArrayLengths.ByValue returnLastElementOfComponentsDSDAL(DemoStructureDifferentArrayLengths.ByValue arg, int debug);
         static {
             Native.register("testlib");
         }

--- a/test/com/sun/jna/StructureByValueTest.java
+++ b/test/com/sun/jna/StructureByValueTest.java
@@ -43,6 +43,17 @@ public class StructureByValueTest extends TestCase {
             return FIELDS;
         }
     }
+
+    @Structure.FieldOrder({"t1", "t2", "t3"})
+    public static class DemoStructureDifferentArrayLengths extends Structure {
+
+        public static class ByValue extends DemoStructureDifferentArrayLengths implements Structure.ByValue {
+        }
+        public double t1[] = new double[3];
+        public double t2[] = new double[4];
+        public double t3[] = new double[5];
+    }
+
     public void testNativeMappedInByValue() {
         new TestNativeMappedInStructure.ByValue();
     }
@@ -53,6 +64,7 @@ public class StructureByValueTest extends TestCase {
         int testStructureByValueArgument32(ByValue32 arg);
         long testStructureByValueArgument64(ByValue64 arg);
         long testStructureByValueArgument128(ByValue128 arg);
+        DemoStructureDifferentArrayLengths.ByValue returnLastElementOfComponentsDSDAL(DemoStructureDifferentArrayLengths.ByValue ts, int debug);
     }
 
     TestLibrary lib;
@@ -144,5 +156,23 @@ public class StructureByValueTest extends TestCase {
         data.data1 = DATA;
         assertEquals("Failed to pass 128-bit struct by value",
                      2*DATA, lib.testStructureByValueArgument128(data));
+    }
+
+    public void testStructureDifferentArrayLengths() {
+        // returnLastElementOfComponentsDSDAL copies the last element of the
+        // components of t1, t2 and t3, which are double arrays with lengths
+        // 3, 4 and 5. In the observed case JNA created ffi_types for primitive
+        // arrays with wrong element count (the first array definition was used)
+
+        DemoStructureDifferentArrayLengths.ByValue ts = new DemoStructureDifferentArrayLengths.ByValue();
+        ts.t1 = new double[]{1, 1, 1};
+        ts.t2 = new double[]{2, 2, 2, 2};
+        ts.t3 = new double[]{3, 3, 3, 3, 3};
+
+        DemoStructureDifferentArrayLengths.ByValue result = lib.returnLastElementOfComponentsDSDAL(ts, 0);
+
+        assertEquals(1.0d, result.t1[2], 0.1d);
+        assertEquals(2.0d, result.t2[3], 0.1d);
+        assertEquals(3.0d, result.t3[4], 0.1d);
     }
 }


### PR DESCRIPTION
libffi uses ffi_type structures to describe arrays and structures passed
to native. JNA builds these structures and caches them using the
associated classes as keys. For arrays this leads to the situation where
only a single ffi_type was stored for all sizes of the same base type.
This in turn causes wrong behavior in libffi.