### PR TITLE
Mask out all but low byte when checking boolean

### DIFF
--- a/src/com/sun/jna/Function.java
+++ b/src/com/sun/jna/Function.java
@@ -418,7 +418,7 @@ public class Function extends Pointer {
             Native.invokeVoid(this, this.peer, callFlags, args);
             result = null;
         } else if (returnType==boolean.class || returnType==Boolean.class) {
-            result = valueOf(Native.invokeInt(this, this.peer, callFlags, args) != 0);
+            result = valueOf((byte)Native.invokeInt(this, this.peer, callFlags, args) != 0);
         } else if (returnType==byte.class || returnType==Byte.class) {
             result = Byte.valueOf((byte)Native.invokeInt(this, this.peer, callFlags, args));
         } else if (returnType==short.class || returnType==Short.class) {


### PR DESCRIPTION
On macOS (M1) at least, a boolean return type is only guaranteed to be 0 or non-zero in the low-order byte.

This is handled correctly in the case of a method called via Native.register, but the NativeLibrary.getFunction nearly always gives true as the upper bytes are random