### PR TITLE
Replace ConcurrentHashMap with ConcurrentLongHashMap: Massive Win

### DIFF
--- a/create-export-package-metadata-pom.xml
+++ b/create-export-package-metadata-pom.xml
@@ -38,6 +38,14 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>8</source>
+                <target>8</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 

--- a/src/com/sun/jna/Memory.java
+++ b/src/com/sun/jna/Memory.java
@@ -22,16 +22,15 @@
  */
 package com.sun.jna;
 
+import com.sun.jna.internal.Cleaner;
+import com.sun.jna.internal.ConcurrentLongHashMap;
+
 import java.io.Closeable;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import com.sun.jna.internal.Cleaner;
 
 /**
  * A <code>Pointer</code> to memory obtained from the native heap via a
@@ -53,8 +52,8 @@ import com.sun.jna.internal.Cleaner;
  */
 public class Memory extends Pointer implements Closeable {
     /** Keep track of all allocated memory so we can dispose of it before unloading. */
-    private static final Map<Long, Reference<Memory>> allocatedMemory =
-            new ConcurrentHashMap<>();
+    private static final ConcurrentLongHashMap<Reference<Memory>> allocatedMemory =
+            new ConcurrentLongHashMap<>();
 
     private static final WeakMemoryHolder buffers = new WeakMemoryHolder();
 

--- a/src/com/sun/jna/internal/ConcurrentLongHashMap.java
+++ b/src/com/sun/jna/internal/ConcurrentLongHashMap.java
@@ -1,0 +1,505 @@
+/*
+ * The contents of this file is dual-licensed under 2
+ * alternative Open Source/Free licenses: LGPL 2.1 or later and
+ * Apache License 2.0. (starting with JNA version 4.0.0).
+ *
+ * You can freely decide which license you want to apply to
+ * the project.
+ *
+ * You may obtain a copy of the LGPL License at:
+ *
+ * http://www.gnu.org/licenses/licenses.html
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "LGPL2.1".
+ *
+ * You may obtain a copy of the Apache License at:
+ *
+ * http://www.apache.org/licenses/
+ *
+ * A copy is also included in the downloadable source code package
+ * containing JNA, in file "AL2.0".
+ */
+package com.sun.jna.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.locks.StampedLock;
+import java.util.function.LongFunction;
+
+/**
+ * Map from long to an Object.
+ * <p>
+ * Provides similar methods as a {@literal ConcurrentMap<long,Object>} with 2 differences:
+ * <ol>
+ * <li>No boxing/unboxing from {@literal long -> Long}
+ * <li>Open hash map with linear probing, no node allocations to store the values
+ * </ol>
+ */
+@SuppressWarnings("unchecked")
+public class ConcurrentLongHashMap<V> {
+
+    private static final Object EmptyValue = null;
+    private static final Object DeletedValue = new Object();
+
+    private static final float MapFillFactor = 0.66f;
+
+    private static final int DefaultExpectedItems = 256;
+    private static final int DefaultConcurrencyLevel = 16;
+
+    private final Section<V>[] sections;
+
+    public ConcurrentLongHashMap() {
+        this(DefaultExpectedItems);
+    }
+
+    public ConcurrentLongHashMap(int expectedItems) {
+        this(expectedItems, DefaultConcurrencyLevel);
+    }
+
+    public ConcurrentLongHashMap(int expectedItems, int numSections) {
+        if (numSections <= 0) {
+            throw new IllegalArgumentException("numSections must be > 0");
+        }
+
+        if (expectedItems < numSections) {
+            expectedItems = numSections;
+        }
+
+        int perSectionExpectedItems = expectedItems / numSections;
+        int perSectionCapacity = (int) (perSectionExpectedItems / MapFillFactor);
+        this.sections = (Section<V>[]) new Section[numSections];
+
+        for (int i = 0; i < numSections; i++) {
+            sections[i] = new Section<>(perSectionCapacity);
+        }
+    }
+
+    public int size() {
+        int size = 0;
+        for (Section<V> s : sections) {
+            //read-acquire s.size that was write-released by s.unlockWrite
+            s.tryOptimisticRead();
+            //a stale value won't hurt: anyway it's subject to concurrent modifications
+            size += s.size;
+        }
+        return size;
+    }
+
+    long getUsedBucketCount() {
+        long usedBucketCount = 0;
+        for (Section<V> s : sections) {
+            usedBucketCount += s.usedBuckets;
+        }
+        return usedBucketCount;
+    }
+
+    public long capacity() {
+        long capacity = 0;
+        for (Section<V> s : sections) {
+            capacity += s.capacity;
+        }
+        return capacity;
+    }
+
+    public boolean isEmpty() {
+        for (Section<V> s : sections) {
+            //read-acquire s.size that was write-released by s.unlockWrite
+            s.tryOptimisticRead();
+            //a stale value won't hurt: anyway it's subject to concurrent modifications
+            if (s.size != 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public V get(long key) {
+        long h = hash(key);
+        return getSection(h).get(key, (int) h);
+    }
+
+    public boolean containsKey(long key) {
+        return get(key) != null;
+    }
+
+    public V put(long key, V value) {
+        Objects.requireNonNull(value);
+        long h = hash(key);
+        return getSection(h).put(key, value, (int) h, false, null);
+    }
+
+    public V putIfAbsent(long key, V value) {
+        Objects.requireNonNull(value);
+        long h = hash(key);
+        return getSection(h).put(key, value, (int) h, true, null);
+    }
+
+    public V computeIfAbsent(long key, LongFunction<V> provider) {
+        Objects.requireNonNull(provider);
+        long h = hash(key);
+        return getSection(h).put(key, null, (int) h, true, provider);
+    }
+
+    public V remove(long key) {
+        long h = hash(key);
+        return getSection(h).remove(key, null, (int) h);
+    }
+
+    public boolean remove(long key, Object value) {
+        Objects.requireNonNull(value);
+        long h = hash(key);
+        return getSection(h).remove(key, value, (int) h) != null;
+    }
+
+    private Section<V> getSection(long hash) {
+        // Use 32 msb out of long to get the section
+        final int sectionIdx = (int) (hash >>> 32) & (sections.length - 1);
+        return sections[sectionIdx];
+    }
+
+    public void clear() {
+        for (Section<V> s : sections) {
+            s.clear();
+        }
+    }
+
+    public void forEach(EntryProcessor<V> processor) {
+        for (Section<V> s : sections) {
+            s.forEach(processor);
+        }
+    }
+
+    /**
+     * @return a new list of all keys (makes a copy)
+     */
+    public List<Long> keys() {
+        List<Long> keys = new ArrayList<>(size());
+        forEach((key, value) -> keys.add(key));
+        return keys;
+    }
+
+    public List<V> values() {
+        List<V> values = new ArrayList<>(size());
+        forEach((key, value) -> values.add(value));
+        return values;
+    }
+
+    public interface EntryProcessor<V> {
+        void accept(long key, V value);
+    }
+
+    // A section is a portion of the hash map that is covered by a single
+    private static final class Section<V> extends StampedLock {
+
+        private static final AtomicIntegerFieldUpdater<Section> CAPACITY_UPDATER = AtomicIntegerFieldUpdater.newUpdater(Section.class, "capacity");
+        private long[] keys;
+        private V[] values;
+
+        private volatile int capacity;
+        private int size;
+        private int usedBuckets;
+        private int resizeThreshold;
+
+        Section(int capacity) {
+            this.capacity = alignToPowerOfTwo(capacity);
+            this.keys = new long[this.capacity];
+            this.values = (V[]) new Object[this.capacity];
+            this.size = 0;
+            this.usedBuckets = 0;
+            this.resizeThreshold = (int) (this.capacity * MapFillFactor);
+        }
+
+        @SuppressWarnings("NonAtomicVolatileUpdate")
+        V get(long key, int keyHash) {
+            int bucket = keyHash;
+
+            long stamp = tryOptimisticRead();
+            boolean acquiredLock = false;
+
+            try {
+                while (true) {
+                    int capacity = this.capacity;
+                    bucket = signSafeMod(bucket, capacity);
+
+                    // First try optimistic locking
+                    long storedKey = keys[bucket];
+                    V storedValue = values[bucket];
+
+                    if (!acquiredLock && validate(stamp)) {
+                        // The values we have read are consistent
+                        if (storedKey == key) {
+                            return storedValue != DeletedValue ? storedValue : null;
+                        } else if (storedValue == EmptyValue) {
+                            // Not found
+                            return null;
+                        }
+                    } else {
+                        // Fallback to acquiring read lock
+                        if (!acquiredLock) {
+                            stamp = readLock();
+                            acquiredLock = true;
+                            storedKey = keys[bucket];
+                            storedValue = values[bucket];
+                        }
+
+                        if (capacity != this.capacity) {
+                            // There has been a rehashing. We need to restart the search
+                            bucket = keyHash;
+                            continue;
+                        }
+
+                        if (storedKey == key) {
+                            return storedValue != DeletedValue ? storedValue : null;
+                        } else if (storedValue == EmptyValue) {
+                            // Not found
+                            return null;
+                        }
+                    }
+
+                    ++bucket;
+                }
+            } finally {
+                if (acquiredLock) {
+                    unlockRead(stamp);
+                }
+            }
+        }
+
+        @SuppressWarnings("NonAtomicVolatileUpdate")
+        V put(long key, V value, int keyHash, boolean onlyIfAbsent, LongFunction<V> valueProvider) {
+            int bucket = keyHash;
+
+            long stamp = writeLock();
+            int capacity = this.capacity;
+
+            // Remember where we find the first available spot
+            int firstDeletedKey = -1;
+
+            try {
+                while (true) {
+                    bucket = signSafeMod(bucket, capacity);
+
+                    long storedKey = keys[bucket];
+                    V storedValue = values[bucket];
+
+                    if (storedKey == key) {
+                        if (storedValue == EmptyValue) {
+                            values[bucket] = value != null ? value : (valueProvider != null ? valueProvider.apply(key) : null);
+                            ++size;
+                            ++usedBuckets;
+                            return valueProvider != null ? values[bucket] : null;
+                        } else if (storedValue == DeletedValue) {
+                            values[bucket] = value != null ? value : (valueProvider != null ? valueProvider.apply(key) : null);
+                            ++size;
+                            return valueProvider != null ? values[bucket] : null;
+                        } else if (!onlyIfAbsent) {
+                            // Over written an old value for same key
+                            values[bucket] = value;
+                            return storedValue;
+                        } else {
+                            return storedValue;
+                        }
+                    } else if (storedValue == EmptyValue) {
+                        // Found an empty bucket. This means the key is not in the map. If we've already seen a deleted
+                        // key, we should write at that position
+                        if (firstDeletedKey != -1) {
+                            bucket = firstDeletedKey;
+                        } else {
+                            ++usedBuckets;
+                        }
+
+                        keys[bucket] = key;
+                        values[bucket] = value != null ? value : (valueProvider != null ? valueProvider.apply(key) : null);
+                        ++size;
+                        return valueProvider != null ? values[bucket] : null;
+                    } else if (storedValue == DeletedValue) {
+                        // The bucket contained a different deleted key
+                        if (firstDeletedKey == -1) {
+                            firstDeletedKey = bucket;
+                        }
+                    }
+
+                    ++bucket;
+                }
+            } finally {
+                if (usedBuckets > resizeThreshold) {
+                    try {
+                        rehash();
+                    } finally {
+                        unlockWrite(stamp);
+                    }
+                } else {
+                    unlockWrite(stamp);
+                }
+            }
+        }
+
+        @SuppressWarnings("NonAtomicVolatileUpdate")
+        private V remove(long key, Object value, int keyHash) {
+            int bucket = keyHash;
+            long stamp = writeLock();
+
+            try {
+                while (true) {
+                    int capacity = this.capacity;
+                    bucket = signSafeMod(bucket, capacity);
+
+                    long storedKey = keys[bucket];
+                    V storedValue = values[bucket];
+                    if (storedKey == key) {
+                        if (value == null || value.equals(storedValue)) {
+                            if (storedValue == EmptyValue || storedValue == DeletedValue) {
+                                return null;
+                            }
+
+                            --size;
+                            V nextValueInArray = values[signSafeMod(bucket + 1, capacity)];
+                            if (nextValueInArray == EmptyValue) {
+                                values[bucket] = (V) EmptyValue;
+                                --usedBuckets;
+                            } else {
+                                values[bucket] = (V) DeletedValue;
+                            }
+
+                            return storedValue;
+                        } else {
+                            return null;
+                        }
+                    } else if (storedValue == EmptyValue) {
+                        // Key wasn't found
+                        return null;
+                    }
+
+                    ++bucket;
+                }
+
+            } finally {
+                unlockWrite(stamp);
+            }
+        }
+
+        void clear() {
+            long stamp = writeLock();
+
+            try {
+                Arrays.fill(keys, 0);
+                Arrays.fill(values, EmptyValue);
+                this.size = 0;
+                this.usedBuckets = 0;
+            } finally {
+                unlockWrite(stamp);
+            }
+        }
+
+        public void forEach(EntryProcessor<V> processor) {
+            long stamp = tryOptimisticRead();
+
+            int capacity = this.capacity;
+            long[] keys = this.keys;
+            V[] values = this.values;
+
+            boolean acquiredReadLock = false;
+
+            try {
+
+                // Validate no rehashing
+                if (!validate(stamp)) {
+                    // Fallback to read lock
+                    stamp = readLock();
+                    acquiredReadLock = true;
+
+                    capacity = this.capacity;
+                    keys = this.keys;
+                    values = this.values;
+                }
+
+                // Go through all the buckets for this section
+                for (int bucket = 0; bucket < capacity; bucket++) {
+                    long storedKey = keys[bucket];
+                    V storedValue = values[bucket];
+
+                    if (!acquiredReadLock && !validate(stamp)) {
+                        // Fallback to acquiring read lock
+                        stamp = readLock();
+                        acquiredReadLock = true;
+
+                        storedKey = keys[bucket];
+                        storedValue = values[bucket];
+                    }
+
+                    if (storedValue != DeletedValue && storedValue != EmptyValue) {
+                        processor.accept(storedKey, storedValue);
+                    }
+                }
+            } finally {
+                if (acquiredReadLock) {
+                    unlockRead(stamp);
+                }
+            }
+        }
+
+        private void rehash() {
+            // Expand the hashmap
+            int newCapacity = capacity * 2;
+            long[] newKeys = new long[newCapacity];
+            V[] newValues = (V[]) new Object[newCapacity];
+
+            // Re-hash table
+            for (int i = 0; i < keys.length; i++) {
+                long storedKey = keys[i];
+                V storedValue = values[i];
+                if (storedValue != EmptyValue && storedValue != DeletedValue) {
+                    insertKeyValueNoLock(newKeys, newValues, storedKey, storedValue);
+                }
+            }
+
+            keys = newKeys;
+            values = newValues;
+            usedBuckets = size;
+            CAPACITY_UPDATER.lazySet(this, newCapacity);
+            resizeThreshold = (int) (newCapacity * MapFillFactor);
+        }
+
+        private static <V> void insertKeyValueNoLock(long[] keys, V[] values, long key, V value) {
+            int bucket = (int) hash(key);
+
+            while (true) {
+                bucket = signSafeMod(bucket, keys.length);
+
+                V storedValue = values[bucket];
+
+                if (storedValue == EmptyValue) {
+                    // The bucket is empty, so we can use it
+                    keys[bucket] = key;
+                    values[bucket] = value;
+                    return;
+                }
+
+                ++bucket;
+            }
+        }
+    }
+
+    private static final long HashMixer = 0xc6a4a7935bd1e995L;
+    private static final int R = 47;
+
+    static long hash(long key) {
+        long hash = key * HashMixer;
+        hash ^= hash >>> R;
+        hash *= HashMixer;
+        return hash;
+    }
+
+    static int signSafeMod(long n, int Max) {
+        return (int) n & (Max - 1);
+    }
+
+    static int alignToPowerOfTwo(int n) {
+        return (int) Math.pow(2, 32 - Integer.numberOfLeadingZeros(n - 1));
+    }
+}


### PR DESCRIPTION
@matthiasblaesing Ok, this change turns out to be a massive win from my perspective. While the new code is *marginally* faster, the actual goal is *memory performance*; specifically reduction of garbage and therefore Garbage Collection (GC).

## Background
Essentially, this is a change from `ConcurrentHashMap` to a replacement class `ConcurrentLongHashMap`. Besides the implementation of `ConcurrentLongHashMap`, the only code change is to the `Memory` class, as seen here:

```diff
-    private static final Map<Long, Reference<Memory>> allocatedMemory =
-            new ConcurrentHashMap<>();
+    private static final ConcurrentLongHashMap<Reference<Memory>> allocatedMemory =
+            new ConcurrentLongHashMap<>();
```

So, what is going on? In essence the `Long` key in the hash map is the `peer` address to a block of allocated memory. This must be tracked because every allocated block of memory must be freed eventually. The tracking happens like this:

```java
allocatedMemory.put(peer, new WeakReference<>(this));
```

> [!IMPORTANT]
> The `peer` address is actually a native `long` value, so what happens when you need to use that as a *key* in a Java hash map? The answer is *AutoBoxing*. Which surfaces an often overlooked issue:

[The Dark Side of Java Autoboxing: Hidden Performance Pitfalls](https://medium.com/@poojaauma/the-dark-side-of-java-autoboxing-hidden-performance-pitfalls-94d31f5969f6)

Every time a block of memory is allocated, basically the lifeblood of JNA, the `peer` must be *AutoBoxed* to a `Long` object when it is stored, and the `peer` value must be *AutoBoxed* again for the `allocatedMemory.remove(peer)` operation.

This results in a large amount of `Long` "garbage" objects that must ultimately be garbage collected.

> [!NOTE]
> Again, given that native memory allocation and deallocation are the lifeblood of JNA this can have a substantial effect on the overall performance of the *system* as a whole due to overworking GC.

## ConcurrentLongHashMap
The `ConcurrentLongHashMap` implementaton comes from the *Apache Artemis* project, under the Apache License v2, located here:

[ConcurrentLongHashMap.java](https://github.com/apache/activemq-artemis/blob/6c0a1f3da0b2d592424859a763f3dc37b2fc4952/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/ConcurrentLongHashMap.java)

The implementation provides a concurrent hash map where the *key* is pinned as a primitive `long`. This means that when adding or removing objects keyed by the `peer` address there is no *AutoBoxing* that occurs.

> [!NOTE]
> The *Apache Artemis* project replaced `ConcurrentHashMap<Long, V>` with this class for the same reason that I am recommending it here -- the Java implementation by its nature generates a lot of garbage as a side-effect.

## Benchmarking
The open question that I had was: *If Apache Artemis saw the need to replace `ConcurrentHashMap` what is the overall benefit?*

I created a JMH benchmark to measure the GC impact using the JMH `GCProfiler` functionality. The JMH benchmark Maven project is attached as a *.zip* at the bottom of this write-up. It includes a shell script named `runbench.sh` and can be run like so:
```shell
./runbench.sh
```
Not that it particularly matters, but the `runbench.sh` takes an optional parameter to test different garbage collection algorithms:
```shell
./runbench.sh G1 # the default
./runbench.sh Shenandoah
./runbench.sh ZGC
```
Because the amount of garbage generated is the same regardless of GC algorithm, the relative impact remains proportional no matter which is used. It was just a side exercise for curiosity.

I will show the "raw" results first, but will break them down more clearly in a pivot table afterwards. In the output, "CHM" as the *mapType* is the Java `ConcurrentHashMap` and "CUSTOM" is `ConcurrentLongHashMap`.
```
Benchmark                                              (mapType)   Mode  Cnt      Score      Error   Units
ConcurrentMapGcBenchmark.addRemove                           CHM  thrpt   12  24453.196 ±  991.067  ops/ms
ConcurrentMapGcBenchmark.addRemove:gc.alloc.rate             CHM  thrpt   12   2440.423 ±   98.577  MB/sec
ConcurrentMapGcBenchmark.addRemove:gc.alloc.rate.norm        CHM  thrpt   12    104.728 ±    0.042    B/op
ConcurrentMapGcBenchmark.addRemove:gc.count                  CHM  thrpt   12    235.000             counts
ConcurrentMapGcBenchmark.addRemove:gc.time                   CHM  thrpt   12    333.000                 ms

ConcurrentMapGcBenchmark.addRemove                        CUSTOM  thrpt   12  27789.730 ± 1042.749  ops/ms
ConcurrentMapGcBenchmark.addRemove:gc.alloc.rate          CUSTOM  thrpt   12    672.000 ±   24.577  MB/sec
ConcurrentMapGcBenchmark.addRemove:gc.alloc.rate.norm     CUSTOM  thrpt   12     25.364 ±    0.036    B/op
ConcurrentMapGcBenchmark.addRemove:gc.count               CUSTOM  thrpt   12     60.000             counts
ConcurrentMapGcBenchmark.addRemove:gc.time                CUSTOM  thrpt   12     39.000                 ms
```

Here are the same results in a more readable pivot table. Values are rounded to the nearest whole number. 👉 Note, except for *Throughput (ops/s)*, <ins>lower values</ins> are better. *CHM* is the Java `ConcurrentHashMap` and *CLHM* is the `ConcurrentLongHashMap`.

| Benchmark              | CHM       | CLHM |
|------------------------|---------------------:|--------------------:|
| Throughput (ops/s)      | 24453               |  27790 |
| gc.alloc.rate (MB/s)     | 2440                |  672 |
| gc.alloc.rate.norm (Bytes/op)     | 105                |  25 |
| gc.count     | 235                |  60 |
| gc.time (ms)     | 333                |  39 |

As you can see, CLHM is *slightly* faster, but it just destroys CHM in the size of garbage, the number of GC required during each iteration, and the amount of time consumed by GC.

> [!NOTE]
> Certainly, the majority of the garbage generated by CHM is due to *AutoBoxing* `long` values, but there are also likely differences between the two implementations that are responsible for more/less garbage in the internal data structures. Internally they work in very different ways.

Again, I think this is a huge win in terms of *system* performance as a whole, in which JNA is playing a part. Garbage Collection is the *hidden thief* of Java, stealing performance in a way mostly invisible from the developer unless they are specifically looking for it.

Here is the benchmark. Use the `runbench.sh` to *build and execute* in a single step.
[chm-bench.zip](https://github.com/user-attachments/files/23601320/chm-bench.zip)
