### PR TITLE
Add dependabot to monitor GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Fixes https://github.com/java-native-access/jna/issues/1566.

This PR adds Dependabot to monitor JNA's GitHub Actions. It also bumps `actions/checkout@v3` to `v4`, the sort of thing Dependabot would otherwise do itself (see [the PR on my fork](https://github.com/pnacht/jna/pull/1)).

Dependabot is configured to use grouped updates. So if more than one Action releases a new version, you'll only receive a single PR updating all Actions instead of one PR per Action. This admittedly isn't too likely to happen currently, seeing as the project only uses two Actions, but can prove far more useful should the project add more workflows with more Actions in the future.

