### PR TITLE
Update recommended Android proguard rules

### DIFF
--- a/www/FrequentlyAskedQuestions.md
+++ b/www/FrequentlyAskedQuestions.md
@@ -218,6 +218,7 @@ If you're using Proguard, you should also add the following to your Proguard rul
 ```
 -dontwarn java.awt.*
 -keep class com.sun.jna.* { *; }
+-keep class * extends com.sun.jna.* { *; }
 -keepclassmembers class * extends com.sun.jna.* { public *; }
 ```
 


### PR DESCRIPTION
With R8 fullMode enabled, classes that extend from `com.sun.jna.*` are all removed, so we should be explicit to include those.

We discovered this in https://github.com/mozilla-mobile/reference-browser/issues/3885 and our patch verified that updating our proguard rules resolve the problem: https://github.com/mozilla/application-services/pull/6979

Additionally, shipping a consumer proguard file would allow consumers to benefit from proguard changes supplied by JNA. Mentioning this is only for your consideration. 🙂 


