### PR TITLE
Fix incorrect bitmask in Pointer#createConstant(int)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Bug Fixes
 ---------
 * [#1452](https://github.com/java-native-access/jna/issues/1452): Fix memory allocation/handling for error message generation in native library code (`dispatch.c`) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1460](https://github.com/java-native-access/jna/issues/1460): Fix win32 variant date conversion in DST offest window and with millisecond values - [@eranl](https://github.com/eranl).
+* [#1472](https://github.com/java-native-access/jna/issues/1472): Fix incorrect bitmask in `c.s.j.Pointer#createConstant(int)` - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.12.1
 ==============

--- a/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/COM/util/ProxyObject.java
@@ -189,7 +189,7 @@ public class ProxyObject implements InvocationHandler, com.sun.jna.platform.win3
     @Override
     public int hashCode() {
         long id = this.getUnknownId();
-        return (int) ((id >>> 32) & 0xFFFFFFFF) + (int) (id & 0xFFFFFFFF);
+        return (int) ((id >>> 32) + (id & 0xFFFFFFFFL));
     }
 
     @Override

--- a/src/com/sun/jna/Pointer.java
+++ b/src/com/sun/jna/Pointer.java
@@ -60,7 +60,7 @@ public class Pointer {
         systems.
      */
     public static final Pointer createConstant(int peer) {
-        return new Opaque((long)peer & 0xFFFFFFFF);
+        return new Opaque(peer & 0xFFFFFFFFL);
     }
 
     /** Pointer value of the real native pointer. Use long to be 64-bit safe.
@@ -112,7 +112,7 @@ public class Pointer {
 
     @Override
     public int hashCode() {
-        return (int)((peer >>> 32) + (peer & 0xFFFFFFFF));
+        return (int) ((peer >>> 32) + (peer & 0xFFFFFFFFL));
     }
 
 

--- a/test/com/sun/jna/PointerTest.java
+++ b/test/com/sun/jna/PointerTest.java
@@ -25,10 +25,11 @@
 
 package com.sun.jna;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+
 import junit.framework.TestCase;
 
 
@@ -233,6 +234,11 @@ public class PointerTest extends TestCase {
                 fail("Need to fix test of method '" + m.getName() + "(" + Arrays.asList(argTypes) + ")'");
             }
         }
+    }
+
+    public void testOpaquePointerNoHighBits() throws Exception {
+        Pointer p = Pointer.createConstant(0x80000000);
+        assertEquals("createConstant(int) should avoid setting any high bits", 0, Pointer.nativeValue(p) >>> 32);
     }
 
     public static void main(String[] args) {

--- a/test/com/sun/jna/PointerTest.java
+++ b/test/com/sun/jna/PointerTest.java
@@ -175,10 +175,13 @@ public class PointerTest extends TestCase {
 
     public void testCreateConstantPointer() {
         Pointer p = Pointer.createConstant(0xFFFFFFFF);
-        assertEquals("Wrong peer value", p.peer, 0xFFFFFFFF);
+        assertEquals("Wrong peer value", p.peer, 0xFFFFFFFFL);
 
-        p = Pointer.createConstant(-1);
+        p = Pointer.createConstant(-1L);
         assertEquals("Wrong peer value", p.peer, -1);
+
+        p = Pointer.createConstant(0x80000000);
+        assertEquals("createConstant(int) should avoid setting any high bits", 0, Pointer.nativeValue(p) >>> 32);
     }
 
     public void testReadStringArrayNULLElement() {
@@ -234,11 +237,6 @@ public class PointerTest extends TestCase {
                 fail("Need to fix test of method '" + m.getName() + "(" + Arrays.asList(argTypes) + ")'");
             }
         }
-    }
-
-    public void testOpaquePointerNoHighBits() throws Exception {
-        Pointer p = Pointer.createConstant(0x80000000);
-        assertEquals("createConstant(int) should avoid setting any high bits", 0, Pointer.nativeValue(p) >>> 32);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Fixes #1470 

`Pointer#hashCode`: defined the mask properly to show author intent, although one could just as easily add without masking because of the eventual downcast.

`ProxyObject#hashCode`: this one had an additional useless mask of a number already shifted right 32 bits and guaranteed to have 0's in the high bits. And in addition to the useless mask of the low bits  it then gets downcast to int and then widened again for the addition.  Simplified it to match the Pointer version.

`Pointer#createConstant(int)` states in its javadocs that it is supposed to avoid setting the high bits.  However, with the improper masking it ends up setting all the high bits for any negative ints.