### PR TITLE
Update CI test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 21, 24]
-        # macos-13 is x86, macos-latest is aarch64
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
+        java: [8, 21, 25]
+        # macos-15-intel is x86_64, macos-latest is aarch64
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
       # Run all tests even if one fails
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}


### PR DESCRIPTION
- Replace deprecated macos-13 with macos-15-intel
   - see https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
- Update JDK 24 to 25