### PR TITLE
low-contention refactored reference Cleaner (fixes #1616)

### DIFF
--- a/src/com/sun/jna/internal/Cleaner.java
+++ b/src/com/sun/jna/internal/Cleaner.java
@@ -88,13 +88,12 @@ public class Cleaner {
     }
 
     // Remove by node reference
-    private void remove(final CleanerRef node) {
-        uncleaned.remove(node);
+    private boolean remove(final CleanerRef node) {
+        return uncleaned.remove(node);
     }
 
     private static class CleanerRef extends PhantomReference<Object> implements Cleanable {
         private volatile Runnable cleanupTask;
-        private AtomicBoolean cleaned = new AtomicBoolean(false);
 
         CleanerRef(Object referent, ReferenceQueue<? super Object> q, Runnable cleanupTask) {
             super(referent, q);
@@ -103,8 +102,7 @@ public class Cleaner {
 
         @Override
         public void clean() {
-            if (cleaned.compareAndSet(false, true)) {
-                INSTANCE.remove(this);
+            if (INSTANCE.remove(this)) {
                 cleanupTask.run();
             }
         }


### PR DESCRIPTION
Refactored (re-written) ``Cleaner`` class, as low-contention and simple as I can get it. Principally, I removed the linked-node structure and replaced with a concurrent set. Fixes #1616.

An ``AtomicBoolean`` is used to track whether the cleaner thread is running and another (per-CleanerRef) is used to track whether the cleanup task has been run, either directly or by the cleaner thread, ensuring it is only executed once.

I don't think this class could be simplified any further and still be correct.

@matthiasblaesing If you still have your JMH harness, I'd be interested in how it performs.
