### PR TITLE
ci: support java 23 (as java 23 already ga)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,13 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17, 21, 23-ea]
+        java: [8, 11, 17, 21, 23]
         # macos-13 is x86, macos-latest is aarch64
         os: [ubuntu-latest, macos-13, macos-latest]
-        exclude:
-          # 23-ea is not available for mac OS
-          - java: 23-ea
-            os: macos-latest
       # Run all tests even if one fails
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}


### PR DESCRIPTION
👋 as java 23 already ga, update to support it.