### PR TITLE
Add 'uses' information to OSGI metadata in MANIFEST.MF

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -470,7 +470,11 @@
               <attribute name="Bundle-RequiredExecutionEnvironment" value="JavaSE-1.6"/>
               <attribute name="Bundle-Vendor" value="${vendor}"/>
               <attribute name="Bundle-ActivationPolicy" value="lazy"/>
-              <attribute name="Export-Package" value="com.sun.jna;version=${jna.major}.${jna.minor}.${jna.revision}, com.sun.jna.ptr;version=${jna.major}.${jna.minor}.${jna.revision}, com.sun.jna.win32;version=${jna.major}.${jna.minor}.${jna.revision}"/>
+              <attribute name="Export-Package" value="
+com.sun.jna;version=&quot;${osgi.version}&quot;,
+com.sun.jna.ptr;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna&quot;,
+com.sun.jna.win32;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna&quot;
+"/>
               <!-- Note that no terminal "*" is included in this list,
                  which will force failure on unsupported platforms.
               -->

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -147,20 +147,20 @@
                 <attribute name="Require-Bundle" value="com.sun.jna;bundle-version=&quot;${osgi.version}&quot;"/>
                 <attribute name="Export-Package"
                            value="
-com.sun.jna.platform;version=${osgi.version},
-com.sun.jna.platform.dnd;version=${osgi.version},
-com.sun.jna.platform.linux;version=${osgi.version},
-com.sun.jna.platform.mac;version=${osgi.version},
-com.sun.jna.platform.unix;version=${osgi.version},
-com.sun.jna.platform.unix.aix;version=${osgi.version},
-com.sun.jna.platform.unix.solaris;version=${osgi.version},
-com.sun.jna.platform.win32;version=${osgi.version},
-com.sun.jna.platform.win32.COM;version=${osgi.version},
-com.sun.jna.platform.win32.COM.tlb;version=${osgi.version},
-com.sun.jna.platform.win32.COM.tlb.imp;version=${osgi.version},
-com.sun.jna.platform.win32.COM.util;version=${osgi.version},
-com.sun.jna.platform.win32.COM.util.annotation;version=${osgi.version},
-com.sun.jna.platform.wince;version=${osgi.version}
+com.sun.jna.platform;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.platform.win32&quot;,
+com.sun.jna.platform.dnd;version=&quot;${osgi.version}&quot;,
+com.sun.jna.platform.linux;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.platform.unix&quot;,
+com.sun.jna.platform.mac;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.platform,com.sun.jna.platform.unix,com.sun.jna.ptr&quot;,
+com.sun.jna.platform.unix;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.ptr&quot;,
+com.sun.jna.platform.unix.aix;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna&quot;,
+com.sun.jna.platform.unix.solaris;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.ptr&quot;,
+com.sun.jna.platform.win32;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.platform,com.sun.jna.platform.win32.COM,com.sun.jna.ptr,com.sun.jna.win32&quot;,
+com.sun.jna.platform.win32.COM;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.platform.win32,com.sun.jna.platform.win32.COM.util,com.sun.jna.ptr,com.sun.jna.win32&quot;,
+com.sun.jna.platform.win32.COM.tlb;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna.platform.win32.COM.tlb.imp&quot;,
+com.sun.jna.platform.win32.COM.tlb.imp;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna.platform.win32,com.sun.jna.platform.win32.COM&quot;,
+com.sun.jna.platform.win32.COM.util;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.platform.win32,com.sun.jna.platform.win32.COM,com.sun.jna.platform.win32.COM.util.annotation,com.sun.jna.ptr&quot;,
+com.sun.jna.platform.win32.COM.util.annotation;version=&quot;${osgi.version}&quot;,
+com.sun.jna.platform.wince;version=&quot;${osgi.version}&quot;;uses:=&quot;com.sun.jna,com.sun.jna.platform.win32&quot;
 "/>
             </manifest>
             <manifest file="@{target}" mode="update" if:true="@{module-info}">

--- a/create-export-package-metadata-pom.xml
+++ b/create-export-package-metadata-pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+  http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.java.dev.jna</groupId>
+  <artifactId>create-export-package-metadata</artifactId>
+  <version>1.0.0</version>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <sourceDirectory>${sourceDirectory}</sourceDirectory>
+    <outputDirectory>${outputDirectory}</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.8</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>${exportedPackages}</Export-Package>
+            <Import-Package>${importedPackages}</Import-Package>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/create-export-package-metadata.sh
+++ b/create-export-package-metadata.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set -e
+
+extract_export_package_value_for_buildxml() {
+  sed -z -E 's:\r?\n ::g' "$1" | grep '^Export-Package' | sed 's/^Export-Package: //' | sed 's/",/",\n/g' | sed 's/1\.0\.0/${osgi.version}/g' | sed 's/"/\&quot;/g'
+}
+
+rm -rf tmp
+mkdir tmp
+cp -r src tmp
+mvn -f create-export-package-metadata-pom.xml clean package -DsourceDirectory=tmp/src -DoutputDirectory=tmp/target -DexportedPackages=com.sun.jna,com.sun.jna.ptr,com.sun.jna.win32
+cp -r contrib/platform/src tmp
+mvn -f create-export-package-metadata-pom.xml clean package -DsourceDirectory=tmp/src -DoutputDirectory=tmp/target-platform -DexportedPackages=com.sun.jna.platform,com.sun.jna.platform.dnd,com.sun.jna.platform.linux,com.sun.jna.platform.mac,com.sun.jna.platform.unix,com.sun.jna.platform.unix.aix,com.sun.jna.platform.unix.solaris,com.sun.jna.platform.win32,com.sun.jna.platform.win32.COM,com.sun.jna.platform.win32.COM.tlb,com.sun.jna.platform.win32.COM.tlb.imp,com.sun.jna.platform.win32.COM.util,com.sun.jna.platform.win32.COM.util.annotation,com.sun.jna.platform.wince -DimportedPackages=com.sun.jna,com.sun.jna.ptr,com.sun.jna.win32
+
+echo 'build.xml: Export-Package:'
+echo
+extract_export_package_value_for_buildxml tmp/target/META-INF/MANIFEST.MF
+echo
+echo
+
+echo 'contrib/platform/build.xml: Export-Package:'
+echo
+extract_export_package_value_for_buildxml tmp/target-platform/META-INF/MANIFEST.MF
+echo
+echo
+
+rm -r tmp


### PR DESCRIPTION
When multiple versions of JNA are present in a single OSGI environment, it can happen that OSGI computes an incorrect dependency chain, which can lead to exceptions like the following:

This can be addressed by enriching the Export-Package metadata with ;uses="..." information [1].

Fixes #1487.

[1] https://spring.io/blog/2008/10/20/understanding-the-osgi-uses-directive/