### PR TITLE
Avoid threading issues in sortFields (#1686)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Features
 
 Bug Fixes
 ---------
-
+* [#1686](https://github.com/java-native-access/jna/issues/1686): Fix `sortFields` race condition while getting fields
 
 Release 5.18.0
 ==============

--- a/src/com/sun/jna/Structure.java
+++ b/src/com/sun/jna/Structure.java
@@ -1125,7 +1125,7 @@ public abstract class Structure {
         and can't be generated automatically.
     **/
     protected List<Field> getFields(boolean force) {
-        List<Field> flist = getFieldList();
+        List<Field> flist = new ArrayList<>(getFieldList());
         Set<String> names = new HashSet<>();
         for (Field f : flist) {
             names.add(f.getName());


### PR DESCRIPTION
I used essentially the same pattern than `validateFields` uses.