### PR TITLE
Add support for FreeBSD aarch64 (it's now a Tier 1 arch).

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -401,6 +401,8 @@ com/sun/jna/freebsd-x86/libjnidispatch.so;
 processor=x86;osname=freebsd,
 com/sun/jna/freebsd-x86-64/libjnidispatch.so;
 processor=x86-64;osname=freebsd,
+com/sun/jna/freebsd-aarch64/libjnidispatch.so;
+processor=aarch64;osname=freebsd,
 
 com/sun/jna/openbsd-x86/libjnidispatch.so;
 processor=x86;osname=openbsd,
@@ -532,6 +534,9 @@ osname=macosx;processor=aarch64
       <zipfileset src="${lib.native}/freebsd-x86-64.jar"
                   includes="*jnidispatch*"
                   prefix="com/sun/jna/freebsd-x86-64"/>
+      <zipfileset src="${lib.native}/freebsd-aarch64.jar"
+                  includes="*jnidispatch*"
+                  prefix="com/sun/jna/freebsd-aarch64"/>
       <zipfileset src="${lib.native}/openbsd-x86.jar"
                   includes="*jnidispatch*"
                   prefix="com/sun/jna/openbsd-x86"/>
@@ -720,6 +725,7 @@ osname=macosx;processor=aarch64
     <copy file="${lib.native}/out-of-date.jar" tofile="${lib.native}/linux-riscv64.jar" overwrite="true"/>
     <copy file="${lib.native}/out-of-date.jar" tofile="${lib.native}/freebsd-x86.jar" overwrite="true"/>
     <copy file="${lib.native}/out-of-date.jar" tofile="${lib.native}/freebsd-x86-64.jar" overwrite="true"/>
+    <copy file="${lib.native}/out-of-date.jar" tofile="${lib.native}/freebsd-aarch64.jar" overwrite="true"/>
     <copy file="${lib.native}/out-of-date.jar" tofile="${lib.native}/openbsd-x86.jar" overwrite="true"/>
     <copy file="${lib.native}/out-of-date.jar" tofile="${lib.native}/openbsd-x86-64.jar" overwrite="true"/>
     <copy file="${lib.native}/out-of-date.jar" tofile="${lib.native}/sunos-x86.jar" overwrite="true"/>

--- a/native/Makefile
+++ b/native/Makefile
@@ -15,7 +15,8 @@
 #   Linux (i386/amd64/ppc/arm)
 #   Solaris (i386/amd64/sparc/sparcv9)
 #   AIX (ppc/ppc64)
-#   FreeBSD/OpenBSD/NetBSD (i386/amd64)
+#   FreeBSD (i386/amd64/aarch64)
+#   OpenBSD/NetBSD (i386/amd64)
 #   Android (arm/armv7/aarch64/x86/x86-64/mipsel/mips64el)
 #
 # Built, but with outstanding bugs (not necessarily within JNA):


### PR DESCRIPTION
Let me know if I should push also the jars with the compiled lib.