### PR TITLE
Prepare build for JDK24+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17, 21, 24]
+        java: [8, 21, 24]
         # macos-13 is x86, macos-latest is aarch64
-        os: [ubuntu-latest, macos-13, macos-latest]
-        include:
-          - java: 17
-            os: 'ubuntu-24.04-arm'
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
       # Run all tests even if one fails
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17, 21, 23]
+        java: [8, 11, 17, 21, 24]
         # macos-13 is x86, macos-latest is aarch64
         os: [ubuntu-latest, macos-13, macos-latest]
         include:

--- a/build.xml
+++ b/build.xml
@@ -1235,6 +1235,10 @@ cd ..
       <propertyref prefix="java.awt.headless"/>
     </propertyset>
     <junit fork="${test.fork}" forkmode="${test.forkmode}" failureproperty="testfailure" tempdir="${build}">
+      <!-- let JVM ignore unknown flags -->
+      <jvmarg value="-XX:+IgnoreUnrecognizedVMOptions" />
+      <!-- enable JNI on JDK 24+ -->
+      <jvmarg value="--enable-native-access=ALL-UNNAMED" />
       <jvmarg if:set="test.jdwp" value="${test.jdwp}" />
       <!-- optionally run headless -->
       <syspropertyset refid="headless"/>

--- a/contrib/platform/build.xml
+++ b/contrib/platform/build.xml
@@ -317,6 +317,10 @@ com.sun.jna.platform.wince;version=&quot;${osgi.version}&quot;;uses:=&quot;com.s
         <propertyref name="w32.ascii"/>
       </propertyset>
       <junit fork="${test.fork}" failureproperty="testfailure" tempdir="${build}">
+        <!-- let JVM ignore unknown flags -->
+        <jvmarg value="-XX:+IgnoreUnrecognizedVMOptions" />
+        <!-- enable JNI on JDK 24+ -->
+        <jvmarg value="--enable-native-access=ALL-UNNAMED" />
         <jvmarg if:set="test.jdwp" value="${test.jdwp}" />
         <!-- optionally run headless -->
         <syspropertyset refid="headless"/>


### PR DESCRIPTION
- enable running CI/CD matrix on JDK24 (dropping JDK23 for this)
- adjust build script to set parameters so that unittests run without warnings from native access