### PR TITLE
Cleaner optimizaton

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1396,6 +1396,7 @@ cd ..
     </propertyset>
     <junit fork="${test.fork}" forkmode="${test.forkmode}" failureproperty="testfailure" tempdir="${build}">
       <jvmarg if:set="test.jdwp" value="${test.jdwp}" />
+      <jvmarg value="-Xmx64m" />
       <!-- optionally run headless -->
       <syspropertyset refid="headless"/>
       <!-- avoid VM conflicts with JNA protected mode -->

--- a/test/com/sun/jna/CallbacksTest.java
+++ b/test/com/sun/jna/CallbacksTest.java
@@ -38,6 +38,7 @@ import java.util.WeakHashMap;
 
 import com.sun.jna.Callback.UncaughtExceptionHandler;
 import com.sun.jna.CallbacksTest.TestLibrary.CbCallback;
+import com.sun.jna.internal.Cleaner;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.W32APIOptions;
@@ -362,7 +363,7 @@ public class CallbacksTest extends TestCase implements Paths {
 
         cb = null;
         System.gc();
-        for (int i = 0; i < 100 && (ref.get() != null || refs.containsValue(ref)); ++i) {
+        for (int i = 0; i < Cleaner.MasterCleaner.CLEANUP_INTERVAL_MS / 10 + 5 && (ref.get() != null || refs.containsValue(ref)); ++i) {
             Thread.sleep(10); // Give the GC a chance to run
             System.gc();
         }
@@ -371,11 +372,11 @@ public class CallbacksTest extends TestCase implements Paths {
 
         ref = null;
         System.gc();
-        for (int i = 0; i < 100 && (cbstruct.peer != 0 || refs.size() > 0); ++i) {
+        for (int i = 0; i < Cleaner.MasterCleaner.CLEANUP_INTERVAL_MS / 10 + 5 && (cbstruct.peer != 0 || refs.size() > 0); ++i) {
             // Flush weak hash map
             refs.size();
             try {
-                Thread.sleep(10); // Give the GC a chance to run
+                Thread.sleep(Cleaner.MasterCleaner.CLEANUP_INTERVAL_MS + 10); // Give the GC a chance to run
                 System.gc();
             } finally {}
         }

--- a/test/com/sun/jna/different_package/CleanerTest.java
+++ b/test/com/sun/jna/different_package/CleanerTest.java
@@ -1,0 +1,47 @@
+package com.sun.jna.different_package;
+
+import com.sun.jna.Structure;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CleanerTest extends TestCase {
+    private static final int NUM_THREADS = 16;
+    private static final long ITERATIONS = 100000;
+
+    @Structure.FieldOrder({"bytes"})
+    public static class Dummy extends Structure {
+        public byte[] bytes;
+
+        public Dummy() {}
+
+        public Dummy(byte[] what) { bytes = what; }
+    }
+
+    private static class Allocator implements Runnable {
+        @Override
+        public void run() {
+            for (long i = 0; i < ITERATIONS; ++i) {
+                Dummy d = new Dummy(new byte[1024]);
+                d.write();
+            }
+        }
+    }
+
+    public void testOOM() {
+        List<Thread> threads = new ArrayList<>(NUM_THREADS);
+        for (int i = 0; i < NUM_THREADS; ++i) {
+            Thread t = new Thread(new Allocator());
+            t.start();
+            threads.add(t);
+        }
+        for (Thread t : threads) {
+            while (t.isAlive()) {
+                try {
+                    t.join();
+                } catch (InterruptedException ignore) {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1535 (also fixes #1521 )

This PR fixes the cleaner overload issue by creating a Cleaner instance per thread so that each thread will clean up the objects it previously created.
An additional "Master Cleaner" cleans up after thread exits. The Master Cleaner terminates itself 1 minute after all registered objects have been cleaned up.
