### PR TITLE
Make handle volatile to ensure safe publication

### DIFF
--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -96,7 +96,7 @@ public class NativeLibrary implements Closeable {
     };
 
     private Cleaner.Cleanable cleanable;
-    private long handle;
+    private volatile long handle;
     private final String libraryName;
     private final String libraryPath;
     private final Map<String, Function> functions = new HashMap<String, Function>();
@@ -1055,7 +1055,7 @@ public class NativeLibrary implements Closeable {
 
     private static final class NativeLibraryDisposer implements Runnable {
 
-        private long handle;
+        private volatile long handle;
 
         public NativeLibraryDisposer(long handle) {
             this.handle = handle;


### PR DESCRIPTION
Mutable fields are not thread-safe.
If a thread sets the handle to 0, other threads may still see the old value.