### PR TITLE
Provide multilingual support of Kernel32Util.formatMessage()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 * [#1459](https://github.com/java-native-access/jna/pull/1459): Add `VirtualLock` and `VirtualUnlock` in `c.s.j.p.win32.Kernel32` - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1471](https://github.com/java-native-access/jna/pull/1471): Add `c.s.j.p.win32.Advapi32Util#isCurrentProcessElevated` and associated Types - [@dbwiddis](https://github.com/dbwiddis).
 * [#1474](https://github.com/java-native-access/jna/pull/1474): Add `c.s.j.p.win32.WbemCli#IWbemClassObject.IWbemQualifierSet`, `IWbemServices.GetObject`, `IWbemContext.SetValue` and associated methods - [@rchateauneu](https://github.com/rchateauneu).
+* [#1482](https://github.com/java-native-access/jna/pull/1482): Add multilingual support of `Kernel32Util.formatMessage` - [@overpathz](https://github.com/overpathz).
 
 Bug Fixes
 ---------

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
@@ -159,6 +159,18 @@ public class Kernel32UtilTest extends TestCase {
         }
     }
 
+    public void testFormatMessageFromErrorCodeWithNonEnglishLocale() {
+        int errorCode = W32Errors.S_OK.intValue();
+        String formattedMsgInDefaultLocale = Kernel32Util.formatMessage(errorCode);
+        // primary and sub languages id's of the english locale, because it is present on most machines
+        String formattedMsgInEnglishLocale = Kernel32Util.formatMessage(errorCode, 9, 1);
+        if(AbstractWin32TestSupport.isEnglishLocale) {
+            assertEquals(formattedMsgInDefaultLocale, formattedMsgInEnglishLocale);
+        } else {
+            assertNotSame(formattedMsgInDefaultLocale, formattedMsgInEnglishLocale);
+        }
+    }
+
     public void testGetTempPath() {
         assertTrue(Kernel32Util.getTempPath().length() > 0);
     }


### PR DESCRIPTION
In the current code, the formatMessage method returns the string in the locale according to the flow specified in the documentation if zero was passed to the dwLanguageId parameter.

This value was hardcoded to zero.

There may be a problem that the end user may have a different locale and when logging an error, we receive an error message not in English, which makes it difficult for developers to understand and solve user problems.

If necessary, the PR can be extended by overloading other methods with parameters for receiving language identifiers.

Implements #1480 