### PR TITLE
Fix variable-size type mappings in mac SystemB and XAttr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Bug Fixes
 * [#1721](https://github.com/java-native-access/jna/pull/1721): Fix switched `serverName`/`domainName` arguments in `Netapi32Util#getDCName` - [@dbwiddis](https://github.com/dbwiddis).
 * [#1722](https://github.com/java-native-access/jna/pull/1722): Fix `Advapi32#RegisterServiceCtrlHandler` using wrong `Handler` type - [@dbwiddis](https://github.com/dbwiddis).
 * [#1636](https://github.com/java-native-access/jna/issues/1636): Drop hard dependency on java.lang.SecurityManager/java.security.AccessController - [@matthiasblaesing](https://github.com/matthiasblaesing).
+* [#1724](https://github.com/java-native-access/jna/pull/1724): Fix `host_page_size` in `c.s.j.p.mac.SystemB` and `getxattr`/`setxattr`/`listxattr` in `c.s.j.p.mac.XAttr` using `long` instead of pointer-sized types for `size_t`/`ssize_t` parameters - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.18.1
 ==============

--- a/contrib/platform/src/com/sun/jna/platform/mac/SystemB.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/SystemB.java
@@ -33,6 +33,7 @@ import com.sun.jna.Structure;
 import com.sun.jna.platform.unix.LibCAPI;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.NativeLongByReference;
 import com.sun.jna.ptr.PointerByReference;
 
 public interface SystemB extends LibCAPI, Library {
@@ -580,6 +581,13 @@ public interface SystemB extends LibCAPI, Library {
      *            The host's page size (in bytes), set on success.
      * @return 0 on success; sets errno on failure
      */
+    int host_page_size(int hostPort, NativeLongByReference pPageSize);
+
+    /**
+     * @deprecated Use
+     *             {@link #host_page_size(int, NativeLongByReference)}
+     */
+    @Deprecated
     int host_page_size(int hostPort, LongByReference pPageSize);
 
     /**

--- a/contrib/platform/src/com/sun/jna/platform/mac/XAttr.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/XAttr.java
@@ -26,6 +26,8 @@ package com.sun.jna.platform.mac;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
+import com.sun.jna.platform.unix.LibCAPI.size_t;
+import com.sun.jna.platform.unix.LibCAPI.ssize_t;
 
 /**
  * JNA wrapper for &lt;sys/xattr.h&gt;
@@ -48,15 +50,33 @@ public interface XAttr extends Library {
     String XATTR_RESOURCEFORK_NAME = "com.apple.ResourceFork";
 
     // see https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getxattr.2.html
+    ssize_t getxattr(String path, String name, Pointer value, size_t size, int position, int options);
+
+    /**
+     * @deprecated Use {@link #getxattr(String, String, Pointer, size_t, int, int)}
+     */
+    @Deprecated
     long getxattr(String path, String name, Pointer value, long size, int position, int options);
 
     // see https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/setxattr.2.html
+    int setxattr(String path, String name, Pointer value, size_t size, int position, int options);
+
+    /**
+     * @deprecated Use {@link #setxattr(String, String, Pointer, size_t, int, int)}
+     */
+    @Deprecated
     int setxattr(String path, String name, Pointer value, long size, int position, int options);
 
     // see https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/removexattr.2.html
     int removexattr(String path, String name, int options);
 
     // see https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/listxattr.2.html
+    ssize_t listxattr(String path, Pointer namebuff, size_t size, int options);
+
+    /**
+     * @deprecated Use {@link #listxattr(String, Pointer, size_t, int)}
+     */
+    @Deprecated
     long listxattr(String path, Pointer namebuff, long size, int options);
 
 }

--- a/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
+++ b/contrib/platform/src/com/sun/jna/platform/mac/XAttrUtil.java
@@ -30,12 +30,13 @@ import java.util.List;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
+import com.sun.jna.platform.unix.LibCAPI.size_t;
 
 public class XAttrUtil {
 
     public static List<String> listXAttr(String path) {
         // get required buffer size
-        long bufferLength = XAttr.INSTANCE.listxattr(path, null, 0, 0);
+        long bufferLength = XAttr.INSTANCE.listxattr(path, null, size_t.ZERO, 0).longValue();
 
         if (bufferLength < 0)
             return null;
@@ -44,7 +45,7 @@ public class XAttrUtil {
             return new ArrayList<>(0);
 
         Memory valueBuffer = new Memory(bufferLength);
-        long valueLength = XAttr.INSTANCE.listxattr(path, valueBuffer, bufferLength, 0);
+        long valueLength = XAttr.INSTANCE.listxattr(path, valueBuffer, new size_t(bufferLength), 0).longValue();
 
         if (valueLength < 0)
             return null;
@@ -54,7 +55,7 @@ public class XAttrUtil {
 
     public static String getXAttr(String path, String name) {
         // get required buffer size
-        long bufferLength = XAttr.INSTANCE.getxattr(path, name, null, 0, 0, 0);
+        long bufferLength = XAttr.INSTANCE.getxattr(path, name, null, size_t.ZERO, 0, 0).longValue();
 
         if (bufferLength < 0) {
             return null;
@@ -66,7 +67,8 @@ public class XAttrUtil {
 
         Memory valueBuffer = new Memory(bufferLength);
         valueBuffer.clear();
-        long valueLength = XAttr.INSTANCE.getxattr(path, name, valueBuffer, bufferLength, 0, 0);
+        long valueLength = XAttr.INSTANCE.getxattr(path, name, valueBuffer, new size_t(bufferLength), 0, 0)
+                .longValue();
 
         if (valueLength < 0) {
             return null;
@@ -77,7 +79,7 @@ public class XAttrUtil {
 
     public static int setXAttr(String path, String name, String value) {
         Memory valueBuffer = encodeString(value);
-        return XAttr.INSTANCE.setxattr(path, name, valueBuffer, valueBuffer.size(), 0, 0);
+        return XAttr.INSTANCE.setxattr(path, name, valueBuffer, new size_t(valueBuffer.size()), 0, 0);
     }
 
     public static int removeXAttr(String path, String name) {


### PR DESCRIPTION
Fix incorrect use of `long`/`LongByReference` for pointer-sized native types in macOS bindings.

**SystemB.host_page_size**: The `vm_size_t *` parameter was mapped as `LongByReference` (always 64-bit). Added correct `NativeLongByReference` overload; deprecated the old signature.

**XAttr.getxattr/setxattr/listxattr**: The `size_t` parameters and `ssize_t` return values were mapped as `long` (always 64-bit). Added correct `NativeLong` overloads; deprecated the old signatures. Updated `XAttrUtil` to use the new methods.

These types are pointer-sized (`unsigned long` in C) and should be 4 bytes on 32-bit and 8 bytes on 64-bit. While macOS is effectively 64-bit-only today, JNA still supports 32-bit macOS and the mappings should be correct.