### PR TITLE
native: fix parallel build issue

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -509,7 +509,7 @@ TESTDEP=$(TESTLIB:.dll=.lib)
 else
 TESTDEP=$(TESTLIB)
 endif
-$(TESTLIB2): $(BUILD)/testlib2.o
+$(TESTLIB2): $(BUILD)/testlib2.o $(TESTDEP)
 	$(LD) $(LDFLAGS) $< $(TESTDEP) $(LIBS)
 
 ifneq ($(DYNAMIC_LIBFFI),true)


### PR DESCRIPTION
This can be reproduced with `make --shuffle=3224289900`. The `$(TESTLIB2)` target needs `libtestlib.*` as it uses `$(TESTDEP)` in the rule, but it doesn't depend on that library actually being built yet. Fix that.

Bug: https://bugs.gentoo.org/963877