### PR TITLE
Add groupCount/groupMasks to CACHE_RELATIONSHIP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Features
 * [#1696](https://github.com/java-native-access/jna/pull/1696): Add `LARGE_INTEGER.ByValue` to `LARGE_INTEGER` in `WinNT.java` - [@baier233](https://github.com/baier233).
 * [#1697](https://github.com/java-native-access/jna/pull/1697): Add WlanApi module - [@eranl](https://github.com/eranl).
 * [#1718](https://github.com/java-native-access/jna/pull/1718): Add `Cups` to `c.s.j.p.unix` providing CUPS printing system bindings for destinations, jobs, options, and server configuration - [@dbwiddis](https://github.com/dbwiddis).
+* [#1720](https://github.com/java-native-access/jna/pull/1720): Add `groupCount` and `groupMasks` fields to `CACHE_RELATIONSHIP` in `c.s.j.p.win32.WinNT`, matching the updated Windows struct layout - [@dbwiddis](https://github.com/dbwiddis).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -3246,7 +3246,7 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
     /**
      * Describes cache attributes.
      */
-    @FieldOrder({ "level", "associativity", "lineSize", "cacheSize", "type", "reserved", "groupMask" })
+    @FieldOrder({ "level", "associativity", "lineSize", "cacheSize", "type", "reserved", "groupCount", "groupMasks" })
     public static class CACHE_RELATIONSHIP extends SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
 
         /**
@@ -3279,19 +3279,67 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
         /**
          * This member is reserved.
          */
-        public byte[] reserved = new byte[20];
+        public byte[] reserved = new byte[18];
+
+        /**
+         * The number of groups included in the GroupMasks array. This field was
+         * introduced in Windows Server 2022 (21H2). On earlier versions, this
+         * value is always 0.
+         */
+        public short groupCount;
 
         /**
          * A {@link GROUP_AFFINITY} structure that specifies a group number and
-         * processor affinity within the group.
+         * processor affinity within the group. This member is only relevant if
+         * {@code groupCount} is 0.
          */
         public GROUP_AFFINITY groupMask;
+
+        /**
+         * An array of {@link GROUP_AFFINITY} structures that specifies a group
+         * number and processor affinity within the group. This member is only
+         * relevant if {@code groupCount} is 1 or greater.
+         */
+        public GROUP_AFFINITY[] groupMasks = new GROUP_AFFINITY[1];
 
         public CACHE_RELATIONSHIP() {
         }
 
         public CACHE_RELATIONSHIP(Pointer memory) {
             super(memory);
+        }
+
+        @Override
+        public void read() {
+            readField("groupCount");
+            // In older version of structure this is part of reserved array and has 0 value.
+            // Force a minimum array size of 1.
+            int actualGroupCount = Math.max(1, groupCount);
+            // Resize if needed
+            if (actualGroupCount != groupMasks.length) {
+                groupMasks = new GROUP_AFFINITY[actualGroupCount];
+            }
+            super.read();
+            // Copy first value from array to older version of structure for compatibility
+            groupMask = groupMasks[0];
+        }
+
+        /*
+         * The groupMask field is provided as a public instance variable for
+         * compatibility. getFieldList is overridden to remove it before comparing
+         * against the structure field order.
+         */
+        @Override
+        protected List<Field> getFieldList() {
+            List<Field> fields = new ArrayList<>(super.getFieldList());
+            Iterator<Field> fieldIterator = fields.iterator();
+            while (fieldIterator.hasNext()) {
+                Field field = fieldIterator.next();
+                if ("groupMask".equals(field.getName())) {
+                    fieldIterator.remove();
+                }
+            }
+            return fields;
         }
     }
 


### PR DESCRIPTION
## Add groupCount/groupMasks to CACHE_RELATIONSHIP

The Windows [`CACHE_RELATIONSHIP`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-cache_relationship) struct was updated (Windows Server 2022 / 21H2) to repurpose 2 of its 20 reserved bytes as a `GroupCount` field and replace the single `GroupMask` with a variable-length `GroupMasks` array. This is the same change documented in [#1324](https://github.com/java-native-access/jna/issues/1324) for `NUMA_NODE_RELATIONSHIP`.

### Changes

- Shrink `reserved` from 20 to 18 bytes
- Add `groupCount` (`short`) field
- Add `groupMasks` (`GROUP_AFFINITY[]`) array
- Retain `groupMask` as a public compatibility field (populated from `groupMasks[0]`)
- Override `read()` to dynamically size the array based on `groupCount`
- Override `getFieldList()` to exclude the compatibility `groupMask` field from structure validation

### Sources

- [Microsoft docs: CACHE_RELATIONSHIP](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-cache_relationship) — documents `GroupCount` and `GroupMasks` fields
- Existing `NUMA_NODE_RELATIONSHIP` implementation in this repo (same pattern applied in [#1563](https://github.com/java-native-access/jna/pull/1563))

### Backward compatibility

On older Windows versions where `GroupCount` is 0 (the bytes were previously reserved/zeroed), the `read()` override forces a minimum array size of 1 and copies the value to `groupMask`, preserving existing behavior.

Closes #1674