### PR TITLE
Fix Advapi32#RegisterServiceCtrlHandler using wrong Handler type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Bug Fixes
 * [#1644](https://github.com/java-native-access/jna/issues/1644): Fix bug in VARDESC and TYPEDESC causing an illegal memory access - [@lwahonen](https://github.com/lwahonen)
 * [#1715](https://github.com/java-native-access/jna/pull/1715): Fix `UdevDevice.getSysname()` calling `udev_device_get_syspath` instead of `udev_device_get_sysname` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1721](https://github.com/java-native-access/jna/pull/1721): Fix switched `serverName`/`domainName` arguments in `Netapi32Util#getDCName` - [@dbwiddis](https://github.com/dbwiddis).
+* [#1722](https://github.com/java-native-access/jna/pull/1722): Fix `Advapi32#RegisterServiceCtrlHandler` using wrong `Handler` type - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.18.1
 ==============

--- a/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/Advapi32.java
@@ -3325,7 +3325,7 @@ public interface Advapi32 extends StdCallLibrary {
      * </table>
      */
     public SERVICE_STATUS_HANDLE RegisterServiceCtrlHandler(String lpServiceName,
-            Handler lpHandlerProc);
+            Winsvc.Handler lpHandlerProc);
 
     /**
      * Registers a function to handle extended service control requests.


### PR DESCRIPTION
The `lpHandlerProc` parameter of `RegisterServiceCtrlHandler` resolved to `com.sun.jna.Library.Handler` (an `InvocationHandler`) instead of the correct [`Winsvc.Handler`](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nc-winsvc-lphandler_function) (a `StdCallCallback`). The import for `Winsvc.Handler` was missing while `Winsvc.HandlerEx` was imported.

The javadoc already correctly referenced `Winsvc.Handler` but the actual type resolution was wrong.

**Note:** @matthiasblaesing [observed](https://github.com/java-native-access/jna/issues/1510#issuecomment-1040476413) that `RegisterServiceCtrlHandler` has runtime issues when called from non-C code, and `RegisterServiceCtrlHandlerEx` (already correctly bound) is the recommended successor. This PR fixes the type signature for correctness regardless.

Closes #1510