### PR TITLE
Fix UdevDevice.getSysname() calling udev_device_get_syspath

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Features
 Bug Fixes
 ---------
 * [#1644](https://github.com/java-native-access/jna/issues/1644): Fix bug in VARDESC and TYPEDESC causing an illegal memory access - [@lwahonen](https://github.com/lwahonen)
+* [#1715](https://github.com/java-native-access/jna/pull/1715): Fix `UdevDevice.getSysname()` calling `udev_device_get_syspath` instead of `udev_device_get_sysname` - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.18.1
 ==============

--- a/contrib/platform/src/com/sun/jna/platform/linux/Udev.java
+++ b/contrib/platform/src/com/sun/jna/platform/linux/Udev.java
@@ -233,7 +233,7 @@ public interface Udev extends Library {
          * @return a string that describes the sysname. On failure, may return NULL.
          */
         public String getSysname() {
-            return INSTANCE.udev_device_get_syspath(this);
+            return INSTANCE.udev_device_get_sysname(this);
         }
 
         /**

--- a/contrib/platform/test/com/sun/jna/platform/linux/UdevTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/linux/UdevTest.java
@@ -111,7 +111,9 @@ public class UdevTest extends TestCase {
                                 assertEquals(String.format("DevType mismatch (%s)", devnode), devType, device.getDevtype());
                                 assertEquals(String.format("Subsystem mismatch (%s)", devnode), "block", device.getSubsystem());
                                 assertEquals(String.format("Syspath mismatch (%s)", devnode), syspath, device.getSyspath());
-                                assertTrue(String.format("Syspath should end with name (%s)", devnode), syspath.endsWith(device.getSysname()));
+                                String sysname = device.getSysname();
+                                assertTrue(String.format("Syspath should end with name (%s)", devnode), syspath.endsWith(sysname));
+                                assertTrue(String.format("Sysname should be shorter than syspath (%s)", devnode), sysname.length() < syspath.length());
                             }
                         } finally {
                             // Release the reference and iterate to the next device


### PR DESCRIPTION
`UdevDevice.getSysname()` has been calling `udev_device_get_syspath` since it was introduced in 2020 -- a [sloppy copy-paste bug by whoever wrote it](https://github.com/oshi/oshi/commits?author=dbwiddis).  At least [he caught the bug six years later](https://github.com/oshi/oshi/pull/3150).

The existing test technically covered this with:
```java
  assertTrue(syspath.endsWith(device.getSysname()));
```
But since `getSysname()` returned the syspath itself, `syspath.endsWith(syspath)` is always true, so the bug sailed right through.

Added test assertion that sysname is strictly shorter than syspath, which would have caught this originally.