### PR TITLE
Fix switched serverName/domainName arguments in Netapi32Util#getDCName

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Bug Fixes
 ---------
 * [#1644](https://github.com/java-native-access/jna/issues/1644): Fix bug in VARDESC and TYPEDESC causing an illegal memory access - [@lwahonen](https://github.com/lwahonen)
 * [#1715](https://github.com/java-native-access/jna/pull/1715): Fix `UdevDevice.getSysname()` calling `udev_device_get_syspath` instead of `udev_device_get_sysname` - [@dbwiddis](https://github.com/dbwiddis).
+* [#1721](https://github.com/java-native-access/jna/pull/1721): Fix switched `serverName`/`domainName` arguments in `Netapi32Util#getDCName` - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.18.1
 ==============

--- a/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Netapi32Util.java
@@ -118,7 +118,7 @@ public abstract class Netapi32Util {
     public static String getDCName(String serverName, String domainName) {
         PointerByReference bufptr = new PointerByReference();
         try {
-            int rc = Netapi32.INSTANCE.NetGetDCName(domainName, serverName, bufptr);
+            int rc = Netapi32.INSTANCE.NetGetDCName(serverName, domainName, bufptr);
             if (LMErr.NERR_Success != rc) {
                 throw new Win32Exception(rc);
             }


### PR DESCRIPTION
Fix the argument order in `Netapi32Util#getDCName` which was passing `(domainName, serverName, bufptr)` to `Netapi32#NetGetDCName` instead of the correct `(serverName, domainName, bufptr)`.

The [`NetGetDCName`](https://learn.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netgetdcname) Windows API expects `serverName` first and `domainName` second. The bug was unnoticed because all existing callers pass `(null, null)`.

Closes #1650