### PR TITLE
Enable linker `build-id` for android builds.

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -180,7 +180,7 @@ COPT+=-fpic -ffunction-sections -funwind-tables -fno-short-enums
 JAVA_INCLUDES=
 CINCLUDES+=-I"$(NDK_PLATFORM)/arch-$(AARCH)/usr/include" # -I/usr/include
 LIBS=-nostdlib -L"$(NDK_PLATFORM)/arch-$(AARCH)$(ALIBDIR)/" -lgcc -lc -ldl -lm
-LDFLAGS+=-Wl,-shared,-Bsymbolic
+LDFLAGS+=-Wl,-shared,-Bsymbolic -Wl,--build-id=sha1
 FFI_ENV=CPP="$(CPP)" CC="$(CC)" CFLAGS="$(COPT) $(CDEBUG) $(CINCLUDES)" CPPFLAGS="$(CDEFINES) $(CINCLUDES)" LIBS="$(LIBS)" RANLIB="$(RANLIB)"
 FFI_CONFIG=--enable-static --disable-shared --with-pic=yes --host=$(HOST)
 endif


### PR DESCRIPTION
Linker build-id is [mandatory](https://firebase.google.com/docs/crashlytics/ndk-reports) to make Firebase crashlytics recognise libraries which encounters crashes. So since Firebase is ubiquitous to monitor app crash performance it make sense to enable it for android builds. It only slightly increases binary size (20 bytes) but make Firebase crash symbolication work. Here I assume that debugging symbols are currently presented/published, if not the case it will be handled in subsequent PRs.
![image](https://github.com/user-attachments/assets/c3ff9df4-8529-4dab-be94-08d385a2efef)
