### PR TITLE
try to load library from /usr/lib/jni if property jna.boot.library.path is not set

### DIFF
--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -952,9 +952,6 @@ public final class Native implements Version {
 
         String libName = System.getProperty("jna.boot.library.name", "jnidispatch");
         String bootPath = System.getProperty("jna.boot.library.path");
-        if (bootPath == null) {
-            bootPath = "/usr/lib/jni" + File.pathSeparator + "/usr/lib/" + Platform.getMultiArchPath() + "/jni";
-        }
         if (bootPath != null) {
             // String.split not available in 1.4
             StringTokenizer dirs = new StringTokenizer(bootPath, File.pathSeparator);

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -952,6 +952,9 @@ public final class Native implements Version {
 
         String libName = System.getProperty("jna.boot.library.name", "jnidispatch");
         String bootPath = System.getProperty("jna.boot.library.path");
+        if (bootPath == null) {
+            bootPath = "/usr/lib/jni" + File.pathSeparator + "/usr/lib/" + Platform.getMultiArchPath() + "/jni";
+        }
         if (bootPath != null) {
             // String.split not available in 1.4
             StringTokenizer dirs = new StringTokenizer(bootPath, File.pathSeparator);

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -944,7 +944,7 @@ public class NativeLibrary implements Closeable {
             // so for platforms which are not multi-arch
             // this should continue to work.
             if (Platform.isLinux() || Platform.iskFreeBSD() || Platform.isGNU()) {
-                String multiArchPath = getMultiArchPath();
+                String multiArchPath = Platform.getMultiArchPath();
 
                 // Assemble path with all possible options
                 paths = new String[] {
@@ -988,30 +988,6 @@ public class NativeLibrary implements Closeable {
             }
         }
         librarySearchPath.addAll(initPaths("jna.platform.library.path"));
-    }
-
-    private static String getMultiArchPath() {
-        String cpu = Platform.ARCH;
-        String kernel = Platform.iskFreeBSD()
-            ? "-kfreebsd"
-            : (Platform.isGNU() ? "" : "-linux");
-        String libc = "-gnu";
-
-        if (Platform.isIntel()) {
-            cpu = (Platform.is64Bit() ? "x86_64" : "i386");
-        }
-        else if (Platform.isPPC()) {
-            cpu = (Platform.is64Bit() ? "powerpc64" : "powerpc");
-        }
-        else if (Platform.isARM()) {
-            cpu = "arm";
-            libc = "-gnueabi";
-        }
-        else if (Platform.ARCH.equals("mips64el")) {
-            libc = "-gnuabi64";
-        }
-
-        return cpu + kernel + libc;
     }
 
     /**

--- a/src/com/sun/jna/Platform.java
+++ b/src/com/sun/jna/Platform.java
@@ -262,8 +262,12 @@ public final class Platform {
             arch = "ppc64le";
         }
         // Map arm to armel if the binary is running as softfloat build
-        if("arm".equals(arch) && platform == Platform.LINUX && isSoftFloat()) {
-            arch = "armel";
+        if("arm".equals(arch) && platform == Platform.LINUX ) {
+            if(isSoftFloat()) {
+                arch = "armel";
+            } else if(!is64Bit()) {
+                arch = "armhf";
+            }
         }
 
         return arch;
@@ -351,5 +355,31 @@ public final class Platform {
                 break;
         }
         return osPrefix;
+    }
+
+    public static String getMultiArchPath() {
+        String cpu = ARCH;
+        String kernel = iskFreeBSD()
+            ? "-kfreebsd"
+            : (isGNU() ? "" : "-linux");
+        String libc = "-gnu";
+
+        if (isIntel()) {
+            cpu = (is64Bit() ? "x86_64" : "i386");
+        }
+        else if (isPPC()) {
+            cpu = cpu.replace("ppc", "powerpc");
+        }
+        else if (isARM()) {
+            cpu = (is64Bit() ? "aarch64" : "arm");
+            libc = is64Bit()
+                ? "-gnu"
+                : ("armhf".equals(ARCH) ? "-gnueabihf" : "-gnueabi");
+        }
+        else if (ARCH.equals("mips64el")) {
+            libc = "-gnuabi64";
+        }
+
+        return cpu + kernel + libc;
     }
 }

--- a/src/com/sun/jna/Platform.java
+++ b/src/com/sun/jna/Platform.java
@@ -262,12 +262,8 @@ public final class Platform {
             arch = "ppc64le";
         }
         // Map arm to armel if the binary is running as softfloat build
-        if("arm".equals(arch) && platform == Platform.LINUX ) {
-            if(isSoftFloat()) {
-                arch = "armel";
-            } else if(!is64Bit()) {
-                arch = "armhf";
-            }
+        if("arm".equals(arch) && platform == Platform.LINUX && isSoftFloat()) {
+            arch = "armel";
         }
 
         return arch;
@@ -374,7 +370,7 @@ public final class Platform {
             cpu = (is64Bit() ? "aarch64" : "arm");
             libc = is64Bit()
                 ? "-gnu"
-                : ("armhf".equals(ARCH) ? "-gnueabihf" : "-gnueabi");
+                : ("armel".equals(ARCH) ? "-gnueabi" : "-gnueabihf");
         }
         else if (ARCH.equals("mips64el")) {
             libc = "-gnuabi64";


### PR DESCRIPTION
This patch moves getMultiarchPath() to Platform so that it is available for both Library and NativeLibrary.

It also fixes the library path on the aarch64, armhf and ppc64el platforms.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1028374 for more info.