### PR TITLE
Added static helper methods for getting the underlying NativeLibrary instance from a Library interface instance or from a "registered" class.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 * [#1593](https://github.com/java-native-access/jna/pull/1593): Add support for DragonFly BSD x86-64 - [@liweitianux](https://github.com/liweitianux).
 * [#1595](https://github.com/java-native-access/jna/pull/1595): Add `IsProcessorFeaturePresent` to `c.s.j.p.win32.Kernel32` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1602](https://github.com/java-native-access/jna/pull/1602): Add `XMoveWindow`, `XResizeWindow`, `XMoveResizeWindow`, `XRaiseWindow`, `XLowerWindow` X11 calls to `c.s.j.p.unix.X11` - [@vinceh121](https://github.com/vinceh121).
+* [#1612](https://github.com/java-native-access/jna/pull/1612): Added static helper methods for getting the underlying NativeLibrary instance from a Library interface instance or from a "registered" class.
 
 Bug Fixes
 ---------

--- a/src/com/sun/jna/Library.java
+++ b/src/com/sun/jna/Library.java
@@ -271,4 +271,17 @@ public interface Library {
             }
         }
     }
+
+    /**
+     * Get the {@link NativeLibrary} instance that is wrapped by the given {@link Library} interface instance.
+     * @param library the {@link Library} interface instance, which was created by the {@link Native#load Native.load()} method
+     * @return the wrapped {@link NativeLibrary} instance
+     */
+    static NativeLibrary getNativeLibrary(final Library library) {
+        final InvocationHandler handler = Proxy.getInvocationHandler(library);
+        if (!(handler instanceof Handler)) {
+            throw new IllegalArgumentException("Object is not a properly initialized Library interface instance");
+        }
+        return ((Handler)handler).getNativeLibrary();
+    }
 }

--- a/src/com/sun/jna/Native.java
+++ b/src/com/sun/jna/Native.java
@@ -1918,6 +1918,23 @@ public final class Native implements Version {
         }
     }
 
+    /**
+     * Get the {@link NativeLibrary} instance to which the given "registered" class is bound.
+     * @param cls the "registered" class, which was previously registered via the {@link Native#register register()} method
+     * @return the {@link NativeLibrary} instance to which the "registered" class is bound
+     */
+    public static NativeLibrary getNativeLibrary(final Class<?> cls) {
+        final Class<?> mappedClass = findDirectMappedClass(cls);
+        synchronized(registeredClasses) {
+            final NativeLibrary nativeLibrary = registeredLibraries.get(mappedClass);
+            if (nativeLibrary == null) {
+                throw new IllegalArgumentException("Class " + cls.getName() + " is not currently registered");
+            } else {
+                return nativeLibrary;
+            }
+        }
+    }
+
     /* Take note of options used for a given library mapping, to facilitate
      * looking them up later.
      */


### PR DESCRIPTION
This adds **static** method **`getNativeLibrary()`** to the `Library` interface:
```java
public interface Library {
    static NativeLibrary getNativeLibrary(final Library library) {
        return ((Handler)Proxy.getInvocationHandler(library)).getNativeLibrary();
    }
}
```

Useful, if the *`Library`-based* interface was loaded via `Native.load()` but we need to access the `NativeLibrary` instance.

One important use-case is the `NativeLibrary.getGlobalVariableAddress()` method!

I'm **not** aware of another way to get a **_global variable_** from the *`Library`-based* interface. If there is, please tell me :smirk:

(BTW: It is **not** trivial to figure out that `getInvocationHandler()` from `java.lang.reflect.Proxy` must be used to get the `Handler`, which then can can be used to get the `NativeLibrary`. This alone is enough reason to provide a dedicated method in the JNA interface for getting the `NativeLibrary` instance from a `Library` interface instance)

----

It will be used like this:

```java
public interface SomeLibrary extends Library {
    SomeLibrary INSTANCE = Native.load("libfoo", SomeLibrary.class);

    static class NativeLibraryHolder {
        public static final NativeLibrary LIBRARY = Library.getNativeLibrary(INSTANCE); // <-- this is new !!!
    }

    static class SOME_GLOBAL_VARIABLE {
        private static final Pointer ADDRESS = NativeLibraryHolder.LIBRARY.getGlobalVariableAddress("FOOBAR");
        int get() { return ADDRESS.getInt(0L); }
        void set(final int newValue) { ADDRESS.setInt(0L, newValue); }
    }

    int some_function(int param);
}
```

