### PR TITLE
Include DragonFlyBSD in library loading fallback paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Bug Fixes
 * [#1722](https://github.com/java-native-access/jna/pull/1722): Fix `Advapi32#RegisterServiceCtrlHandler` using wrong `Handler` type - [@dbwiddis](https://github.com/dbwiddis).
 * [#1636](https://github.com/java-native-access/jna/issues/1636): Drop hard dependency on java.lang.SecurityManager/java.security.AccessController - [@matthiasblaesing](https://github.com/matthiasblaesing).
 * [#1724](https://github.com/java-native-access/jna/pull/1724): Fix `host_page_size` in `c.s.j.p.mac.SystemB` and `getxattr`/`setxattr`/`listxattr` in `c.s.j.p.mac.XAttr` using `long` instead of pointer-sized types for `size_t`/`ssize_t` parameters - [@dbwiddis](https://github.com/dbwiddis).
+* [#1727](https://github.com/java-native-access/jna/pull/1727): Include DragonFlyBSD in `NativeLibrary` versioned library resolution, libc special-case loading, and 64-bit search paths - [@dbwiddis](https://github.com/dbwiddis).
 
 Release 5.18.1
 ==============

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -245,7 +245,7 @@ public class NativeLibrary implements Closeable {
                     exceptions.add(e2);
                 }
             }
-            else if (Platform.isLinux() || Platform.isFreeBSD()) {
+            else if (Platform.isLinux() || Platform.isFreeBSD() || Platform.isDragonFlyBSD()) {
                 //
                 // Failed to load the library normally - try to match libfoo.so.*
                 //
@@ -465,7 +465,7 @@ public class NativeLibrary implements Closeable {
 
         // Use current process to load libraries we know are already
         // loaded by the VM to ensure we get the correct version
-        if ((Platform.isLinux() || Platform.isFreeBSD() || Platform.isAIX())
+        if ((Platform.isLinux() || Platform.isFreeBSD() || Platform.isDragonFlyBSD() || Platform.isAIX())
             && Platform.C_LIBRARY_NAME.equals(libraryName)) {
             libraryName = null;
         }
@@ -788,7 +788,7 @@ public class NativeLibrary implements Closeable {
             }
             return name;
         }
-        else if (Platform.isLinux() || Platform.isFreeBSD()) {
+        else if (Platform.isLinux() || Platform.isFreeBSD() || Platform.isDragonFlyBSD()) {
             if (isVersionedName(libName) || libName.endsWith(".so")) {
                 // A specific version was requested - use as is for search
                 return libName;
@@ -926,8 +926,8 @@ public class NativeLibrary implements Closeable {
             // one when running a 64bit JVM.
             //
             if (Platform.isLinux() || Platform.isSolaris()
-                || Platform.isFreeBSD() || Platform.iskFreeBSD()) {
-                // Linux & FreeBSD use /usr/lib32, solaris uses /usr/lib/32
+                || Platform.isFreeBSD() || Platform.isDragonFlyBSD() || Platform.iskFreeBSD()) {
+                // Linux, FreeBSD & DragonFlyBSD use /usr/lib32, solaris uses /usr/lib/32
                 archPath = (Platform.isSolaris() ? "/" : "") + Native.POINTER_SIZE * 8;
             }
             String[] paths = {


### PR DESCRIPTION
## Summary

DragonFlyBSD platform support was added in #1593 but `NativeLibrary` was not updated to include DragonFlyBSD in the fallback paths that FreeBSD already uses.

## Problem

When loading `libc` (or any library by short name) on DragonFlyBSD, the following fails with `UnsatisfiedLinkError` / `NoClassDefFoundError`:
- The versioned `.so` fallback (`matchLibrary()`) only triggers for Linux and FreeBSD
- The special-case libc loading from the current process only covers Linux, FreeBSD, and AIX
- The `mapSharedLibraryName()` handling for `.so` files only covers Linux and FreeBSD
- The 64-bit library search path only includes Linux, FreeBSD, Solaris, and kFreeBSD

## Fix

Add `Platform.isDragonFlyBSD()` to all four locations in `NativeLibrary.java` where `Platform.isFreeBSD()` is checked. DragonFlyBSD is a FreeBSD derivative and uses the same library naming conventions.

## Testing

Discovered while porting [OSHI](https://github.com/oshi/oshi) to DragonFlyBSD. Verified that the workaround (using `"c"` instead of `"libc"`) resolves the loading issue, confirming the root cause is in these fallback paths.