### PR TITLE
windows: making library loading work after `SetDefaultDllDirectories()` call (#1413)

### DIFF
--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -164,10 +164,14 @@ public class NativeLibrary implements Closeable {
     }
 
     private static final int DEFAULT_OPEN_OPTIONS = -1;
-    private static int openFlags(Map<String, ?> options) {
+    private static final int DEFAULT_WINDOWS_RELATIVE_PATH_OPEN_OPTIONS = 0;
+    private static int openFlags(Map<String, ?> options, boolean isAbsolutePath) {
         Object opt = options.get(Library.OPTION_OPEN_FLAGS);
         if (opt instanceof Number) {
             return ((Number)opt).intValue();
+        }
+        if (Platform.isWindows() && !isAbsolutePath) {
+            return DEFAULT_WINDOWS_RELATIVE_PATH_OPEN_OPTIONS;
         }
         return DEFAULT_OPEN_OPTIONS;
     }
@@ -178,7 +182,7 @@ public class NativeLibrary implements Closeable {
         List<Throwable> exceptions = new ArrayList<>();
         boolean isAbsolutePath = new File(libraryName).isAbsolute();
         LinkedHashSet<String> searchPath = new LinkedHashSet<>();
-        int openFlags = openFlags(options);
+        int openFlags = openFlags(options, isAbsolutePath);
 
         //
         // Prepend any custom search paths specifically for this library
@@ -475,7 +479,7 @@ public class NativeLibrary implements Closeable {
 
             if (library == null) {
                 if (libraryName == null) {
-                    library = new NativeLibrary("<process>", null, Native.open(null, openFlags(options)), options);
+                    library = new NativeLibrary("<process>", null, Native.open(null, openFlags(options, true)), options);
                 }
                 else {
                     library = loadLibrary(libraryName, options);


### PR DESCRIPTION
When a client doesn't specify open options, JNA defaults to `LOAD_WITH_ALTERED_SEARCH_PATH` ([dispatch.c#L54](https://github.com/java-native-access/jna/blob/master/native/dispatch.c#L54)). According to `LoadLibraryEx` [documentation](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw), this results in an undefined behavior when a library name is given as a relative path.

In a "normal" mode, this is not a problem: Windows just ignores the flag and carries on, but if an application tries to improve [DLL loading security](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-security) and restricts the DLL search path by calling `SetDefaultDllDirectories()` ([docs](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories)), calling `LoadLibraryEx(relative_path, ..., LOAD_WITH_ALTERED_SEARCH_PATH)` results in `ERROR_INVALID_PARAMETER`.

A simple reproducer in C, just in case:
```c
#include <stdio.h>
#include <Windows.h>

int main() {
  if (!SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)) {
    printf("SetDefaultDllDirectories: 0x%lx\n", GetLastError());
    return 1;
  }

  HMODULE w = LoadLibraryExW(L"WtsApi32", NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
  if (w == NULL) {
    printf("LoadLibraryEx: 0x%lx\n", GetLastError());
    return 2;
  }

  printf("handle=%p\n", w);

  return 0;
}
```

The PR fixes the issue by setting default open options to `0` when a relative path is specified.