### PR TITLE
Improve error handling in OpenProcess method : Windows32Exception - The parameter is incorrect #1700

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Features
 
 Bug Fixes
 ---------
-* [#1700](https://github.com/java-native-access/jna/issues/1700): Windows: treat `ERROR_INVALID_PARAMETER` from `OpenProcess` in `c.s.j.p.WindowUtils#getProcessFilePath` like `ERROR_ACCESS_DENIED` to avoid spurious `Win32Exception` when enumerating windows whose processes have exited or are otherwise inaccessible.
+* [#1700](https://github.com/java-native-access/jna/issues/1700): Windows: treat `ERROR_INVALID_PARAMETER` from `OpenProcess` in `c.s.j.p.WindowUtils#getProcessFilePath` like `ERROR_ACCESS_DENIED` to avoid spurious `Win32Exception` when enumerating windows whose processes have exited or are otherwise inaccessible - [marktech0813](https://github.com/marktech0813).
 
 
 Release 5.18.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features
 
 Bug Fixes
 ---------
+* [#1700](https://github.com/java-native-access/jna/issues/1700): Windows: treat `ERROR_INVALID_PARAMETER` from `OpenProcess` in `c.s.j.p.WindowUtils#getProcessFilePath` like `ERROR_ACCESS_DENIED` to avoid spurious `Win32Exception` when enumerating windows whose processes have exited or are otherwise inaccessible.
 
 
 Release 5.18.1

--- a/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
@@ -1311,6 +1311,7 @@ public class WindowUtils {
                         switch (Kernel32.INSTANCE.GetLastError()) {
                             case WinNT.ERROR_ACCESS_DENIED:
                             case WinError.ERROR_INVALID_PARAMETER:
+                                // Ignore windows, that can't be accessed
                                 return "";
                         }
                         /* if above didn't already break or return, fall through to default */

--- a/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
@@ -1298,25 +1298,26 @@ public class WindowUtils {
                     pid.getValue());
 
             if (process == null) {
-                int lastError = Kernel32.INSTANCE.GetLastError();
-                if (lastError == WinNT.ERROR_ACCESS_DENIED
-                        || lastError == WinError.ERROR_INVALID_PARAMETER) {
-                    process = Kernel32.INSTANCE.OpenProcess( 
-                            WinNT.PROCESS_QUERY_LIMITED_INFORMATION, 
-                            false, 
-                            pid.getValue());
-
-                    if (process == null) {
-                        lastError = Kernel32.INSTANCE.GetLastError();
-                        if (lastError == WinNT.ERROR_ACCESS_DENIED
-                                || lastError == WinError.ERROR_INVALID_PARAMETER) {
-                            return "";
-                        } 
-                        throw new Win32Exception(lastError);
-                    }
-                } else {
-                    throw new Win32Exception(lastError);
-                } 
+                switch (Kernel32.INSTANCE.GetLastError()) {
+                    case WinNT.ERROR_ACCESS_DENIED:
+                    case WinError.ERROR_INVALID_PARAMETER:
+                        process = Kernel32.INSTANCE.OpenProcess(
+                                WinNT.PROCESS_QUERY_LIMITED_INFORMATION,
+                                false,
+                                pid.getValue());
+                        if (process == null) {
+                            switch (Kernel32.INSTANCE.GetLastError()) {
+                                case WinNT.ERROR_ACCESS_DENIED:
+                                case WinError.ERROR_INVALID_PARAMETER:
+                                    return "";
+                                default:
+                                    throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+                            }
+                        }
+                        break;
+                    default:
+                        throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+                }
             }
 
             try {

--- a/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
@@ -1305,16 +1305,15 @@ public class WindowUtils {
                                 WinNT.PROCESS_QUERY_LIMITED_INFORMATION,
                                 false,
                                 pid.getValue());
-                        if (process == null) {
-                            switch (Kernel32.INSTANCE.GetLastError()) {
-                                case WinNT.ERROR_ACCESS_DENIED:
-                                case WinError.ERROR_INVALID_PARAMETER:
-                                    return "";
-                                default:
-                                    throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-                            }
+                        if (process != null) {
+                            break;
                         }
-                        break;
+                        switch (Kernel32.INSTANCE.GetLastError()) {
+                            case WinNT.ERROR_ACCESS_DENIED:
+                            case WinError.ERROR_INVALID_PARAMETER:
+                                return "";
+                        }
+                        /* if above didn't already break or return, fall through to default */
                     default:
                         throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
                 }

--- a/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
+++ b/contrib/platform/src/com/sun/jna/platform/WindowUtils.java
@@ -1298,23 +1298,25 @@ public class WindowUtils {
                     pid.getValue());
 
             if (process == null) {
-                if(Kernel32.INSTANCE.GetLastError() != WinNT.ERROR_ACCESS_DENIED) {
-                    throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-                } else {
-                    process = Kernel32.INSTANCE.OpenProcess(
-                            WinNT.PROCESS_QUERY_LIMITED_INFORMATION,
-                            false,
+                int lastError = Kernel32.INSTANCE.GetLastError();
+                if (lastError == WinNT.ERROR_ACCESS_DENIED
+                        || lastError == WinError.ERROR_INVALID_PARAMETER) {
+                    process = Kernel32.INSTANCE.OpenProcess( 
+                            WinNT.PROCESS_QUERY_LIMITED_INFORMATION, 
+                            false, 
                             pid.getValue());
 
                     if (process == null) {
-                        if (Kernel32.INSTANCE.GetLastError() != WinNT.ERROR_ACCESS_DENIED) {
-                            throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-                        } else {
-                            // Ignore windows, that can't be accessed
+                        lastError = Kernel32.INSTANCE.GetLastError();
+                        if (lastError == WinNT.ERROR_ACCESS_DENIED
+                                || lastError == WinError.ERROR_INVALID_PARAMETER) {
                             return "";
-                        }
+                        } 
+                        throw new Win32Exception(lastError);
                     }
-                }
+                } else {
+                    throw new Win32Exception(lastError);
+                } 
             }
 
             try {


### PR DESCRIPTION
I found the Windows code path that throws in getProcessFilePath(HWND) and implemented a defensive fix so your logs won’t fill with Win32Exceptions anymore. Now, when OpenProcess fails with ERROR_INVALID_PARAMETER (87), it is treated like ACCESS_DENIED: we either retry with PROCESS_QUERY_LIMITED_INFORMATION, or return an empty path if access still fails. This covers the race where a PID disappears between enumeration and open, or other transient/unsupported cases.

In contrib/platform/src/com/sun/jna/platform/WindowUtils.java, updated W32WindowUtils.getProcessFilePath:
On first OpenProcess failure, if GetLastError() is ACCESS_DENIED or INVALID_PARAMETER, we attempt PROCESS_QUERY_LIMITED_INFORMATION.
If the second OpenProcess also fails with ACCESS_DENIED or INVALID_PARAMETER, we return an empty string instead of throwing.
Only other error codes still throw a Win32Exception.