### PR TITLE
Fix #1460 - conversion of win32 variant dates within DST offset windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Features
 Bug Fixes
 ---------
 * [#1452](https://github.com/java-native-access/jna/issues/1452): Fix memory allocation/handling for error message generation in native library code (`dispatch.c`) - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1460](https://github.com/java-native-access/jna/issues/1460): Fix win32 variant date conversion in DST offest window and with millisecond values - [@eranl](https://github.com/eranl).
 
 Release 5.12.1
 ==============

--- a/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OaIdl.java
@@ -22,7 +22,7 @@
  */
 package com.sun.jna.platform.win32;
 
-import java.util.List;
+import java.util.Calendar;
 
 import com.sun.jna.IntegerType;
 import com.sun.jna.Memory;
@@ -76,6 +76,7 @@ import static com.sun.jna.platform.win32.Variant.VT_UINT;
 import static com.sun.jna.platform.win32.Variant.VT_UNKNOWN;
 import static com.sun.jna.platform.win32.Variant.VT_VARIANT;
 import com.sun.jna.ptr.ByReference;
+import com.sun.jna.ptr.DoubleByReference;
 import com.sun.jna.ptr.PointerByReference;
 import java.io.Closeable;
 import java.util.Date;
@@ -223,7 +224,7 @@ public interface OaIdl {
 
     @FieldOrder({"date"})
     public static class DATE extends Structure {
-        private final static long MICRO_SECONDS_PER_DAY = 24L * 60L * 60L * 1000L;
+        private static final double MILLISECONDS_PER_DAY = 24L * 60L * 60L * 1000L;
 
         public static class ByReference extends DATE implements
                 Structure.ByReference {
@@ -244,38 +245,28 @@ public interface OaIdl {
         }
 
         public Date getAsJavaDate() {
-            long days = (((long) this.date) * MICRO_SECONDS_PER_DAY) + DATE_OFFSET;
-            double timePart = 24 * Math.abs(this.date - ((long) this.date));
-            int hours = (int) timePart;
-            timePart = 60 * (timePart - ((int) timePart));
-            int minutes = (int) timePart;
-            timePart = 60 * (timePart - ((int) timePart));
-            int seconds = (int) timePart;
-            timePart = 1000 * (timePart - ((int) timePart));
-            int milliseconds = (int) timePart;
+            WinBase.SYSTEMTIME systemtime = new WinBase.SYSTEMTIME();
+            OleAuto.INSTANCE.VariantTimeToSystemTime(date, systemtime);
+            Calendar calendar = systemtime.toCalendar();
 
-            Date baseDate = new Date(days);
-            baseDate.setHours(hours);
-            baseDate.setMinutes(minutes);
-            baseDate.setSeconds(seconds);
-            baseDate.setTime(baseDate.getTime() + milliseconds);
-            return baseDate;
+            // Fix milliseconds, as VariantTimeToSystemTime rounds them off
+            int millis = (int) ((long) (Math.abs(date) * MILLISECONDS_PER_DAY + 0.5) % 1000L);
+            if (date > 0 && millis > 500 || date < 0 && millis > 499) {
+                millis -= 1000;
+            }
+            calendar.set(Calendar.MILLISECOND, millis);
+            return calendar.getTime();
         }
 
         public void setFromJavaDate(Date javaDate) {
-            double msSinceOrigin = javaDate.getTime() - DATE_OFFSET;
-            double daysAsFract = msSinceOrigin / MICRO_SECONDS_PER_DAY;
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(javaDate);
+            DoubleByReference pvtime = new DoubleByReference();
+            OleAuto.INSTANCE.SystemTimeToVariantTime(new WinBase.SYSTEMTIME(calendar), pvtime);
+            double value = pvtime.getValue();
 
-            Date dayDate = new Date(javaDate.getTime());
-            dayDate.setHours(0);
-            dayDate.setMinutes(0);
-            dayDate.setSeconds(0);
-            dayDate.setTime(dayDate.getTime() / 1000 * 1000); // Clear milliseconds
-
-            double integralPart = Math.floor(daysAsFract);
-            double fractionalPart = Math.signum(daysAsFract) * ((javaDate.getTime() - dayDate.getTime()) / (24d * 60 * 60 * 1000));
-
-            this.date = integralPart + fractionalPart;
+            // Add milliseconds, as SystemTimeToVariantTime truncates them
+            date = value + Math.signum(value) * calendar.get(Calendar.MILLISECOND) / MILLISECONDS_PER_DAY;
         }
     }
 

--- a/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/OleAuto.java
@@ -24,8 +24,6 @@
 package com.sun.jna.platform.win32;
 
 import com.sun.jna.Memory;
-import java.util.List;
-
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -926,4 +924,15 @@ public interface OleAuto extends StdCallLibrary {
      * @return The function returns TRUE on success and FALSE otherwise.
      */
     int SystemTimeToVariantTime(SYSTEMTIME lpSystemTime, DoubleByReference pvtime);
+
+    /**
+     * Converts a variant representation of time to a system time.
+     *
+     * @param vtime [in] The variant time.
+     *
+     * @param lpSystemTime [out] The system time.
+     *
+     * @return The function returns TRUE on success and FALSE otherwise.
+     */
+    int VariantTimeToSystemTime(double vtime, SYSTEMTIME lpSystemTime);
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/COM/util/ConvertTest.java
@@ -40,7 +40,11 @@ import com.sun.jna.platform.win32.WinDef.BYTE;
 import com.sun.jna.platform.win32.WinDef.CHAR;
 import com.sun.jna.platform.win32.WinDef.LONG;
 import com.sun.jna.platform.win32.WinDef.SHORT;
+
+import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
+
 import org.junit.AfterClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -267,7 +271,50 @@ public class ConvertTest {
 
     @Test
     public void testConvertDate() {
-        Date testDate = new Date(2015 - 1900, 1, 1, 9, 0, 0);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 9, 0, 0));
+    }
+
+    @Test
+    public void testConvertDstOffsetTime() {
+        TimeZone timeZone = TimeZone.getDefault();
+        try {
+            // Use a timezone with a DST offset
+            TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+            // Use a date in the DST period, and a time in the DST offset window
+            testConvertDate(new Date(2015 - 1900, 8 - 1, 1, 0, 30, 0));
+        } finally {
+            TimeZone.setDefault(timeZone);
+        }
+    }
+
+    @Test
+    public void testConvertMillisecondTime() {
+        testConvertDate(new Date(2015 - 1900, 1, 1, 0, 0, 0), 1);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 0, 0, 0), 499);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 0, 0, 0), 500);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 0, 0, 0), 999);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 0, 0, 0), 1);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 0, 0, 0), 499);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 0, 0, 0), 500);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 0, 0, 0), 999);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 23, 59, 59), 1);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 23, 59, 59), 499);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 23, 59, 59), 500);
+        testConvertDate(new Date(2015 - 1900, 1, 1, 23, 59, 59), 999);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 23, 59, 59), 1);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 23, 59, 59), 499);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 23, 59, 59), 500);
+        testConvertDate(new Date(1815 - 1900, 1, 1, 23, 59, 59), 999);
+    }
+
+    private static void testConvertDate(Date date, int milliseconds) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.set(Calendar.MILLISECOND, milliseconds);
+        testConvertDate(calendar.getTime());
+    }
+
+    private static void testConvertDate(Date testDate) {
         VARIANT resultDate = Convert.toVariant(testDate);
         DATE testDATE = new DATE(testDate);
         VARIANT resultDATE = Convert.toVariant(testDATE);


### PR DESCRIPTION
The main goal here is to fix #1460, which I found can be done in a straightforward way by using: 
- java.util.Calendar for converting between UTC and local time, and
- win32 APIs for converting between local time and variant date.

While testing the fix, I realized that dates with non-zero millisecond values were not converted correctly by the win32 APIs, so I added some correction logic for preserving millisecond values. BTW, I found that the existing implementation didn't handle some millisecond values correctly either.

Overall, this is relatively simple logic, avoiding the reconstruction of complex calculations provided by the above APIs.

Added OleAuto.VariantTimeToSystemTime and a test for it.
Added tests for DST offset window that fails with existing logic, and tests for millisecond dates, some of which fail with existing logic.

Note: OaIdl.DATE_OFFSET is not used anymore, but I left it in since it's declared public.
