### PR TITLE
Handle ELF binaries without section header table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Features
 
 Bug Fixes
 ---------
-
+* [#1579](https://github.com/java-native-access/jna/issues/1579): Fix analysis of ELF binary on arm systems running with a java ELF binary without section table headers (java8 on armv7 NAS) - [@matthiasblaesing](https://github.com/matthiasblaesing).
 
 Release 5.14.0
 ==============


### PR DESCRIPTION
The ELFAnalyser failed to analyse the java binary on Java 8 for armv7 synology NAS systems (DS115j, ...). The binary did not contain an ELF section header table, which caused an IndexOutOfBoundsException.

Closes: #1579 