### PR TITLE
NPE in `NativeLibrary` when unpacking from classpath is disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Bug Fixes
 * [#1452](https://github.com/java-native-access/jna/issues/1452): Fix memory allocation/handling for error message generation in native library code (`dispatch.c`) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1460](https://github.com/java-native-access/jna/issues/1460): Fix win32 variant date conversion in DST offest window and with millisecond values - [@eranl](https://github.com/eranl).
 * [#1472](https://github.com/java-native-access/jna/issues/1472): Fix incorrect bitmask in `c.s.j.Pointer#createConstant(int)` - [@dbwiddis](https://github.com/dbwiddis).
+* [#1481](https://github.com/java-native-access/jna/issues/1481): Fix NPE in NativeLibrary when unpacking from classpath is disabled - [@trespasserw](https://github.com/trespasserw).
 
 Release 5.12.1
 ==============

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -279,13 +279,15 @@ public class NativeLibrary implements Closeable {
             if (handle == 0) {
                 try {
                     File embedded = Native.extractFromResourcePath(libraryName, (ClassLoader)options.get(Library.OPTION_CLASSLOADER));
-                    try {
-                        handle = Native.open(embedded.getAbsolutePath(), openFlags);
-                        libraryPath = embedded.getAbsolutePath();
-                    } finally {
-                        // Don't leave temporary files around
-                        if (Native.isUnpacked(embedded)) {
-                            Native.deleteLibrary(embedded);
+                    if (embedded != null) {
+                        try {
+                            handle = Native.open(embedded.getAbsolutePath(), openFlags);
+                            libraryPath = embedded.getAbsolutePath();
+                        } finally {
+                            // Don't leave temporary files around
+                            if (Native.isUnpacked(embedded)) {
+                                Native.deleteLibrary(embedded);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
When a native library is packed into a .jar, but unpacking is disabled (`jna.nounpack = true`), `Native#extractFromResourcePath` returns `null`.